### PR TITLE
avoid ambiguous or unresolvable exercism paths

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -23,8 +23,7 @@ func Configure(ctx *cli.Context) {
 	dir := ctx.String("dir")
 	api := ctx.String("api")
 
-	err = c.Update(key, host, dir, api)
-	if err != nil {
+	if err = c.Update(key, host, dir, api); err != nil {
 		log.Fatalf("Error updating your configuration %s\n", err)
 	}
 

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -22,7 +22,11 @@ func Configure(ctx *cli.Context) {
 	host := ctx.String("host")
 	dir := ctx.String("dir")
 	api := ctx.String("api")
-	c.Update(key, host, dir, api)
+
+	err = c.Update(key, host, dir, api)
+	if err != nil {
+		log.Fatalf("Error updating your configuration %s\n", err)
+	}
 
 	if err := os.MkdirAll(c.Dir, os.ModePerm); err != nil {
 		log.Fatalf("Error creating exercism directory %s\n", err)

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,8 @@ func New(path string) (*Config, error) {
 }
 
 // Update sets new values where given.
-func (c *Config) Update(key, host, dir, xapi string) {
+func (c *Config) Update(key, host, dir, xapi string) error {
+	var err error
 	key = strings.TrimSpace(key)
 	if key != "" {
 		c.APIKey = key
@@ -89,13 +90,18 @@ func (c *Config) Update(key, host, dir, xapi string) {
 
 	dir = strings.TrimSpace(dir)
 	if dir != "" {
-		c.SetDir(dir)
+		err = c.SetDir(dir)
+		if err != nil {
+			return err
+		}
 	}
 
 	xapi = strings.TrimSpace(xapi)
 	if xapi != "" {
 		c.XAPI = xapi
 	}
+
+	return nil
 }
 
 // Write saves the config as JSON.

--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,6 @@ func New(path string) (*Config, error) {
 
 // Update sets new values where given.
 func (c *Config) Update(key, host, dir, xapi string) error {
-	var err error
 	key = strings.TrimSpace(key)
 	if key != "" {
 		c.APIKey = key
@@ -90,8 +89,7 @@ func (c *Config) Update(key, host, dir, xapi string) error {
 
 	dir = strings.TrimSpace(dir)
 	if dir != "" {
-		err = c.SetDir(dir)
-		if err != nil {
+		if err := c.SetDir(dir); err != nil {
 			return err
 		}
 	}
@@ -259,13 +257,29 @@ func (c *Config) SetDir(path string) error {
 	if err != nil {
 		return err
 	}
+
+	var dir string
+
 	if path == "" {
-		c.Dir = filepath.Join(home, DirExercises)
+		dir = filepath.Join(home, DirExercises)
 	} else {
-		c.Dir = path
+		dir = path
 	}
 
-	c.Dir = expandHome(c.Dir, home)
+	dir = expandHome(dir, home)
+
+	// if the user has provided us with a relative path, make it absolute so
+	// it will always work
+	if !filepath.IsAbs(dir) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		dir = filepath.Join(wd, dir)
+	}
+
+	c.Dir = dir
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestSetDir(t *testing.T) {
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		givenPath    string
 		expectedPath string
@@ -20,7 +23,7 @@ func TestSetDir(t *testing.T) {
 		{"~/foobar", "/test/home/foobar"},
 		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
 		{"/no/modification", "/no/modification"},
-		{"nomodification", "nomodification"},
+		{"relativePath", filepath.Join(dir, "relativePath")},
 	}
 
 	for _, testCase := range testCases {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -184,22 +184,25 @@ func TestUpdateConfig(t *testing.T) {
 	}
 
 	// Test the blank values don't overwrite existing values
-	c.Update("", "", "", "")
+	err = c.Update("", "", "", "")
 	assert.Equal(t, "MyKey", c.APIKey)
 	assert.Equal(t, "localhost", c.API)
 	assert.Equal(t, "/exercism/directory", c.Dir)
 	assert.Equal(t, "localhost", c.XAPI)
+	assert.NoError(t, err)
 
 	// Test that each value can be overwritten
-	c.Update("NewKey", "http://example.com", "/tmp/exercism", "http://x.example.org")
+	err = c.Update("NewKey", "http://example.com", "/tmp/exercism", "http://x.example.org")
 	assert.Equal(t, "NewKey", c.APIKey)
 	assert.Equal(t, "http://example.com", c.API)
 	assert.Equal(t, "/tmp/exercism", c.Dir)
 	assert.Equal(t, "http://x.example.org", c.XAPI)
+	assert.NoError(t, err)
 
 	// Test home is expanded on update
-	c.Update("", "", "~/myexercism", "")
+	err = c.Update("", "", "~/myexercism", "")
 	assert.Equal(t, filepath.Join(tmpDir, "myexercism"), c.Dir)
+	assert.NoError(t, err)
 }
 
 func fixturePath(t *testing.T, filename string) string {


### PR DESCRIPTION
Prepend any relative path with the current working directory so the path can be absolute and will be resolvable no matter what directory you're in.

Fixes #205