### PR TITLE
Make file paths in config_test OS agnostic

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,7 @@ func TestDefaultValues(t *testing.T) {
 	c.configure()
 	assert.Equal(t, "", c.APIKey)
 	assert.Equal(t, "http://exercism.io", c.API)
-	assert.Equal(t, "/home/alice/exercism", c.Dir)
+	assert.Equal(t, filepath.FromSlash("/home/alice/exercism"), c.Dir)
 }
 
 func TestCustomValues(t *testing.T) {
@@ -55,7 +55,7 @@ func TestFilePath(t *testing.T) {
 	c := &Config{}
 	c.home = "/home/alice"
 	c.configure()
-	assert.Equal(t, "/home/alice/.exercism.json", c.File())
+	assert.Equal(t, filepath.FromSlash("/home/alice/.exercism.json"), c.File())
 
 	// can override location of config file
 	c = &Config{}
@@ -70,7 +70,7 @@ func TestReadNonexistantConfig(t *testing.T) {
 	assert.Equal(t, c.APIKey, "")
 	assert.Equal(t, c.API, "http://exercism.io")
 	assert.False(t, c.IsAuthenticated())
-	if !strings.HasSuffix(c.Dir, "/exercism") {
+	if !strings.HasSuffix(c.Dir, filepath.FromSlash("/exercism") )  {
 		t.Fatal("Default unconfigured config should use home dir")
 	}
 }


### PR DESCRIPTION
When trying to do an initial build on Windows 8, the modified tests were failing because they were expecting unix '/'s, but were getting windows style double-backslash. The filepath.FromSlash function was trivially easy to use, and made the tests pass on my system.

Note: I otherwise have absolutely NO clue what these tests are actually doing...
