### PR TITLE
sanitize configuration values on read or write

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 
 // ToFile writes a Config to a JSON file.
 func ToFile(path string, c Config) error {
+	sanitize(&c)
 	bytes, err := json.Marshal(c)
 	if err != nil {
 		return err
@@ -56,6 +57,11 @@ func FromFile(path string) (c Config, err error) {
 	}
 
 	err = json.Unmarshal(bytes, &c)
+	if err != nil {
+		return
+	}
+	sanitize(&c)
+
 	return
 }
 
@@ -105,4 +111,15 @@ func demoDirectory() (dir string, err error) {
 	}
 	dir = filepath.Join(dir, DemoDirname)
 	return
+}
+
+func sanitize(c *Config) {
+	c.GithubUsername = sanitizeField(c.GithubUsername)
+	c.APIKey = sanitizeField(c.APIKey)
+	c.ExercismDirectory = sanitizeField(c.ExercismDirectory)
+	c.Hostname = sanitizeField(c.Hostname)
+}
+
+func sanitizeField(v string) string {
+	return strings.TrimSpace(v)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,16 +34,41 @@ func TestReadingWritingConfig(t *testing.T) {
 	filename := Filename(tmpDir)
 	assert.NoError(t, err)
 
-	writtenConfig := Config{
+	currentConfig := Config{
 		GithubUsername:    "user",
 		APIKey:            "MyKey",
 		ExercismDirectory: "/exercism/directory",
+		Hostname:          "localhost\r\n",
+	}
+	sanitizedConfig := Config{
+		GithubUsername:    "user",
+		APIKey:            "MyKey",
+		ExercismDirectory: "/exercism/directory",
+		Hostname:          "localhost",
 	}
 
-	ToFile(filename, writtenConfig)
+	ToFile(filename, currentConfig)
 
 	loadedConfig, err := FromFile(filename)
 	assert.NoError(t, err)
 
-	assert.Equal(t, writtenConfig, loadedConfig)
+	assert.Equal(t, sanitizedConfig, loadedConfig)
+}
+
+func TestSanitizeFields(t *testing.T) {
+	config := Config{
+		GithubUsername:    "user ",
+		APIKey:            "MyKey     ",
+		ExercismDirectory: "/home/user name\r\n",
+		Hostname:          "localhost\n",
+	}
+	sanitizedConfig := Config{
+		GithubUsername:    "user",
+		APIKey:            "MyKey",
+		ExercismDirectory: "/home/user name",
+		Hostname:          "localhost",
+	}
+	sanitize(&config)
+
+	assert.Equal(t, config, sanitizedConfig)
 }


### PR DESCRIPTION
- trims trailing or leading whitespace or newline characters from all values in `Config`
- resolves issue #55
