### PR TITLE
Prefer EXERCISM_CONFIG_FILE to XDG_CONFIG_HOME

### DIFF
--- a/exercism/main.go
+++ b/exercism/main.go
@@ -47,7 +47,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "config, c",
 			Usage:  "path to config file",
-			EnvVar: "XDG_CONFIG_HOME,EXERCISM_CONFIG_FILE",
+			EnvVar: "EXERCISM_CONFIG_FILE,XDG_CONFIG_HOME",
 		},
 		cli.BoolFlag{
 			Name:  "verbose",


### PR DESCRIPTION
Seems like it's currently impossible to override the config path using `EXERCISM_CONFIG_FILE` when `XDG_CONFIG_HOME` is set up.