### PR TITLE
Change in return position so the build is OK

### DIFF
--- a/fetch_endpoint.go
+++ b/fetch_endpoint.go
@@ -7,7 +7,6 @@ import (
 func FetchEndpoint(args []string) string {
 	if len(args) == 0 {
 		return FetchEndpoints["current"]
-	} else {
-		return fmt.Sprintf("%s/%s/%s", FetchEndpoints["exercise"], args[0], args[1])
 	}
+	return fmt.Sprintf("%s/%s/%s", FetchEndpoints["exercise"], args[0], args[1])
 }


### PR DESCRIPTION
I've just downloaded the project to tinker with it and my local build fails with the following message:
`./fetch_endpoint.go:7: function ends without a return statement`

Could it be a matter of versions or something like that? My output of `go version` is `go version go1.0.2`.

Anyway, this seems to solve the problem.
