### PR TITLE
Refactor submit command action into handlers/submit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,12 @@ import (
 )
 
 const (
+	// Version is the current release of the command-line app.
+	// We try to follow Semantic Versioning (http://semver.org),
+	// but with the http://exercism.io app being a prototype, a
+	// lot of things get out of hand.
+	Version = "1.7.0"
+
 	// File is the default name of the JSON file where the config written.
 	// The user can pass an alternate filename when using the CLI.
 	File = ".exercism.json"
@@ -30,6 +36,10 @@ const (
 
 var (
 	errHomeNotFound = errors.New("unable to locate home directory")
+
+	// UserAgent is sent along as a header to HTTP requests that the
+	// CLI makes. This helps with debugging.
+	UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 )
 
 // Config represents the settings for particular user.

--- a/handlers/submit.go
+++ b/handlers/submit.go
@@ -1,0 +1,162 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"io/ioutil"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/exercism/cli/config"
+)
+
+const (
+	msgPleaseAuthenticate = "You must be authenticated. Run `exercism configure --key=YOUR_API_KEY`."
+)
+
+var testExtensions = map[string]string{
+	"ruby":    "_test.rb",
+	"js":      ".spec.js",
+	"elixir":  "_test.exs",
+	"clojure": "_test.clj",
+	"python":  "_test.py",
+	"go":      "_test.go",
+	"haskell": "_test.hs",
+	"cpp":     "_test.cpp",
+}
+
+func Submit(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 {
+		fmt.Println("Please enter a file name")
+		return
+	}
+
+	c, err := config.Read(ctx.GlobalString("config"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if !c.IsAuthenticated() {
+		fmt.Println(msgPleaseAuthenticate)
+		return
+	}
+
+	filename := ctx.Args()[0]
+
+	// Make filename relative to config.Dir.
+	absPath, err := absolutePath(filename)
+	if err != nil {
+		fmt.Printf("Couldn't find %v: %v\n", filename, err)
+		return
+	}
+	exDir := c.Dir + string(filepath.Separator)
+	if !strings.HasPrefix(absPath, exDir) {
+		fmt.Printf("%v is not under your exercism project path (%v)\n", absPath, exDir)
+		return
+	}
+	filename = absPath[len(exDir):]
+
+	if IsTest(filename) {
+		fmt.Println("It looks like this is a test, please submit a solution.")
+		return
+	}
+
+	code, err := ioutil.ReadFile(absPath)
+	if err != nil {
+		fmt.Printf("Error reading %v: %v\n", absPath, err)
+		return
+	}
+
+	response, err := SubmitAssignment(c, filename, code)
+	if err != nil {
+		fmt.Printf("There was an issue with your submission: %v\n", err)
+		return
+	}
+
+	fmt.Printf("For feedback on your submission visit %s%s%s\n",
+		c.Hostname, "/submissions/", response.ID)
+}
+
+type submitResponse struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	Language       string `json:"language"`
+	Exercise       string `json:"exercise"`
+	SubmissionPath string `json:"submission_path"`
+	Error          string `json:"error"`
+}
+
+type submitRequest struct {
+	Key  string `json:"key"`
+	Code string `json:"code"`
+	Path string `json:"path"`
+}
+
+func SubmitAssignment(c *config.Config, filePath string, code []byte) (*submitResponse, error) {
+	path := "api/v1/user/assignments"
+
+	url := fmt.Sprintf("%s/%s", c.Hostname, path)
+
+	submission := submitRequest{Key: c.APIKey, Code: string(code), Path: filePath}
+	submissionJSON, err := json.Marshal(submission)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(submissionJSON))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", config.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		err = fmt.Errorf("Error posting assignment: [%v]", err)
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var r submitResponse
+	if resp.StatusCode != http.StatusCreated {
+		err = json.Unmarshal(body, &r)
+		if err != nil {
+			return nil, err
+		}
+		err = fmt.Errorf("Status: %d, Error: %v", resp.StatusCode, r)
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing API response: [%v]", err)
+	}
+	return &r, nil
+}
+
+func absolutePath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(path)
+}
+
+func IsTest(filename string) bool {
+	for _, ext := range testExtensions {
+		if strings.LastIndex(filename, ext) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/handlers/submit_test.go
+++ b/handlers/submit_test.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/exercism/cli/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitWithKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(submitHandler))
+	defer server.Close()
+
+	var code = []byte("My source code\n")
+	c := &config.Config{
+		Hostname: server.URL,
+		APIKey:   "myAPIKey",
+	}
+	response, err := SubmitAssignment(c, "ruby/bob/bob.rb", code)
+	assert.NoError(t, err)
+
+	assert.Equal(t, response.Status, "saved")
+	assert.Equal(t, response.Language, "ruby")
+	assert.Equal(t, response.Exercise, "bob")
+	assert.Equal(t, response.SubmissionPath, "/username/ruby/bob")
+}
+
+func TestSubmitWithIncorrectKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(submitHandler))
+	defer server.Close()
+
+	c := &config.Config{
+		Hostname: server.URL,
+		APIKey:   "myWrongAPIKey",
+	}
+
+	var code = []byte("My source code\n")
+	_, err := SubmitAssignment(c, "ruby/bob/bob.rb", code)
+
+	assert.Error(t, err)
+}
+
+var submitHandler = func(rw http.ResponseWriter, r *http.Request) {
+	pathMatches := r.URL.Path == "/api/v1/user/assignments"
+	methodMatches := r.Method == "POST"
+	if !(pathMatches && methodMatches) {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	userAgentMatches := strings.HasPrefix(r.Header.Get("User-Agent"), fmt.Sprintf("github.com/exercism/cli v%s", config.Version))
+
+	if !userAgentMatches {
+		fmt.Printf("User agent mismatch: %s\n", r.Header.Get("User-Agent"))
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Printf("Reading body error: %s\n", err)
+		return
+	}
+
+	type Submission struct {
+		Key  string
+		Code string
+		Path string
+	}
+
+	submission := Submission{}
+
+	err = json.Unmarshal(body, &submission)
+	if err != nil {
+		fmt.Printf("Unmarshalling error: %v, Body: %s\n", err, body)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if submission.Key != "myAPIKey" {
+		rw.WriteHeader(http.StatusForbidden)
+		rw.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(rw, `{"error": "Unable to identify user"}`)
+		return
+	}
+
+	code := submission.Code
+	filePath := submission.Path
+
+	codeMatches := string(code) == "My source code\n"
+	filePathMatches := filePath == "ruby/bob/bob.rb"
+
+	if !filePathMatches {
+		fmt.Printf("FilePathMismatch: File Path: %s\n", filePath)
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !codeMatches {
+		fmt.Printf("Code Mismatch: Code: %v\n", code)
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	rw.WriteHeader(http.StatusCreated)
+	rw.Header().Set("Content-Type", "application/json")
+
+	submitJSON := `
+{
+	"status":"saved",
+	"language":"ruby",
+	"exercise":"bob",
+	"submission_path":"/username/ruby/bob"
+}
+`
+	fmt.Fprintf(rw, submitJSON)
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/config"
@@ -17,12 +14,6 @@ import (
 )
 
 const (
-	// Version is the current release of the command-line app.
-	// We try to follow Semantic Versioning (http://semver.org),
-	// but with the http://exercism.io app being a prototype, a
-	// lot of things get out of hand.
-	Version = "1.7.0"
-
 	msgPleaseAuthenticate = "You must be authenticated. Run `exercism configure --key=YOUR_API_KEY`."
 
 	descDebug     = "Outputs useful debug information."
@@ -38,12 +29,6 @@ const (
 	descLongRestore = "Restore will pull the latest revisions of exercises that have already been submitted. It will *not* overwrite existing files. If you have made changes to a file and have not submitted it, and you're trying to restore the last submitted version, first move that file out of the way, then call restore."
 )
 
-var (
-	// UserAgent is sent along as a header to HTTP requests that the
-	// CLI makes. This helps with debugging.
-	UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
-)
-
 var FetchEndpoints = map[string]string{
 	"current":  "/api/v1/user/assignments/current",
 	"next":     "/api/v1/user/assignments/next",
@@ -51,22 +36,11 @@ var FetchEndpoints = map[string]string{
 	"exercise": "/api/v1/assignments",
 }
 
-var testExtensions = map[string]string{
-	"ruby":    "_test.rb",
-	"js":      ".spec.js",
-	"elixir":  "_test.exs",
-	"clojure": "_test.clj",
-	"python":  "_test.py",
-	"go":      "_test.go",
-	"haskell": "_test.hs",
-	"cpp":     "_test.cpp",
-}
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "exercism"
 	app.Usage = "A command line tool to interact with http://exercism.io"
-	app.Version = Version
+	app.Version = config.Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "config, c",
@@ -133,59 +107,7 @@ func main() {
 			Name:      "submit",
 			ShortName: "s",
 			Usage:     descSubmit,
-			Action: func(ctx *cli.Context) {
-				if len(ctx.Args()) == 0 {
-					fmt.Println("Please enter a file name")
-					return
-				}
-
-				c, err := config.Read(ctx.GlobalString("config"))
-				if err != nil {
-					fmt.Println(err)
-					return
-				}
-
-				if !c.IsAuthenticated() {
-					fmt.Println(msgPleaseAuthenticate)
-					return
-				}
-
-				filename := ctx.Args()[0]
-
-				// Make filename relative to config.Dir.
-				absPath, err := absolutePath(filename)
-				if err != nil {
-					fmt.Printf("Couldn't find %v: %v\n", filename, err)
-					return
-				}
-				exDir := c.Dir + string(filepath.Separator)
-				if !strings.HasPrefix(absPath, exDir) {
-					fmt.Printf("%v is not under your exercism project path (%v)\n", absPath, exDir)
-					return
-				}
-				filename = absPath[len(exDir):]
-
-				if IsTest(filename) {
-					fmt.Println("It looks like this is a test, please submit a solution.")
-					return
-				}
-
-				code, err := ioutil.ReadFile(absPath)
-				if err != nil {
-					fmt.Printf("Error reading %v: %v\n", absPath, err)
-					return
-				}
-
-				response, err := SubmitAssignment(c, filename, code)
-				if err != nil {
-					fmt.Printf("There was an issue with your submission: %v\n", err)
-					return
-				}
-
-				fmt.Printf("For feedback on your submission visit %s%s%s\n",
-					c.API, "/submissions/", response.ID)
-
-			},
+			Action:    handlers.Submit,
 		},
 		{
 			Name:      "unsubmit",
@@ -217,29 +139,6 @@ func main() {
 		fmt.Errorf("%v", err)
 		os.Exit(1)
 	}
-}
-
-func absolutePath(path string) (string, error) {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	return filepath.EvalSymlinks(path)
-}
-
-type submitResponse struct {
-	ID             string `json:"id"`
-	Status         string `json:"status"`
-	Language       string `json:"language"`
-	Exercise       string `json:"exercise"`
-	SubmissionPath string `json:"submission_path"`
-	Error          string `json:"error"`
-}
-
-type submitRequest struct {
-	Key  string `json:"key"`
-	Code string `json:"code"`
-	Path string `json:"path"`
 }
 
 func FetchAssignments(c *config.Config, path string) ([]Assignment, error) {
@@ -300,7 +199,7 @@ func UnsubmitAssignment(c *config.Config) error {
 		return err
 	}
 
-	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("User-Agent", config.UserAgent)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -330,53 +229,6 @@ func UnsubmitAssignment(c *config.Config) error {
 	}
 
 	return nil
-}
-func SubmitAssignment(c *config.Config, filePath string, code []byte) (*submitResponse, error) {
-	path := "api/v1/user/assignments"
-
-	url := fmt.Sprintf("%s/%s", c.API, path)
-
-	submission := submitRequest{Key: c.APIKey, Code: string(code), Path: filePath}
-	submissionJSON, err := json.Marshal(submission)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", url, bytes.NewReader(submissionJSON))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		err = fmt.Errorf("Error posting assignment: [%v]", err)
-		return nil, err
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	var r submitResponse
-	if resp.StatusCode != http.StatusCreated {
-		err = json.Unmarshal(body, &r)
-		if err != nil {
-			return nil, err
-		}
-		err = fmt.Errorf("Status: %d, Error: %v", resp.StatusCode, r)
-		return nil, err
-	}
-
-	err = json.Unmarshal(body, &r)
-	if err != nil {
-		return nil, fmt.Errorf("Error parsing API response: [%v]", err)
-	}
-	return &r, nil
 }
 
 type Assignment struct {
@@ -426,13 +278,4 @@ func FetchEndpoint(args []string) string {
 	}
 
 	return endpoint
-}
-
-func IsTest(filename string) bool {
-	for _, ext := range testExtensions {
-		if strings.LastIndex(filename, ext) > 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -97,7 +97,7 @@ var submitHandler = func(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userAgentMatches := strings.HasPrefix(r.Header.Get("User-Agent"), fmt.Sprintf("github.com/exercism/cli v%s", Version))
+	userAgentMatches := strings.HasPrefix(r.Header.Get("User-Agent"), fmt.Sprintf("github.com/exercism/cli v%s", config.Version))
 
 	if !userAgentMatches {
 		fmt.Printf("User agent mismatch: %s\n", r.Header.Get("User-Agent"))
@@ -166,39 +166,6 @@ var submitHandler = func(rw http.ResponseWriter, r *http.Request) {
 }
 `
 	fmt.Fprintf(rw, submitJSON)
-}
-
-func TestSubmitWithKey(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(submitHandler))
-	defer server.Close()
-
-	var code = []byte("My source code\n")
-	c := &config.Config{
-		API:    server.URL,
-		APIKey: "myAPIKey",
-	}
-	response, err := SubmitAssignment(c, "ruby/bob/bob.rb", code)
-	assert.NoError(t, err)
-
-	assert.Equal(t, response.Status, "saved")
-	assert.Equal(t, response.Language, "ruby")
-	assert.Equal(t, response.Exercise, "bob")
-	assert.Equal(t, response.SubmissionPath, "/username/ruby/bob")
-}
-
-func TestSubmitWithIncorrectKey(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(submitHandler))
-	defer server.Close()
-
-	c := &config.Config{
-		API:    server.URL,
-		APIKey: "myWrongAPIKey",
-	}
-
-	var code = []byte("My source code\n")
-	_, err := SubmitAssignment(c, "ruby/bob/bob.rb", code)
-
-	assert.Error(t, err)
 }
 
 func TestSavingAssignment(t *testing.T) {


### PR DESCRIPTION
This PR extracts the `submit` command action handler into a stand alone handler
in `handlers/submit.go` to match the other actions.
- The related specs from `main.go` have been moved to
  `submit_test.go`.
- `Version` and `UserAgent` was moved out of `main` and into
  `config` for this update to work. There may be a better place for these
  constants / variables.
- `msgPleaseAuthenticate` is currently duplicated in both `main` and in
  `submit`. Do you have a preferred way to share these messages?
