### PR TITLE
Loosen up restriction for --test flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 
 ## Next Release
 
+* [#192](https://github.com/exercism/cli/pull/192): Loosen up restrictions on --test flag for submissions - [@Tonkpils](https://github.com/Tonkpils)
 * [#190](https://github.com/exercism/cli/pull/190): Fix bug in home directory expansion for Windows - [@Tonkpils](https://github.com/Tonkpils)
 * **Your contribution here**
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -54,8 +54,6 @@ func Submit(ctx *cli.Context) {
 		if isTest(filename) && !ctx.Bool("test") {
 			log.Fatal("You're trying to submit a test file. If this is really what " +
 				"you want, please pass the --test flag to exercism submit.")
-		} else if !isTest(filename) && ctx.Bool("test") {
-			log.Fatal("You've passed the --test flag but you're not submitting a test file.")
 		}
 
 		file, err := filepath.Abs(filename)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -124,7 +124,7 @@ func main() {
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "test",
-					Usage: "submit a test file",
+					Usage: "allow submision of test files",
 				},
 			},
 		},


### PR DESCRIPTION
Allows submitting test files along with regular files. (e.g. exercism submit --test foo.rb foo_test.rb)

Fixes #191 