### PR TITLE
Update development instrucitons in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If that throws an error, try ```brew install go --cross-compile-common --with-ll
 Development
 ===========
 1. `go get github.com/exercism/cli`
-1. `cd $GOPATH/src/exercism/cli`
+1. `cd $GOPATH/src/github.com/exercism/cli`
 1. `go get`
 1. `go get github.com/levicook/glitch`
 1. `go install github.com/levicook/glitch`


### PR DESCRIPTION
I **think** that we need to add `github.com` to the path in step #2. There doesn't appear to be a directory located at `$GOPATH/src/exercism/cli`, but there is one located at `$GOPATH/src/github.com/exercism/cli`
