### PR TITLE
added --api option to exercism configure; updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ If that throws an error, try ```brew install go --cross-compile-common --with-ll
 
 Development
 ===========
+1. fork this repo
 1. `go get github.com/exercism/cli/exercism`
 1. `cd $GOPATH/src/github.com/exercism/cli`
+1. `git remote set-url origin https://github.com/<your-github-username>/cli`
 1. `go get`
 1. `go get github.com/levicook/glitch`
 1. `go install github.com/levicook/glitch`

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -22,7 +22,8 @@ func Configure(ctx *cli.Context) {
 	key := ctx.String("key")
 	host := ctx.String("host")
 	dir := ctx.String("dir")
-	c.Update(key, host, dir)
+	api := ctx.String("api")
+	c.Update(key, host, dir, api)
 
 	if err := os.MkdirAll(c.Dir, os.ModePerm); err != nil {
 		log.Fatalf("Error creating exercism directory %s\n", err)

--- a/config/config.go
+++ b/config/config.go
@@ -79,17 +79,18 @@ func Read(file string) (*Config, error) {
 
 // New returns a new config.
 // It will attempt to set defaults where no value is passed in.
-func New(key, host, dir string) (*Config, error) {
+func New(key, host, dir, xapi string) (*Config, error) {
 	c := &Config{
 		APIKey: key,
 		API:    host,
 		Dir:    dir,
+		XAPI:   xapi,
 	}
 	return c.configure()
 }
 
 // Update sets new values where given.
-func (c *Config) Update(key, host, dir string) {
+func (c *Config) Update(key, host, dir, xapi string) {
 	if key != "" {
 		c.APIKey = key
 	}
@@ -101,6 +102,11 @@ func (c *Config) Update(key, host, dir string) {
 	if dir != "" {
 		c.Dir = dir
 	}
+	
+	if xapi != "" {
+		c.XAPI = xapi
+	}
+	
 	c.configure()
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,11 +26,13 @@ func TestCustomValues(t *testing.T) {
 		APIKey: "abc123",
 		API:    "http://example.org",
 		Dir:    "/path/to/exercises",
+		XAPI:   "http://x.example.org",
 	}
 	c.configure()
 	assert.Equal(t, "abc123", c.APIKey)
 	assert.Equal(t, "http://example.org", c.API)
 	assert.Equal(t, "/path/to/exercises", c.Dir)
+	assert.Equal(t, "http://x.example.org", c.XAPI)
 }
 
 func TestExpandHomeDir(t *testing.T) {
@@ -45,11 +47,13 @@ func TestSanitizeWhitespace(t *testing.T) {
 		APIKey: "   abc123\n\r\n  ",
 		API:    "       ",
 		Dir:    "  \r\n/path/to/exercises   \r\n",
+		XAPI:   "   ",
 	}
 	c.configure()
 	assert.Equal(t, "abc123", c.APIKey)
 	assert.Equal(t, "http://exercism.io", c.API)
 	assert.Equal(t, "/path/to/exercises", c.Dir)
+	assert.Equal(t, "http://x.exercism.io", c.XAPI)
 }
 
 func TestFilePath(t *testing.T) {
@@ -71,6 +75,7 @@ func TestReadNonexistantConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, c.APIKey, "")
 	assert.Equal(t, c.API, "http://exercism.io")
+	assert.Equal(t, c.XAPI, "http://x.exercism.io")
 	assert.False(t, c.IsAuthenticated())
 	if !strings.HasSuffix(c.Dir, filepath.FromSlash("/exercism")) {
 		t.Fatal("Default unconfigured config should use home dir")
@@ -86,6 +91,7 @@ func TestReadingWritingConfig(t *testing.T) {
 		APIKey: "MyKey",
 		Dir:    "/exercism/directory",
 		API:    "localhost",
+		XAPI:   "localhost",
 	}
 	c1.configure()
 
@@ -98,6 +104,7 @@ func TestReadingWritingConfig(t *testing.T) {
 	assert.Equal(t, c1.APIKey, c2.APIKey)
 	assert.Equal(t, c1.Dir, c2.Dir)
 	assert.Equal(t, c1.API, c2.API)
+	assert.Equal(t, c1.XAPI, c2.XAPI)
 }
 
 func TestUpdateConfig(t *testing.T) {
@@ -105,22 +112,32 @@ func TestUpdateConfig(t *testing.T) {
 		APIKey: "MyKey",
 		Dir:    "/exercism/directory",
 		API:    "localhost",
+		XAPI:   "localhost",
 	}
 
-	c.Update("NewKey", "", "")
+	c.Update("NewKey", "", "", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "localhost", c.API)
 	assert.Equal(t, "/exercism/directory", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
 
-	c.Update("", "http://example.com", "")
+	c.Update("", "http://example.com", "", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "http://example.com", c.API)
 	assert.Equal(t, "/exercism/directory", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
 
-	c.Update("", "", "/tmp/exercism")
+	c.Update("", "", "/tmp/exercism", "")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "http://example.com", c.API)
 	assert.Equal(t, "/tmp/exercism", c.Dir)
+	assert.Equal(t, "localhost", c.XAPI)
+
+	c.Update("", "", "", "http://x.example.org")
+	assert.Equal(t, "NewKey", c.APIKey)
+	assert.Equal(t, "http://example.com", c.API)
+	assert.Equal(t, "/tmp/exercism", c.Dir)
+	assert.Equal(t, "http://x.example.org", c.XAPI)
 }
 
 func TestReadDefaultConfig(t *testing.T) {

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -72,6 +72,10 @@ func main() {
 					Name:  "key, k",
 					Usage: "exercism.io API key (see http://exercism.io/account)",
 				},
+				cli.StringFlag{
+					Name:  "api, a",
+					Usage: "exercism xapi host",
+				},
 			},
 			Action: cmd.Configure,
 		},


### PR DESCRIPTION
In response to #145

Summary of changes:

* add `--api` and `-a` parameters to `exercism configure`
* updated `config_test.go` to test success of changes