### PR TITLE
add --api option to exercism configure command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ go:
   - 1.1.2
   - tip
 
-install: true
+install:
+  go get -d -v ./... && go build -v ./...
 
 before_install:
   go get github.com/codegangsta/cli && go get github.com/stretchr/testify/assert

--- a/api/api.go
+++ b/api/api.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/exercism/cli/config"
+	"../config"
 )
 
 var (

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/config"
+	"../config"
 )
 
 // Configure stores settings in a JSON file.
@@ -22,7 +22,8 @@ func Configure(ctx *cli.Context) {
 	key := ctx.String("key")
 	host := ctx.String("host")
 	dir := ctx.String("dir")
-	c.Update(key, host, dir)
+	api := ctx.String("api")
+	c.Update(key, host, dir, api)
 
 	if err := os.MkdirAll(c.Dir, os.ModePerm); err != nil {
 		log.Fatalf("Error creating exercism directory %s\n", err)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/config"
+	"../config"
 )
 
 // Debug provides information about the user's environment and configuration.

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -5,9 +5,9 @@ import (
 	"log"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
-	"github.com/exercism/cli/user"
+	"../api"
+	"../config"
+	"../user"
 )
 
 // Demo returns one problem for each active track.

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
+	"../api"
+	"../config"
 )
 
 // Download returns specified submissions and related problem.

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -5,9 +5,9 @@ import (
 	"log"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
-	"github.com/exercism/cli/user"
+	"../api"
+	"../config"
+	"../user"
 )
 
 // Fetch returns exercism problems.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/config"
+	"../config"
 )
 
 // Login interactively stores exercism API configuration.

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/config"
+	"../config"
 )
 
 // Logout deletes the config file.

--- a/cmd/logout_test.go
+++ b/cmd/logout_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/config"
+	"../config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -5,9 +5,9 @@ import (
 	"log"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
-	"github.com/exercism/cli/user"
+	"../api"
+	"../config"
+	"../user"
 )
 
 // Restore returns a user's solved problems.

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
+	"../api"
+	"../config"
 )
 
 // Submit posts an iteration to the api

--- a/cmd/tracks.go
+++ b/cmd/tracks.go
@@ -5,9 +5,9 @@ import (
 	"log"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
-	"github.com/exercism/cli/user"
+	"../api"
+	"../config"
+	"../user"
 )
 
 // Tracks lists available tracks.

--- a/cmd/unsubmit.go
+++ b/cmd/unsubmit.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
+	"../api"
+	"../config"
 )
 
 // Unsubmit deletes an iteration from the api.

