### PR TITLE
Fix incorrect download path

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -32,7 +32,7 @@ func Download(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
-	path := filepath.Join(c.Dir, "solutions", submission.Username, submission.Language, submission.Slug, args[0])
+	path := filepath.Join(c.Dir, "solutions", submission.Username, submission.TrackID, submission.Slug, args[0])
 
 	if err := os.MkdirAll(path, 0755); err != nil {
 		log.Fatal(err)
@@ -45,7 +45,7 @@ func Download(ctx *cli.Context) {
 	}
 
 	for name, contents := range submission.SolutionFiles {
-		filename := strings.TrimPrefix(name, strings.ToLower("/"+submission.Language+"/"+submission.Slug+"/"))
+		filename := strings.TrimPrefix(name, strings.ToLower("/"+submission.TrackID+"/"+submission.Slug+"/"))
 		if err := ioutil.WriteFile(fmt.Sprintf("%s/%s", path, filename), []byte(contents), 0755); err != nil {
 			log.Fatalf("Unable to write file %s: %s", name, err)
 		}


### PR DESCRIPTION
When downloading a submission by uuid, we were using the language name
(e.g. C++ or Objective-C) rather than the track ID (cpp or objective-c).