### PR TITLE
Return an error from askForConfigInfo instead of using panic

### DIFF
--- a/exercism.go
+++ b/exercism.go
@@ -21,7 +21,7 @@ func absolutePath(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
-func askForConfigInfo() (c configuration.Config) {
+func askForConfigInfo() (c configuration.Config, err error) {
 	var un, key, dir string
 	delim := "\r\n"
 
@@ -29,27 +29,27 @@ func askForConfigInfo() (c configuration.Config) {
 
 	currentDir, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		return
 	}
 
 	fmt.Print("Your GitHub username: ")
 	un, err = bio.ReadString('\n')
 	if err != nil {
-		panic(err)
+		return
 	}
 
 	fmt.Print("Your exercism.io API key: ")
 	key, err = bio.ReadString('\n')
 	if err != nil {
-		panic(err)
+		return
 	}
 
 	fmt.Println("What is your exercism exercises project path?")
 	fmt.Printf("Press Enter to select the default (%s):\n", currentDir)
 	fmt.Print("> ")
 	dir, err = bio.ReadString('\n')
-	if err != nil && err.Error() != "unexpected newline" {
-		panic(err)
+	if err != nil {
+		return
 	}
 
 	key = strings.TrimRight(key, delim)
@@ -70,8 +70,9 @@ func askForConfigInfo() (c configuration.Config) {
 
 	dir, err = absolutePath(dir)
 	if err != nil {
-		panic(err)
+		return
 	}
 
-	return configuration.Config{GithubUsername: un, ApiKey: key, ExercismDirectory: dir, Hostname: "http://exercism.io"}
+	c = configuration.Config{GithubUsername: un, ApiKey: key, ExercismDirectory: dir, Hostname: "http://exercism.io"}
+	return
 }

--- a/exercism_test.go
+++ b/exercism_test.go
@@ -47,7 +47,10 @@ func TestAskForConfigInfoAllowsSpaces(t *testing.T) {
 
 	os.Stdin = file
 
-	c := askForConfigInfo()
+	c, err := askForConfigInfo()
+	if err != nil {
+		t.Errorf("Error asking for configuration info [%v]", err)
+	}
 	os.Stdin = oldStdin
 	absoluteDirName, _ := absolutePath(dirName)
 	_, err = os.Stat(absoluteDirName)

--- a/main.go
+++ b/main.go
@@ -132,7 +132,12 @@ func main() {
 			ShortName: "l",
 			Usage:     "Save exercism.io api credentials",
 			Action: func(c *cli.Context) {
-				configuration.ToFile(c.GlobalString("config"), askForConfigInfo())
+				config, err := askForConfigInfo()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				configuration.ToFile(c.GlobalString("config"), config)
 			},
 		},
 		{


### PR DESCRIPTION
This will just print out the error message for the user instead of the stack trace panic creates. 
