### PR TITLE
Upgrade command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -266,6 +266,7 @@ func (c *Client) Tracks() ([]*Track, error) {
 	return payload.Tracks, nil
 }
 
+// Skip sends a request to exercism to skip the exercise given language and slug
 func (c *Client) Skip(language, slug string) error {
 	url := fmt.Sprintf("%s/api/v1/iterations/%s/%s/skip?key=%s", c.APIHost, language, slug, c.APIKey)
 

--- a/api/iteration.go
+++ b/api/iteration.go
@@ -73,6 +73,8 @@ func NewIteration(dir string, filenames []string) (*Iteration, error) {
 	return iter, nil
 }
 
+// RelativePath returns the iterations relative path
+// iter.Dir/iter.Language/iter.Problem/
 func (iter *Iteration) RelativePath() string {
 	return filepath.Join(iter.Dir, iter.Language, iter.Problem) + string(filepath.Separator)
 }

--- a/bin/build-all
+++ b/bin/build-all
@@ -5,51 +5,75 @@ set -e -x
 echo "Creating release dir..."
 mkdir -p release
 
-echo "Creating darwin/386 binary..."
-GOOS=darwin GOARCH=386 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-mac-32bit.tgz exercism
-cd ..
+# variables as defined by "go tool nm"
+OSVAR=github.com/exercism/cli/cmd.BuildOS
+ARCHVAR=github.com/exercism/cli/cmd.BuildARCH
+ARMVAR=github.com/exercism/cli/cmd.BuildARM
 
-echo "Creating darwin/amd64 binary..."
-GOOS=darwin GOARCH=amd64 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-mac-64bit.tgz exercism
-cd ..
+createRelease() {
+	os=$1
+	arch=$2
+	arm=$3
 
-echo "Creating linux/386 binary..."
-GOOS=linux GOARCH=386 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-linux-32bit.tgz exercism
-cd ..
+	if [ "$os" = darwin ]
+	then
+		osname='mac'
+	else
+		osname=$os
+	fi
+	if [ "$arch" = amd64 ]
+	then
+		osarch=64bit
+	else
+		osarch=32bit
+	fi
 
-echo "Creating linux/amd64 binary..."
-GOOS=linux GOARCH=amd64 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-linux-64bit.tgz exercism
-cd ..
+	ldflags="-X $OSVAR $os -X $ARCHVAR $arch"
+	if [ "$arm" ]
+	then
+		osarch=arm-v$arm
+		ldflags="$ldflags -X $ARMVAR $arm"
+	fi
 
-echo "Creating linux/ARMv5 binary..."
-GOOS=linux GOARCH=arm GOARM=5 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-linux-arm-v5.tgz exercism
-cd ..
+	binname=exercism
+	if [ "$osname" = windows ]
+	then
+		binname="$binname.exe"
+	fi
 
-echo "Creating linux/ARMv6 binary..."
-GOOS=linux GOARCH=arm GOARM=6 go build -o out/exercism exercism/main.go
-cd out
-tar cvzf ../release/exercism-linux-arm-v6.tgz exercism
-cd ..
+	relname="../release/exercism-$osname-$osarch"
+	echo "Creating $os/$arch binary..."
 
-echo "Creating windows/386 binary..."
-GOOS=windows GOARCH=386 go build -o out/exercism.exe exercism/main.go
-cd out
-zip ../release/exercism-windows-32bit.zip exercism.exe
-cd ..
+	if [ "$arm" ]
+	then
+		GOOS=$os GOARCH=$arch GOARM=$arm go build -ldflags "$ldflags" -o "out/$binname" exercism/main.go
+	else
+		GOOS=$os GOARCH=$arch go build -ldflags "$ldflags" -o "out/$binname" exercism/main.go
+	fi
 
-echo "Creating windows/amd64 binary..."
-GOOS=windows GOARCH=amd64 go build -o out/exercism.exe exercism/main.go
-cd out
-zip ../release/exercism-windows-64bit.zip exercism.exe
-cd ..
+	cd out
 
+	if [ "$osname" = windows ]
+	then
+		zip "$relname.zip" "$binname"
+	else
+		tar cvzf "$relname.tgz" "$binname"
+	fi
+	cd ..
+}
+
+# Mac Releases
+createRelease darwin 386
+createRelease darwin amd64
+
+# Linux Releases
+createRelease linux 386
+createRelease linux amd64
+
+# ARM Releases
+createRelease linux arm 5
+createRelease linux arm 6
+
+# Windows Releases
+createRelease windows 386
+createRelease windows amd64

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -34,6 +34,10 @@ func Debug(ctx *cli.Context) {
 	}
 
 	fmt.Printf("OS/Architecture: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("Build OS/Architecture %s/%s\n", BuildOS, BuildARCH)
+	if BuildARM != "" {
+		fmt.Printf("Build ARMv%s\n", BuildARM)
+	}
 
 	dir, err := config.Home()
 	if err != nil {

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -8,21 +8,11 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/config"
 )
-
-type release struct {
-	Location string `json:"html_url"`
-	TagName  string `json:"tag_name"`
-}
-
-func (r *release) Version() string {
-	return strings.TrimPrefix(r.TagName, "v")
-}
 
 // Debug provides information about the user's environment and configuration.
 func Debug(ctx *cli.Context) {

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -63,8 +63,8 @@ func Debug(ctx *cli.Context) {
 		fmt.Println("API Key: <not configured>")
 	}
 
-	fmt.Printf("API: %s [%s]\n", c.API, pingUrl(client, c.API))
-	fmt.Printf("XAPI: %s [%s]\n", c.XAPI, pingUrl(client, c.XAPI))
+	fmt.Printf("API: %s [%s]\n", c.API, pingURL(client, c.API))
+	fmt.Printf("XAPI: %s [%s]\n", c.XAPI, pingURL(client, c.XAPI))
 	fmt.Printf("Exercises Directory: %s\n", c.Dir)
 }
 
@@ -82,7 +82,7 @@ func checkLatestRelease(client http.Client) (*release, error) {
 	return &rel, nil
 }
 
-func pingUrl(client http.Client, url string) string {
+func pingURL(client http.Client, url string) string {
 	res, err := client.Get(url)
 	if err != nil {
 		return err.Error()

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -11,6 +11,7 @@ import (
 	"github.com/exercism/cli/config"
 )
 
+// Open uses the given language and exercise and opens it in the browser
 func Open(ctx *cli.Context) {
 	c, err := config.New(ctx.GlobalString("config"))
 	if err != nil {

--- a/cmd/skip.go
+++ b/cmd/skip.go
@@ -9,6 +9,7 @@ import (
 	"github.com/exercism/cli/config"
 )
 
+// Skip command allows a user to skip a specific problem
 func Skip(ctx *cli.Context) {
 	c, err := config.New(ctx.GlobalString("config"))
 	if err != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/codegangsta/cli"
+	"github.com/kardianos/osext"
+)
+
+func Upgrade(ctx *cli.Context) {
+	client := http.Client{Timeout: 5 * time.Second}
+	rel, err := checkLatestRelease(client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// TODO: This checks strings against string
+	// Version 2.2.0 against release 2.1.0
+	// will trigger an upgrade...
+	// should probably parse semver and compare
+	if rel.Version() == ctx.App.Version {
+		fmt.Println("Your CLI is up to date!")
+		return
+	}
+
+	// current executable path
+	dest, err := osext.Executable()
+	if err != nil {
+		log.Fatalf("Unable to find current executable path: %s", err)
+	}
+
+	// TODO: we may have to set these during build
+	// and use them to select the correct asset...
+	// Also need GOARM
+	var (
+		OS   = osMap[runtime.GOOS]
+		ARCH = archMap[runtime.GOARCH]
+	)
+
+	var downloadRC *bytes.Reader
+	for _, a := range rel.Assets {
+		if strings.Contains(a.Name, OS) && strings.Contains(a.Name, ARCH) {
+			// TODO: only display on debug
+			fmt.Println("Downloading", a.Name)
+			downloadRC, err = a.Download()
+			if err != nil {
+				log.Fatalf("error downloading executable: %s\n", err)
+			}
+			break
+		}
+	}
+	if downloadRC == nil {
+		log.Fatal("Unable to find the correct executable for your OS and ARCH")
+	}
+
+	if OS == "windows" {
+		err = installZip(downloadRC, dest)
+	} else {
+		err = installTgz(downloadRC, dest)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Successfully upgraded!")
+}
+
+var (
+	osMap = map[string]string{
+		"darwin":  "mac",
+		"linux":   "linux",
+		"windows": "windows",
+	}
+
+	archMap = map[string]string{
+		"amd64": "64bit",
+		"386":   "32bit",
+		"arm":   "arm",
+	}
+)
+
+const installFlag = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+
+func installTgz(source *bytes.Reader, dest string) error {
+	gr, err := gzip.NewReader(source)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		fileCopy, err := os.OpenFile(dest, installFlag, hdr.FileInfo().Mode())
+		if err != nil {
+			return err
+		}
+		defer fileCopy.Close()
+
+		if _, err = io.Copy(fileCopy, tr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func installZip(source *bytes.Reader, dest string) error {
+	zr, err := zip.NewReader(source, int64(source.Len()))
+	if err != nil {
+		return err
+	}
+
+	for _, f := range zr.File {
+		fileCopy, err := os.OpenFile(dest, installFlag, f.Mode())
+		if err != nil {
+			return err
+		}
+		defer fileCopy.Close()
+
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		_, err = io.Copy(fileCopy, rc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type asset struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	ContentType string `json:"content_type"`
+}
+
+func (a *asset) Download() (*bytes.Reader, error) {
+	downloadURL := fmt.Sprintf("https://api.github.com/repos/exercism/cli/releases/assets/%d", a.ID)
+	req, err := http.NewRequest("GET", downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	// https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+	req.Header.Set("Accept", "application/octet-stream")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	bs, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(bs), nil
+}
+
+type release struct {
+	Location string  `json:"html_url"`
+	TagName  string  `json:"tag_name"`
+	Assets   []asset `json:"assets"`
+}
+
+func (r *release) Version() string {
+	return strings.TrimPrefix(r.TagName, "v")
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kardianos/osext"
 )
 
+// Upgrade command allows the user to upgrade to the latest CLI version
 func Upgrade(ctx *cli.Context) {
 	client := http.Client{Timeout: 5 * time.Second}
 	rel, err := checkLatestRelease(client)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -26,6 +26,7 @@ const (
 	descSubmit    = "Submits a new iteration to a problem on exercism.io."
 	descSkip      = "Skips a problem given a language and slug."
 	descUnsubmit  = "Deletes the most recently submitted iteration."
+	descUpgrade   = "Upgrades the CLI to the latest released version."
 	descTracks    = "List the available language tracks"
 	descOpen      = "Opens the current submission of the specified exercise"
 
@@ -133,6 +134,11 @@ func main() {
 			ShortName: "u",
 			Usage:     descUnsubmit,
 			Action:    cmd.Unsubmit,
+		},
+		{
+			Name:   "upgrade",
+			Usage:  descUpgrade,
+			Action: cmd.Upgrade,
 		},
 		{
 			Name:      "tracks",


### PR DESCRIPTION
This is a working prototype of the `upgrade` command for the CLI.

It will install the latest version of the CLI under the same path as the executable that called the command. 

One thing that it does not support yet that I'd like to fix before this gets merged:

1. **ARM version upgrades**
  Golang has no way of checking the ARM version during runtime
    - A possible solution would be to set the ARM version during the build process with `-ldflags` which would allow us to set the binary's OS/ARCH/ARMV that was used during build. 

Also, I wrote the windows portion a bit blindly since I don't have a windows machine to test it on. I'll make sure it works properly when I get a chance. 

I'd also like to include a generic message to file an issue here if the install fails with the `debug` info but not too sure how the message should read. Thoughts?

Once this is merged it fixes #61 


