### PR TITLE
update default exercism assignment path to ~/exercism

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,9 @@ const (
 	Host = "http://exercism.io"
 	// DemoDirname is the default directory to download problems to.
 	DemoDirname = "exercism-demo"
+
+	// AssignmentDirname is the default name of the directory for active users.
+	AssignmentDirname = "exercism"
 )
 
 // Config represents the settings for particular user.
@@ -144,6 +147,11 @@ func Demo() *Config {
 		APIKey:            "",
 		ExercismDirectory: demoDirectory(),
 	}
+}
+
+// DefaultAssignmentPath returns the absolute path of the default exercism directory
+func DefaultAssignmentPath() string {
+	return filepath.Join(HomeDir(), AssignmentDirname)
 }
 
 // ReplaceTilde replaces the short-hand home path with the absolute path.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,15 @@ func TestDemoDir(t *testing.T) {
 	assert.Equal(t, demoDir, path)
 }
 
+func TestDefaultAssignmentPath(t *testing.T) {
+	homeDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	path := DefaultAssignmentPath()
+
+	assert.Equal(t, filepath.Join(homeDir, AssignmentDirname), path)
+}
+
 func TestExpandsTildeInExercismDirectory(t *testing.T) {
 	expandedDir := ReplaceTilde("~/exercism/directory")
 	assert.NotContains(t, "~", expandedDir)

--- a/main.go
+++ b/main.go
@@ -380,13 +380,8 @@ func askForConfigInfo() (*config.Config, error) {
 
 	bio := bufio.NewReader(os.Stdin)
 
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
 	fmt.Print("Your GitHub username: ")
-	un, err = bio.ReadString('\n')
+	un, err := bio.ReadString('\n')
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +393,7 @@ func askForConfigInfo() (*config.Config, error) {
 	}
 
 	fmt.Println("What is your exercism exercises project path?")
-	fmt.Printf("Press Enter to select the default (%s):\n", currentDir)
+	fmt.Printf("Press Enter to select the default (%s):\n", config.DefaultAssignmentPath())
 	fmt.Print("> ")
 	dir, err = bio.ReadString('\n')
 	if err != nil {
@@ -410,7 +405,7 @@ func askForConfigInfo() (*config.Config, error) {
 	dir = strings.TrimRight(dir, delim)
 
 	if dir == "" {
-		dir = currentDir
+		dir = config.DefaultAssignmentPath()
 	}
 
 	dir = config.ReplaceTilde(dir)


### PR DESCRIPTION
Previously the default path (if none was provided by the user) when logging in defaulted to a folder called exercism in the current working directory. Now the default path is relative to the user's home directory. If the user requests a demo the demo directory will also be relative to the home directory.

Feedback welcome!

Closes #96
