### PR TITLE
Expand '~' to user home in config file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ----------------
 
+* [#151](https://github.com/exercism/cli/pull/151): Expand '~' in config path to home directory - @lcowell
 * Your contribution here
 
 ## v1.9.2 (Jan 11, 2015)

--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,10 @@ func Expand(path, env, home string) string {
 		path = env
 	}
 
+	if path != "" && path[0] == '~' {
+		path = strings.Replace(path, "~/", fmt.Sprintf("%s/", home), 1)
+	}
+
 	if path == "" {
 		path = filepath.Join(home, File)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,11 @@ func TestExpandConfigPath(t *testing.T) {
 		},
 		{
 			"",
+			"~/config.json",
+			"/home/alice/config.json",
+		},
+		{
+			"",
 			"",
 			"/home/alice/.exercism.json",
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,30 @@ func TestExpandHomeDir(t *testing.T) {
 	assert.Equal(t, "/home/alice/practice", c.Dir)
 }
 
+func TestExpandConfigPath(t *testing.T) {
+	testCases := []struct {
+		path   string
+		env    string
+		result string
+	}{
+		{
+			"path/to/config.json",
+			"",
+			"path/to/config.json",
+		},
+		{
+			"",
+			"",
+			"/home/alice/.exercism.json",
+		},
+	}
+	home := "/home/alice"
+
+	for _, tt := range testCases {
+		assert.Equal(t, Expand(tt.path, tt.env, home), tt.result)
+	}
+}
+
 func TestSanitizeWhitespace(t *testing.T) {
 	c := &Config{
 		APIKey: "   abc123\n\r\n  ",


### PR DESCRIPTION
* Added `config.Expand` function to make it easier to test the various permutations of inputs for a config file's location.
* Closes #149 

Looking for any input before I merge this in.