### PR TITLE
Compare home path expansion using OS specific separator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -264,7 +264,7 @@ func (c *Config) SetDir(path string) error {
 }
 
 func expandHome(path, home string) string {
-	if path[:2] == "~/" {
+	if path[:2] == "~"+string(os.PathSeparator) {
 		return strings.Replace(path, "~", home, 1)
 	}
 	return path


### PR DESCRIPTION
Fixes https://github.com/exercism/exercism.io/issues/2393

I was able to test it on a windows machine and it worked fine. I'll have to think of a way to write a unit test for it though. 