### PR TITLE
Provide a more robust error message if JSON is invalid.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -140,8 +141,15 @@ func (c *Config) read() error {
 	}
 	defer f.Close()
 
-	d := json.NewDecoder(f)
-	return d.Decode(&c)
+	if err := json.NewDecoder(f).Decode(&c); err != nil {
+		var extra string
+		if _, ok := err.(*json.SyntaxError); ok {
+			extra = ":\nThe file contains invalid JSON syntax"
+		}
+		return fmt.Errorf("error parsing JSON in the config file %s%s: %s", f.Name(), extra, err)
+	}
+
+	return nil
 }
 
 // IsAuthenticated returns true if the config contains an API key.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,6 @@ func TestLoad(t *testing.T) {
 	if err := os.Link(fixturePath(t, "dirty.json"), dirtyPath); err != nil {
 		t.Fatal(err)
 	}
-
 	testCases := []struct {
 		desc                string
 		in                  string // the name of the file passed as a command line argument
@@ -109,6 +108,23 @@ func TestReadDirectory(t *testing.T) {
 	myConfig, err = New("badpath")
 	assert.NoError(t, err)
 	assert.Equal(t, "badpath", myConfig.File)
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidPath := filepath.Join(tmpDir, "config_invalid.json")
+	if err := os.Link(fixturePath(t, "config_invalid.json"), invalidPath); err != nil {
+		t.Fatal(err)
+	}
+	c := &Config{home: tmpDir}
+
+	err = c.load("~/config_invalid.json")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "The file contains invalid JSON syntax")
+	}
 }
 
 func TestReadingWritingConfig(t *testing.T) {

--- a/fixtures/config_invalid.json
+++ b/fixtures/config_invalid.json
@@ -1,0 +1,1 @@
+{"apiKey":"abc123","dir":"D:\\Users\escaped","api":"http://api.example.com","xapi":"http://x.example.com"}


### PR DESCRIPTION
Fixes #170 

With `json.SyntaxError` we also have the `Offset` at which the error is, so we can highlight where the syntax error is. I can work on that if that's something we want but this should be enough to get going.

