### PR TITLE
Pretty print JSON config.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -123,7 +123,7 @@ func TestLoad_InvalidJSON(t *testing.T) {
 
 	err = c.load("~/config_invalid.json")
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "The file contains invalid JSON syntax")
+		assert.Contains(t, err.Error(), "invalid JSON syntax")
 	}
 }
 


### PR DESCRIPTION
Also, print line number highlight the entire JSON line when a syntax error occurs

errors now point to the line number

```
2015/04/03 13:17:37 error parsing JSON in the config file /Users/tonkpils/.exercism.json:
invalid JSON syntax at line 3:
    3: 	"dir": "/Users/tonkpil\s <~
invalid character 's' in string escape code
```

And the file now looks like

```
$ cat ~/.exercism.json                                                                                
{
	"apiKey": <api_key>,
	"dir": "/Users/tonkpils/exercism",
	"api": "http://exercism.io",
	"xapi": "http://x.exercism.io"
}
```