### PR TITLE
Only add padding in report if necessary. Fixes #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 
 ## Next Release
 
+* [#174](https://github.com/exercism/cli/issues/174): Fix panic during fetch
 * **Your contribution here**
 
 ## v2.0.1 (2015-25-05)

--- a/user/homework.go
+++ b/user/homework.go
@@ -112,7 +112,10 @@ func (hw *Homework) heading(filter HWFilter, count, width int) {
 		status = "Not Submitted:"
 	}
 	summary := fmt.Sprintf("%d %s", count, unit)
-	padding := strings.Repeat(" ", width-len(status))
+	var padding string
+	if width > len(status) {
+		padding = strings.Repeat(" ", width-len(status))
+	}
 	fmt.Printf(hw.template, status, padding, summary)
 }
 


### PR DESCRIPTION
The fetch command was trying to create negative padding
under certain circumstances, causing a panic.