### PR TITLE
Improve Internal Server Error response message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 ## Next Release
 
 * **Your contribution here**
+* [b3c3d6f](https://github.com/exercism/cli/commit/b3c3d6fe54c622fc0ee07fdd221c8e8e5b73c8cd): Improve error message on Internal Server Error - [@Tonkpils](https://github.com/Tonkpils)
 * [#196](https://github.com/exercism/cli/pull/196): Add upgrade command - [@Tonkpils](https://github.com/Tonkpils)
 * [#194](https://github.com/exercism/cli/pull/194): Fix home expansion on configure update - [@Tonkpils](https://github.com/Tonkpils)
 


### PR DESCRIPTION
This does two things:
- Doesn't attempt to parse the response body on 500 responses
- Adds a message depending on which API was attempted to file an issue with the corresponding GitHub issue tracker