### PR TITLE
Normalize usage messages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -54,7 +54,7 @@ func (c *Client) Fetch(args []string) ([]*Problem, error) {
 		problem := args[1]
 		url = fmt.Sprintf("%s/v2/exercises/%s/%s", c.XAPIHost, language, problem)
 	default:
-		return nil, fmt.Errorf("Usage: exercism fetch\n   or: exercism fetch LANGUAGE\n   or: exercism fetch LANGUAGE PROBLEM")
+		return nil, fmt.Errorf("Usage: exercism fetch\n   or: exercism fetch TRACK_ID\n   or: exercism fetch TRACK_ID PROBLEM")
 	}
 
 	req, err := c.NewRequest("GET", url, nil)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,7 +20,7 @@ func List(ctx *cli.Context) {
 	args := ctx.Args()
 
 	if len(args) != 1 {
-		msg := "Usage: exercism list LANGUAGE"
+		msg := "Usage: exercism list TRACK_ID"
 		log.Fatal(msg)
 	}
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -21,7 +21,7 @@ func Open(ctx *cli.Context) {
 
 	args := ctx.Args()
 	if len(args) != 2 {
-		msg := "Usage: exercism open LANGUAGE EXERCISE"
+		msg := "Usage: exercism open TRACK_ID PROBLEM"
 		log.Fatal(msg)
 	}
 

--- a/cmd/skip.go
+++ b/cmd/skip.go
@@ -18,7 +18,7 @@ func Skip(ctx *cli.Context) {
 	args := ctx.Args()
 
 	if len(args) != 2 {
-		msg := "Usage: exercism skip LANGUAGE SLUG"
+		msg := "Usage: exercism skip TRACK_ID PROBLEM"
 		log.Fatal(msg)
 	}
 


### PR DESCRIPTION
We're calling the problem slugs "SLUG", "EXERCISE", and "PROBLEM".
This changes the messages to use PROBLEM everywhere.

This also changes LANGUAGE to TRACK_ID, since language refers to the
language name (e.g. C++) whereas track ID refers to the language
identifier (e.g. cpp).