### PR TITLE
move config code concerned with paths in to separate package

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/config"
+	"github.com/exercism/cli/paths"
 )
 
 // Debug provides information about the user's environment and configuration.
@@ -37,11 +38,7 @@ func Debug(ctx *cli.Context) {
 		fmt.Printf("Build ARMv%s\n", BuildARM)
 	}
 
-	dir, err := config.Home()
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Home Dir: %s\n", dir)
+	fmt.Printf("Home Dir: %s\n", paths.Home)
 
 	c, err := config.New(ctx.GlobalString("config"))
 	if err != nil {

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/api"
 	"github.com/exercism/cli/config"
+	"github.com/exercism/cli/paths"
 	"github.com/exercism/cli/user"
 )
 
@@ -25,7 +26,7 @@ func Demo(ctx *cli.Context) {
 	}
 
 	if dirOpt := ctx.String("dir"); dirOpt != "" {
-		c.SetDir(dirOpt)
+		c.Dir = paths.Exercises(dirOpt)
 	}
 
 	fmt.Printf("Your exercises will be saved at: %s\n", c.Dir)

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -1,0 +1,115 @@
+package paths
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	// File is the default name of the JSON file where the config written.
+	// The user can pass an alternate filename when using the CLI.
+	File = ".exercism.json"
+	// DirExercises is the default name of the directory for active users.
+	// Make this non-exported when handlers.Login is deleted.
+	DirExercises = "exercism"
+)
+
+var (
+	// Home by default will contact the location of your home directory
+	Home            string
+	errHomeNotFound = errors.New("unable to locate home directory")
+)
+
+func init() {
+	// on startup set default values for Home and Config
+	Recalculate()
+}
+
+// Config will return the correct input path given any input.
+//  blank input will return the default location for configuration
+//  non-blank input will have:
+//  * its home expanded and will be expanded to an absolute path
+//  * the config file appended if we know the target is a directory
+func Config(path string) string {
+	if path == "" {
+		return filepath.Join(Home, File)
+	}
+
+	expandedPath := expandPath(path)
+	if IsDir(path) {
+		expandedPath = filepath.Join(expandedPath, File)
+	}
+	return expandedPath
+}
+
+// Exercises will return the correct exercises path given any input.
+//  blank input will return the default location for exercises
+//  non-blank input will have:
+//  * its home expanded and will be expanded to an absolute path
+//  * the config file appended if we know the target is a directory
+func Exercises(path string) string {
+	if path == "" {
+		return filepath.Join(Home, DirExercises)
+	}
+	return expandPath(path)
+}
+
+// Recalculate sets exercism paths based on Home
+func Recalculate() {
+	if Home == "" {
+		home, err := findHome()
+		if err != nil {
+			panic(err)
+		}
+		Home = home
+	}
+}
+
+// IsDir tells us if the path is valid and is a directory
+func IsDir(path string) bool {
+	fi, _ := os.Stat(path)
+	return fi != nil && fi.IsDir()
+}
+
+func expandPath(path string) string {
+	return makeAbsolute(expandHome(strings.TrimSpace(path)))
+}
+
+func findHome() (string, error) {
+	var dir string
+	if runtime.GOOS == "windows" {
+		dir = os.Getenv("USERPROFILE")
+		if dir == "" {
+			dir = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		}
+	} else {
+		dir = os.Getenv("HOME")
+	}
+
+	if dir == "" {
+		return "", errHomeNotFound
+	}
+
+	return dir, nil
+}
+
+func makeAbsolute(path string) string {
+	if !filepath.IsAbs(path) {
+		wd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		return filepath.Join(wd, path)
+	}
+	return path
+}
+
+func expandHome(path string) string {
+	if path[:2] == "~"+string(os.PathSeparator) {
+		return strings.Replace(path, "~", Home, 1)
+	}
+	return path
+}

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -1,0 +1,76 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHome(t *testing.T) {
+	assert.Equal(t, os.Getenv("HOME"), Home)
+}
+
+func TestExercises(t *testing.T) {
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+	Home = "/test/home"
+	Recalculate()
+
+	testCases := []struct {
+		givenPath    string
+		expectedPath string
+	}{
+		{"", "/test/home/exercism"},
+		{"~/foobar", "/test/home/foobar"},
+		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
+		{"/no/modification", "/no/modification"},
+		{"relativePath", filepath.Join(dir, "relativePath")},
+	}
+
+	for _, testCase := range testCases {
+		actual := Exercises(testCase.givenPath)
+		assert.Equal(t, testCase.expectedPath, actual)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	Home = dir
+	Recalculate()
+
+	testCases := []struct {
+		desc         string
+		givenPath    string
+		expectedPath string
+	}{
+		{
+			"blank path",
+			"",
+			filepath.Join(Home, ".exercism.json"),
+		},
+		{
+			"unknown path is expanded, but not modified",
+			"~/unknown",
+			filepath.Join(Home, "unknown"),
+		},
+		{
+			"absolute path is unmodified",
+			Config(Config("")),
+			Config(""),
+		},
+		{
+			"dir path has the config file appended",
+			dir,
+			filepath.Join(dir, File),
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := Config(tc.givenPath)
+		assert.Equal(t, tc.expectedPath, actual, tc.desc)
+	}
+}


### PR DESCRIPTION
I wanted to resolve issue #211 , but I quickly found that it was difficult to reason about how and when paths are calculated. This is an attempt to centralize the knowledge of paths in the exercism cli.