--- a/config/config.go
+++ b/config/config.go
@@ -79,17 +79,18 @@ func Read(file string) (*Config, error) {
 
 // New returns a new config.
 // It will attempt to set defaults where no value is passed in.
-func New(key, host, dir string) (*Config, error) {
+func New(key, host, dir, xapi string) (*Config, error) {
 	c := &Config{
 		APIKey: key,
 		API:    host,
 		Dir:    dir,
+		XAPI:   xapi,
 	}
 	return c.configure()
 }
 
 // Update sets new values where given.
-func (c *Config) Update(key, host, dir string) {
+func (c *Config) Update(key, host, dir, xapi string) {
 	if key != "" {
 		c.APIKey = key
 	}
@@ -101,6 +102,11 @@ func (c *Config) Update(key, host, dir string) {
 	if dir != "" {
 		c.Dir = dir
 	}
+	
+	if xapi != "" {
+		c.XAPI = xapi
+	}
+	
 	c.configure()
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,11 +26,13 @@ func TestCustomValues(t *testing.T) {
 		APIKey: "abc123",
 		API:    "http://example.org",
 		Dir:    "/path/to/exercises",
+		XAPI:   "http://x.example.org",
 	}
 	c.configure()
 	assert.Equal(t, "abc123", c.APIKey)
 	assert.Equal(t, "http://example.org", c.API)
 	assert.Equal(t, "/path/to/exercises", c.Dir)
+	assert.Equal(t, "http://x.example.org", c.XAPI)
 }
 
 func TestExpandHomeDir(t *testing.T) {
@@ -45,11 +47,13 @@ func TestSanitizeWhitespace(t *testing.T) {
 		APIKey: "   abc123\n\r\n  ",
 		API:    "       ",
 		Dir:    "  \r\n/path/to/exercises   \r\n",
+		XAPI:   "   ",
 	}
 	c.configure()
 	assert.Equal(t, "abc123", c.APIKey)
 	assert.Equal(t, "http://exercism.io", c.API)
 	assert.Equal(t, "/path/to/exercises", c.Dir)
+	assert.Equal(t, "http://x.exercism.io", c.XAPI)
 }
 
 func TestFilePath(t *testing.T) {
@@ -71,6 +75,7 @@ func TestReadNonexistantConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, c.APIKey, "")
 	assert.Equal(t, c.API, "http://exercism.io")
+	assert.Equal(t, c.XAPI, "http://x.exercism.io")
 	assert.False(t, c.IsAuthenticated())
 	if !strings.HasSuffix(c.Dir, filepath.FromSlash("/exercism")) {
 		t.Fatal("Default unconfigured config should use home dir")
@@ -86,6 +91,7 @@ func TestReadingWritingConfig(t *testing.T) {
 		APIKey: "MyKey",
 		Dir:    "/exercism/directory",
 		API:    "localhost",
+		XAPI:   "localhost",
 	}
 	c1.configure()
 
@@ -98,6 +104,7 @@ func TestReadingWritingConfig(t *testing.T) {
 	assert.Equal(t, c1.APIKey, c2.APIKey)
 	assert.Equal(t, c1.Dir, c2.Dir)
 	assert.Equal(t, c1.API, c2.API)
+	assert.Equal(t, c1.XAPI, c2.XAPI)
 }
 
 func TestUpdateConfig(t *testing.T) {
@@ -105,22 +112,32 @@ func TestUpdateConfig(t *testing.T) {
 		APIKey: "MyKey",
 		Dir:    "/exercism/directory",
 		API:    "localhost",
+		XAPI:   "localhost",
 	}
 
-	c.Update("NewKey", "", "")
+	c.Update("NewKey", "", "", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "localhost", c.API)
 	assert.Equal(t, "/exercism/directory", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
 
-	c.Update("", "http://example.com", "")
+	c.Update("", "http://example.com", "", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "http://example.com", c.API)
 	assert.Equal(t, "/exercism/directory", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
 
-	c.Update("", "", "/tmp/exercism")
+	c.Update("", "", "/tmp/exercism", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "http://example.com", c.API)
 	assert.Equal(t, "/tmp/exercism", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
+
+	c.Update("", "", "", "http://x.example.org")
+	assert.Equal(t, "NewKey", c.APIKey)
+	assert.Equal(t, "http://example.com", c.API)
+	assert.Equal(t, "/tmp/exercism", c.Dir)
+	assert.Equal(t, "http://x.example.org", c.XAPI)
 }
 
 func TestReadDefaultConfig(t *testing.T) {

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 
 	"github.com/codegangsta/cli"
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/cmd"
+	"../api"
+	"../cmd"
 )
 
 const (
@@ -71,6 +71,10 @@ func main() {
 				cli.StringFlag{
 					Name:  "key, k",
 					Usage: "exercism.io API key (see http://exercism.io/account)",
+				},
+				cli.StringFlag{
+					Name:  "api, a",
+					Usage: "exercism xapi host",
 				},
 			},
 			Action: cmd.Configure,

--- a/user/curriculum.go
+++ b/user/curriculum.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/exercism/cli/api"
+	"../api"
 )
 
 // Status is the status of a track (active/inactive).

--- a/user/homework.go
+++ b/user/homework.go
@@ -3,8 +3,8 @@ package user
 import (
 	"fmt"
 
-	"github.com/exercism/cli/api"
-	"github.com/exercism/cli/config"
+	"../api"
+	"../config"
 )
 
 // HWFilter is used to categorize homework items.

--- a/user/item.go
+++ b/user/item.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/exercism/cli/api"
+	"../api"
 )
 
 // Item is a problem that has been fetched from the APIs.


### PR DESCRIPTION
In response to #145 

Summary of changes:

* add `--api` and `-a` parameters to `exercism configure`
* updated `config_test.go` to test success of changes
* replaced `github.com/exercism/cli` in all `import` statements with `..` to refer to local code

I found in working on this that my changes to code didn't get reflected in builds because the `import` statements always pulled the other cli library code from github instead of the local package, hence the 3rd change above.