### PR TITLE
Rename field on iteration

### DIFF
--- a/api/iteration.go
+++ b/api/iteration.go
@@ -27,7 +27,7 @@ type Iteration struct {
 	Key      string            `json:"key"`
 	Code     string            `json:"code"`
 	Dir      string            `json:"dir"`
-	Language string            `json:"language"`
+	TrackID  string            `json:"language"`
 	Problem  string            `json:"problem"`
 	Solution map[string]string `json:"solution"`
 }
@@ -58,7 +58,7 @@ func NewIteration(dir string, filenames []string) (*Iteration, error) {
 	if len(segments) < 4 {
 		return nil, errUnidentifiable
 	}
-	iter.Language = segments[1]
+	iter.TrackID = segments[1]
 	iter.Problem = segments[2]
 
 	for _, filename := range filenames {
@@ -75,7 +75,7 @@ func NewIteration(dir string, filenames []string) (*Iteration, error) {
 
 // RelativePath returns the iteration's relative path.
 func (iter *Iteration) RelativePath() string {
-	return filepath.Join(iter.Dir, iter.Language, iter.Problem) + string(filepath.Separator)
+	return filepath.Join(iter.Dir, iter.TrackID, iter.Problem) + string(filepath.Separator)
 }
 
 func (iter *Iteration) isValidFilepath(path string) bool {

--- a/api/iteration_test.go
+++ b/api/iteration_test.go
@@ -25,8 +25,8 @@ func TestNewIteration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if iter.Language != "python" {
-		t.Errorf("Expected language to be python, was %s", iter.Language)
+	if iter.TrackID != "python" {
+		t.Errorf("Expected language to be python, was %s", iter.TrackID)
 	}
 	if iter.Problem != "leap" {
 		t.Errorf("Expected problem to be leap, was %s", iter.Problem)


### PR DESCRIPTION
We're using Language to mean language name (e.g. C++) and TrackID to mean the
normalized identifier for the language (e.g. cpp). The iteration is using the latter.