### PR TITLE
Allow setting additional configuration options.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,30 @@ func New(key, host, dir string) (*Config, error) {
 	return c.configure()
 }
 
+func AddValues(filename, key, host, dir string) (*Config, error) {
+	c, err := Read(filename)
+	if err != nil {
+		return c, err
+	}
+
+	if key != "" {
+		c.APIKey = key
+	}
+
+	if host != "" {
+		c.API = host
+	}
+
+	if dir != "" {
+		err = c.setDir(dir)
+		if err != nil {
+			return c, err
+		}
+	}
+
+	return c, nil
+}
+
 // Read loads the config from the stored JSON file.
 func (c *Config) Read(file string) error {
 	renameLegacy()
@@ -187,8 +211,24 @@ func (c *Config) configure() (*Config, error) {
 	if c.Dir == "" {
 		c.Dir = filepath.Join(dir, DirExercises)
 	}
-	c.Dir = strings.Replace(c.Dir, "~/", fmt.Sprintf("%s/", dir), 1)
+
+	err = c.setDir(c.Dir)
+	if err != nil {
+		return c, err
+	}
+
 	return c, nil
+}
+
+func (c *Config) setDir(dir string) error {
+	homeDir, err := c.homeDir()
+	if err != nil {
+		return err
+	}
+
+	c.Dir = strings.Replace(dir, "~/", fmt.Sprintf("%s/", homeDir), 1)
+
+	return nil
 }
 
 // FilePath returns the path to the config file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -98,6 +98,27 @@ func TestReadingWritingConfig(t *testing.T) {
 	assert.Equal(t, c1.API, c2.API)
 }
 
+func TestAddingNewValues(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+
+	filename := fmt.Sprintf("%s/%s", tmpDir, File)
+
+	c1 := &Config{
+		APIKey: "MyKey",
+		Dir:    "/exercism/directory",
+		API:    "localhost",
+	}
+	c1.configure()
+	c1.SavePath(filename)
+	c1.Write()
+
+	c2, err := AddValues(filename, "NewKey", "", "")
+	assert.Equal(t, "NewKey", c2.APIKey)
+	assert.Equal(t, c1.API, c2.API)
+	assert.Equal(t, c1.Dir, c2.Dir)
+}
+
 func TestReadDefaultConfig(t *testing.T) {
 	dir, err := filepath.Abs("../fixtures/home")
 	assert.NoError(t, err)


### PR DESCRIPTION
Currently when you set one configuration option, it blows away previously set configuration options.

If we set a custom directory, then the value is set.

```
$ exercism configure --dir="~/code/exercism"
The configuration has been written to /Users/josh/.exercism.json
Your exercism directory can be found at /Users/josh/code/exercism

$ cat ~/.exercism.json
{"apiKey":"","exercismDirectory":"/Users/josh/code/exercism","hostname":"http://exercism.io"}
```

However, when we set a key, the custom directory is blown away

```
$ exercism configure --key="abc123"
The configuration has been written to /Users/josh/.exercism.json
Your exercism directory can be found at /Users/josh/exercism

$ cat ~/.exercism.json
{"apiKey":"abc123","exercismDirectory":"/Users/josh/exercism","hostname":"http://exercism.io"}
```
