### PR TITLE
Clarify trackID/language distinction on Problem type

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -41,7 +41,7 @@ func Fetch(ctx *cli.Context) {
 
 func setSubmissionState(problems []*api.Problem, submissionInfo map[string][]api.SubmissionInfo) error {
 	for _, problem := range problems {
-		langSubmissions := submissionInfo[problem.Language]
+		langSubmissions := submissionInfo[problem.TrackID]
 		for _, submission := range langSubmissions {
 			if submission.Slug == problem.Slug {
 				problem.Submitted = true


### PR DESCRIPTION
The API is currently returning the track ID twice, once for track ID and
once for language. This fixes the CLI code so that if we fix the API,
the CLI will not break.

However, we cannot fix the API until we have released the next version
of the CLI, since doing so would break on existing versions.