### PR TITLE
Handle exercise stubs

### DIFF
--- a/assignment.go
+++ b/assignment.go
@@ -10,6 +10,8 @@ type Assignment struct {
 	Track    string
 	Slug     string
 	Readme   string
+	StubFile string `json:"stub_file"`
+	Stub     string
 	TestFile string `json:"test_file"`
 	Tests    string
 }
@@ -26,6 +28,13 @@ func SaveAssignment(dir string, a Assignment) (err error) {
 	if err != nil {
 		err = fmt.Errorf("Error writing README.md file: [%v]", err)
 		return
+	}
+
+	if a.Stub != "" && a.StubFile != "" {
+		err = ioutil.WriteFile(fmt.Sprintf("%s/%s", assignmentPath, a.StubFile), []byte(a.Stub), 0644)
+		if err != nil {
+			err = fmt.Errorf("Error writing file %s: [%v]", a.StubFile, err)
+		}
 	}
 
 	err = ioutil.WriteFile(fmt.Sprintf("%s/%s", assignmentPath, a.TestFile), []byte(a.Tests), 0644)

--- a/assignment_test.go
+++ b/assignment_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -14,6 +15,8 @@ func TestSavingAssignment(t *testing.T) {
 		Track:    "ruby",
 		Slug:     "bob",
 		Readme:   "Readme text",
+		StubFile: "bob.rb",
+		Stub:     "Stub Text",
 		TestFile: "bob_test.rb",
 		Tests:    "Tests Text",
 	}
@@ -25,7 +28,24 @@ func TestSavingAssignment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(readme), "Readme text")
 
+	stub, err := ioutil.ReadFile(tmpDir + "/ruby/bob/bob.rb")
+	assert.NoError(t, err)
+	assert.Equal(t, string(stub), "Stub Text")
+
 	tests, err := ioutil.ReadFile(tmpDir + "/ruby/bob/bob_test.rb")
 	assert.NoError(t, err)
 	assert.Equal(t, string(tests), "Tests Text")
+
+	assignment = Assignment{
+		Track:    "ruby",
+		Slug:     "space-age",
+		Readme:   "Readme text",
+		StubFile: "",
+		Stub:     "",
+		TestFile: "space-age_test.rb",
+		Tests:    "Tests Text",
+	}
+
+	_, err = ioutil.ReadFile(tmpDir + "/ruby/space-age/space-age.rb")
+	assert.True(t, os.IsNotExist(err))
 }


### PR DESCRIPTION
Stubs contain boilerplate for the exercise submission.

This works with exercism/exercism.io#961
