### PR TITLE
Add a guard to the unsubmit command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 
 ## Next Release
 
+* [#200](https://github.com/exercism/cli/pull/200): Add guard to unsubmit command - [@kytrinyx](https://github.com/kytrinyx)
 * **Your contribution here**
 
 ## v2.2.0 (2015-06-27)

--- a/cmd/unsubmit.go
+++ b/cmd/unsubmit.go
@@ -9,10 +9,12 @@ import (
 	"github.com/exercism/cli/config"
 )
 
-// Unsubmit deletes an iteration from the api.
-// If no iteration is specified, the most recent iteration
-// is deleted.
+// Unsubmit deletes the most recent submission from the API.
 func Unsubmit(ctx *cli.Context) {
+	if len(ctx.Args()) > 0 {
+		log.Fatal("\nThe unsubmit command does not take any arguments, it deletes the most recent submission.\n\nTo delete a different submission, you'll need to do it from the website.")
+	}
+
 	c, err := config.New(ctx.GlobalString("config"))
 	if err != nil {
 		log.Fatal(err)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -25,7 +25,7 @@ const (
 	descRestore   = "Restores completed and current problems on from exercism.io, along with your most recent iteration for each."
 	descSubmit    = "Submits a new iteration to a problem on exercism.io."
 	descSkip      = "Skips a problem given a language and slug."
-	descUnsubmit  = "Deletes the most recently submitted iteration."
+	descUnsubmit  = "Deletes the most recently submitted solution."
 	descUpgrade   = "Upgrades the CLI to the latest released version."
 	descTracks    = "List the available language tracks"
 	descOpen      = "Opens the current submission of the specified exercise"


### PR DESCRIPTION
The unsubmit command does not take any arguments, but it would be
easy to assume that it does, considering how most of the other commands
work.

This changes the command so that it stops with a warning if someone
tries to pass an argument.

This change is in response to https://github.com/exercism/exercism.io/issues/2446
where someone tried unsubmitting a submission by passing the file path
to the unsubmit command, which blithely unsubmitted the most recent
submission--period.

It's confusing and unfriendly.