### PR TITLE
Tweak output from fetch to make it more scannable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 ## Next Release
 
 * [#167](https://github.com/exercism/cli/pull/167): Fixes misspelling of exercism list command - [@queuebit](https://github.com/queuebit)
+* Tweak output from `fetch` so that languages are scannable.
 * **Your contribution here**
 
 ## v2.0.0 (2015-03-05)

--- a/api/problem.go
+++ b/api/problem.go
@@ -14,5 +14,5 @@ type Problem struct {
 }
 
 func (p *Problem) String() string {
-	return fmt.Sprintf("%s (%s)", p.Name, p.Language)
+	return fmt.Sprintf("%s (%s)", p.Language, p.Name)
 }

--- a/user/homework.go
+++ b/user/homework.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/exercism/cli/api"
 	"github.com/exercism/cli/config"
@@ -46,7 +47,7 @@ func NewHomework(problems []*api.Problem, c *config.Config) *Homework {
 		hw.Items = append(hw.Items, item)
 	}
 
-	hw.template = fmt.Sprintf("%%%ds %%s\n", hw.maxTitleWidth())
+	hw.template = "%s%s %s\n"
 	return &hw
 }
 
@@ -75,14 +76,18 @@ func (hw *Homework) ItemsMatching(filter HWFilter) []*Item {
 // It prints the track name, the problem name, and the full
 // path to the problem on the user's filesystem.
 func (hw *Homework) Report(filter HWFilter) {
+	if hw == nil {
+		return
+	}
+	width := hw.maxTitleWidth()
 	items := hw.ItemsMatching(filter)
-	hw.heading(filter, len(items))
+	hw.heading(filter, len(items), width)
 	for _, item := range items {
-		fmt.Printf(hw.template, item.String(), item.Path())
+		fmt.Print(item.Report(hw.template, width))
 	}
 }
 
-func (hw *Homework) heading(filter HWFilter, count int) {
+func (hw *Homework) heading(filter HWFilter, count, width int) {
 	if count == 0 {
 		return
 	}
@@ -107,17 +112,21 @@ func (hw *Homework) heading(filter HWFilter, count int) {
 		status = "Not Submitted:"
 	}
 	summary := fmt.Sprintf("%d %s", count, unit)
-	fmt.Printf(hw.template, status, summary)
+	padding := strings.Repeat(" ", width-len(status))
+	fmt.Printf(hw.template, status, padding, summary)
 }
 
 func (hw *Homework) maxTitleWidth() int {
-	var max int
+	if hw == nil {
+		return 0
+	}
+	var width int
 	for _, item := range hw.Items {
-		if len(item.String()) > max {
-			max = len(item.String())
+		if len(item.String()) > width {
+			width = len(item.String())
 		}
 	}
-	return max
+	return width
 }
 
 // Summarize prints a full report of new and updated items in the set.

--- a/user/item.go
+++ b/user/item.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -73,4 +74,10 @@ func (it *Item) Save() error {
 		}
 	}
 	return nil
+}
+
+// Report outputs the line's string and path in the format of the passed in template.
+func (it *Item) Report(template string, max int) string {
+	padding := strings.Repeat(" ", max-len(it.String()))
+	return fmt.Sprintf(template, it.String(), padding, it.Path())
 }

--- a/user/item_test.go
+++ b/user/item_test.go
@@ -1,0 +1,39 @@
+package user
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/config"
+)
+
+func TestItemReport(t *testing.T) {
+	testCases := []struct {
+		max      int
+		expected string
+	}{
+		{10, "Go (Clock) /tmp/go/clock\n"},
+		{15, "Go (Clock)      /tmp/go/clock\n"},
+		{25, "Go (Clock)                /tmp/go/clock\n"},
+	}
+
+	for _, tc := range testCases {
+		problem1 := &api.Problem{
+			TrackID:  "go",
+			Slug:     "clock",
+			Language: "Go",
+			Name:     "Clock",
+		}
+
+		hw := NewHomework([]*api.Problem{problem1}, &config.Config{Dir: "/tmp"})
+		if len(hw.Items) == 0 {
+			t.Fatal(errors.New("failed to initialize homework correctly"))
+		}
+		item := hw.Items[0]
+		actual := item.Report(hw.template, tc.max)
+		if tc.expected != actual {
+			t.Errorf("Expected:\n'%s', Got:\n'%s'\n", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
It's sometimes difficult to find the problem(s) that you're
currently working on. The previous 'report' output format
ordered by the problem name, grouping "Bobs" in all the languages
together.

It seems like people tend to scan for the language, not the problem.

Makes sense in hindsight.

See:
- https://github.com/exercism/cli/issues/137
- https://github.com/exercism/exercism.io/issues/1972

I just realised how utterly awful I think the homework/report/item stuff is. I'm not sure what I was thinking when I wrote that. When I have finished traveling for a bit I'll take another look at rewriting or refactoring that.