### PR TITLE
[Low priority] Tweak dev setup to clone via https

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If that throws an error, try ```brew install go --cross-compile-common --with-ll
 Development
 ===========
 1. `cd $GOPATH`
-1. git clone git@github.com:exercism/cli.git src/github.com/exercism/cli
+1. git clone https://github.com/exercism/cli src/github.com/exercism/cli
 1. cd src/github.com/exercism/cli
 1. go get
 1. go get github.com/levicook/glitch


### PR DESCRIPTION
Before, trying to `git clone git@github.com:exercism/cli.git` would result in an error because non-repo-collaborators don't have git-ssh access.

```
> git clone git@github.com:exercism/cli.git src/github.com/exercism/cli
Cloning into 'src/github.com/exercism/cli'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

This is a _very_ minor change, but maybe one that will make it marginally easier to jump into development of exercism/cli.

Thanks for such a great project!
