### PR TITLE
Print release info on debug

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -38,7 +38,7 @@ func Debug(ctx *cli.Context) {
 		log.Println(err)
 	} else {
 		if rel.Version() != ctx.App.Version {
-			defer fmt.Println("\nYour CLI is outdated. A new release can be found here:", rel.Location)
+			defer fmt.Printf("\nA newer version of the CLI (%s) can be downloaded here: %s\n", rel.TagName, rel.Location)
 		}
 		fmt.Printf("Exercism CLI Latest Release: %s\n", rel.Version())
 	}


### PR DESCRIPTION
This prints out the latest release version as part of the debug and it informs the user if their client is currently outdated and where they can find the latest release. 

This is in the interim while I work on the `upgrade` functionality. 

The wording could use some help though. 

This is mostly for review and thoughts. If we want the upgrade functionality instead of this I'll have it ready fairly soon.