### PR TITLE
Allow submitting test file with --test flag

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -51,8 +51,11 @@ func Submit(ctx *cli.Context) {
 			log.Printf("file name: %s", filename)
 		}
 
-		if isTest(filename) {
-			log.Fatal("Please submit the solution, not the test file.")
+		if isTest(filename) && !ctx.Bool("test") {
+			log.Fatal("You're trying to submit a test file. If this is really what " +
+				"you want, please pass the --test flag to exercism submit.")
+		} else if !isTest(filename) && ctx.Bool("test") {
+			log.Fatal("You've passed the --test flag but you're not submitting a test file.")
 		}
 
 		file, err := filepath.Abs(filename)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -121,6 +121,12 @@ func main() {
 			ShortName: "s",
 			Usage:     descSubmit,
 			Action:    cmd.Submit,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "test",
+					Usage: "submit a test file",
+				},
+			},
 		},
 		{
 			Name:      "unsubmit",


### PR DESCRIPTION
This is a bit of a different approach than we discussed earlier. It still blocks accidental test submissions but gives instructions for how to submit tests if that's what you want.

Closes #188