### PR TITLE
WIP - Adding `exercism status $language` command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -273,3 +273,28 @@ func (c *Client) Skip(trackID, slug string) error {
 
 	return errors.New(pe.Error)
 }
+
+// Status sends a request to exercism to fetch the user's
+// completion status for the given language track.
+func (c *Client) Status(trackID string) (*StatusInfo, error) {
+	url := fmt.Sprintf("%s/api/v1/tracks/%s/status?key=%s", c.APIHost, trackID, c.APIKey)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.Do(req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	var si StatusInfo
+	if err := json.NewDecoder(res.Body).Decode(&si); err != nil {
+		return nil, err
+	}
+
+	return &si, nil
+}

--- a/api/status_info.go
+++ b/api/status_info.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+const dateFormat = "January 2, 2006"
+
+// StatusInfo contains information about a user's status on a particular language track.
+type StatusInfo struct {
+	TrackID         string `json:"track_id"`
+	Recent          *Recent
+	FetchedProblems *Slugs `json:"fetched"`
+	SkippedProblems *Slugs `json:"skipped"`
+}
+
+// Recent contains information about the user's most recently submitted exercise on a particular language track.
+type Recent struct {
+	Problem     string `json:"problem"`
+	SubmittedAt string `json:"submitted_at"`
+}
+
+// Slugs is a collection of slugs, all of which are the names of exercises.
+type Slugs []string
+
+func (r *Recent) String() string {
+	submittedAt, err := time.Parse(time.RFC3339Nano, r.SubmittedAt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return fmt.Sprintf(" - %s (submitted on %s)", r.Problem, submittedAt.Format(dateFormat))
+}
+
+func (s *StatusInfo) String() string {
+	if len(*s.FetchedProblems) == 0 && s.Recent.Problem == "" {
+		return fmt.Sprintf("\nYou have yet to begin the %s track!\n", s.TrackID)
+	}
+
+	msg := `
+Your status on the %s track:
+
+Most recently submitted exercise:
+%s
+
+Exercises fetched but not submitted:
+%s
+
+Exercises skipped:
+%s
+`
+
+	return fmt.Sprintf(msg, s.TrackID, s.Recent, s.FetchedProblems, s.SkippedProblems)
+}
+
+func (s Slugs) String() string {
+	for i, problem := range s {
+		s[i] = fmt.Sprintf(" - %s", problem)
+	}
+	return strings.Join(s, "\n")
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/codegangsta/cli"
+	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/config"
+)
+
+// Status is a command that allows a user to view their progress in a given
+// language track.
+func Status(ctx *cli.Context) {
+	c, err := config.New(ctx.GlobalString("config"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	args := ctx.Args()
+
+	if len(args) != 1 {
+		log.Fatal("Usage: exercism status LANGUAGE")
+	}
+
+	client := api.NewClient(c)
+	status, err := client.Status(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(status)
+}

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -30,6 +30,7 @@ const (
 	descOpen      = "Opens exercism.io to your most recent iteration of a problem given the track ID and problem slug."
 	descDownload  = "Downloads a solution given the ID of the latest iteration."
 	descList      = "Lists the available problems for a language track, given its ID."
+	descStatus    = "Fetches information about your progress with a given language track."
 
 	descLongRestore  = "Restore will pull the latest revisions of exercises that have already been submitted. It will *not* overwrite existing files. If you have made changes to a file and have not submitted it, and you're trying to restore the last submitted version, first move that file out of the way, then call restore."
 	descLongDownload = "The submission ID is the last part of the URL when looking at a solution on exercism.io."
@@ -166,6 +167,12 @@ func main() {
 			ShortName: "li",
 			Usage:     descList,
 			Action:    cmd.List,
+		},
+		{
+			Name:      "status",
+			ShortName: "st",
+			Usage:     descStatus,
+			Action:    cmd.Status,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
This is the first commit in my attempt to implement the new `status` feature as described in #223. Since this is my first time contributing to this project, I'm pushing this up now mainly to get feedback on if this is the right way to go with this feature before I go clean things up and move on to next steps. At the moment the I am basically mocking out an API response so I can make sure the command works as intended.

Below is a screenshot of the output to the user as it stands now.
![status_screenshot](https://cloud.githubusercontent.com/assets/8422484/10858082/8a806306-7f52-11e5-9902-8ab9cf1c6d67.png)

I'd love any feedback anyone has to offer. Specifically, I'd like to know if the API endpoint I'm looking to use looks like a good choice, if the API response format (in comments right now in `api.go` seems like a good choice, and also if there is any standardized format for outputting the information to the user that I should be using instead of the format that I have implemented now.