### PR TITLE
Create exercism directory on configuration

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/config"
@@ -23,10 +24,14 @@ func Configure(ctx *cli.Context) {
 	dir := ctx.String("dir")
 	c.Update(key, host, dir)
 
-	err = c.Write()
-	if err != nil {
+	if err := os.MkdirAll(c.Dir, os.ModePerm); err != nil {
+		log.Fatalf("Error creating exercism directory %s\n", err)
+	}
+
+	if err := c.Write(); err != nil {
 		log.Fatal(err)
 	}
+
 	fmt.Printf("The configuration has been written to %s\n", c.File())
 	fmt.Printf("Your exercism directory can be found at %s\n", c.Dir)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,7 @@ func TestReadNonexistantConfig(t *testing.T) {
 	assert.Equal(t, c.APIKey, "")
 	assert.Equal(t, c.API, "http://exercism.io")
 	assert.False(t, c.IsAuthenticated())
-	if !strings.HasSuffix(c.Dir, filepath.FromSlash("/exercism") )  {
+	if !strings.HasSuffix(c.Dir, filepath.FromSlash("/exercism")) {
 		t.Fatal("Default unconfigured config should use home dir")
 	}
 }


### PR DESCRIPTION
I wasn't really sure where to place the logic to create the directory. Initially, I had planned to put it under `configure()` but that gets called when reading the contents of the file. It also seems like errors coming from `configure()` don't get checked but this is an error we'd generally want to display.

I decided to go for creating an exported function of Config and calling it before writing the file so that the file does not have a directory that could not be created. Let me know if anything jumps out. 

Fixes #122 
