### PR TITLE
ENV based config path handed in main app

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	fileEnvKey = "EXERCISM_CONFIG_FILE"
 	// File is the default name of the JSON file where the config written.
 	// The user can pass an alternate filename when using the CLI.
 	File = ".exercism.json"
@@ -67,7 +66,7 @@ func Home() (string, error) {
 // New returns a configuration struct with content from the exercism.json file
 func New(path string) (*Config, error) {
 	c := &Config{}
-	err := c.load(path, os.Getenv(fileEnvKey))
+	err := c.load(path)
 	return c, err
 }
 
@@ -107,8 +106,8 @@ func (c *Config) Write() error {
 	return e.Encode(c)
 }
 
-func (c *Config) load(argPath, envPath string) error {
-	path, err := c.resolvePath(argPath, envPath)
+func (c *Config) load(argPath string) error {
+	path, err := c.resolvePath(argPath)
 	if err != nil {
 		return err
 	}
@@ -159,11 +158,8 @@ func (c *Config) homeDir() (string, error) {
 	return Home()
 }
 
-func (c *Config) resolvePath(argPath, envPath string) (string, error) {
+func (c *Config) resolvePath(argPath string) (string, error) {
 	path := argPath
-	if path == "" {
-		path = envPath
-	}
 	if path == "" {
 		path = filepath.Join("~", File)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,14 +28,12 @@ func TestLoad(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		in                  string // the name of the file passed as a command line argument
-		env                 string // the name of the file stored in the environment variable
 		out                 string // the name of the file that the config will be written to
 		dir, key, api, xapi string // the actual config values
 	}{
 		{
 			desc: "defaults",
 			in:   "",
-			env:  "",
 			out:  filepath.Join(tmpDir, File),
 			dir:  filepath.Join(tmpDir, DirExercises),
 			key:  "",
@@ -45,7 +43,6 @@ func TestLoad(t *testing.T) {
 		{
 			desc: "no such file",
 			in:   filepath.Join(tmpDir, "no-such.json"),
-			env:  "",
 			out:  filepath.Join(tmpDir, "no-such.json"),
 			dir:  filepath.Join(tmpDir, DirExercises),
 			key:  "",
@@ -55,7 +52,6 @@ func TestLoad(t *testing.T) {
 		{
 			desc: "file exists",
 			in:   configPath,
-			env:  "",
 			out:  configPath,
 			dir:  "/a/b/c",
 			key:  "abc123",
@@ -65,47 +61,15 @@ func TestLoad(t *testing.T) {
 		{
 			desc: "unexpanded path",
 			in:   "~/config.json",
-			env:  "",
 			out:  configPath,
 			dir:  "/a/b/c",
 			key:  "abc123",
 			api:  "http://api.example.com",
 			xapi: "http://x.example.com",
-		},
-		{
-			desc: "file in env",
-			in:   "",
-			env:  configPath,
-			out:  configPath,
-			dir:  "/a/b/c",
-			key:  "abc123",
-			api:  "http://api.example.com",
-			xapi: "http://x.example.com",
-		},
-		{
-			desc: "unexpanded path in env",
-			in:   "",
-			env:  "~/env.json",
-			out:  filepath.Join(tmpDir, "env.json"),
-			dir:  filepath.Join(tmpDir, DirExercises),
-			key:  "",
-			api:  hostAPI,
-			xapi: hostXAPI,
-		},
-		{
-			desc: "command line argument overrides env",
-			in:   "~/arg.json",
-			env:  "~/env.json",
-			out:  filepath.Join(tmpDir, "arg.json"),
-			dir:  filepath.Join(tmpDir, DirExercises),
-			key:  "",
-			api:  hostAPI,
-			xapi: hostXAPI,
 		},
 		{
 			desc: "sanitizes whitespace",
 			in:   "~/dirty.json",
-			env:  "",
 			out:  filepath.Join(tmpDir, "dirty.json"),
 			dir:  "/a/b/c",
 			key:  "abc123",
@@ -117,7 +81,7 @@ func TestLoad(t *testing.T) {
 	for _, tc := range testCases {
 		c := &Config{home: tmpDir}
 
-		if err := c.load(tc.in, tc.env); err != nil {
+		if err := c.load(tc.in); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, tc.out, c.File, tc.desc)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -44,8 +44,9 @@ func main() {
 	app.HideVersion = true
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "config, c",
-			Usage: "path to config file",
+			Name:   "config, c",
+			Usage:  "path to config file",
+			EnvVar: "EXERCISM_CONFIG_FILE",
 		},
 		cli.BoolFlag{
 			Name:  "verbose, v",


### PR DESCRIPTION
codegangsta/cli can handle cascading configuration options which means
we don't need to handle the EXERCISM_CONFIG_FILE environment variable
in the config package.

See Issue #172 for more information.