### PR TITLE
Allow $XDG_CONFIG_HOME to configure config location

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,14 @@ func (c *Config) resolvePath(argPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.Replace(path, "~", h, 1), nil
+	path = strings.Replace(path, "~", h, 1)
+
+	fi, _ := os.Stat(path)
+	if fi != nil && fi.IsDir() {
+		path = filepath.Join(path, File)
+	}
+
+	return path, nil
 }
 
 func (c *Config) setDefaults() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -92,6 +92,25 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestReadDirectory(t *testing.T) {
+	// if the provided path is a directory, append the default filename
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+
+	myConfig, err := New(tmpDir)
+	assert.NoError(t, err)
+
+	expected := filepath.Join(tmpDir, File)
+	actual := myConfig.File
+	assert.Equal(t, expected, actual)
+
+	// if it can't determine if the provided path is a directory, don't modify
+	// the path
+	myConfig, err = New("badpath")
+	assert.NoError(t, err)
+	assert.Equal(t, "badpath", myConfig.File)
+}
+
 func TestReadingWritingConfig(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	filename := fmt.Sprintf("%s/%s", tmpDir, File)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -46,7 +46,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "config, c",
 			Usage:  "path to config file",
-			EnvVar: "EXERCISM_CONFIG_FILE",
+			EnvVar: "XDG_CONFIG_HOME,EXERCISM_CONFIG_FILE",
 		},
 		cli.BoolFlag{
 			Name:  "verbose, v",


### PR DESCRIPTION
If $XDG_CONFIG_HOME (or any mechanism for setting the config path) points to a directory, append the default filename to the provided path. Resolves #161 and possibly resolves #176 