### PR TITLE
Clarify domain language in api package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -47,12 +47,9 @@ func (c *Client) Fetch(args []string) ([]*Problem, error) {
 	case 0:
 		url = fmt.Sprintf("%s/v2/exercises?key=%s", c.XAPIHost, c.APIKey)
 	case 1:
-		language := args[0]
-		url = fmt.Sprintf("%s/v2/exercises/%s?key=%s", c.XAPIHost, language, c.APIKey)
+		url = fmt.Sprintf("%s/v2/exercises/%s?key=%s", c.XAPIHost, args[0], c.APIKey)
 	case 2:
-		language := args[0]
-		slug := args[1]
-		url = fmt.Sprintf("%s/v2/exercises/%s/%s", c.XAPIHost, language, slug)
+		url = fmt.Sprintf("%s/v2/exercises/%s/%s", c.XAPIHost, args[0], args[1])
 	default:
 		return nil, fmt.Errorf("Usage: exercism fetch\n   or: exercism fetch TRACK_ID\n   or: exercism fetch TRACK_ID PROBLEM")
 	}
@@ -112,9 +109,9 @@ func (c *Client) Submissions() (map[string][]SubmissionInfo, error) {
 	return payload, nil
 }
 
-// Submission get the latest submitted exercise for the given language and exercise.
-func (c *Client) Submission(language, excercise string) (*Submission, error) {
-	url := fmt.Sprintf("%s/api/v1/submissions/%s/%s?key=%s", c.APIHost, language, excercise, c.APIKey)
+// Submission gets the latest submitted exercise for the given language track id and problem slug.
+func (c *Client) Submission(trackID, slug string) (*Submission, error) {
+	url := fmt.Sprintf("%s/api/v1/submissions/%s/%s?key=%s", c.APIHost, trackID, slug, c.APIKey)
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -197,9 +194,9 @@ func (c *Client) Submit(iter *Iteration) (*Submission, error) {
 	return ps.Submission, nil
 }
 
-// List available problems for a language.
-func (c *Client) List(language string) ([]string, error) {
-	url := fmt.Sprintf("%s/tracks/%s", c.XAPIHost, language)
+// List available problems for a language track.
+func (c *Client) List(trackID string) ([]string, error) {
+	url := fmt.Sprintf("%s/tracks/%s", c.XAPIHost, trackID)
 
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
@@ -223,7 +220,7 @@ func (c *Client) List(language string) ([]string, error) {
 		return nil, err
 	}
 	problems := make([]string, len(payload.Track.Problems))
-	prefix := language + "/"
+	prefix := trackID + "/"
 
 	for n, p := range payload.Track.Problems {
 		problems[n] = strings.TrimPrefix(p, prefix)
@@ -250,9 +247,9 @@ func (c *Client) Tracks() ([]*Track, error) {
 	return payload.Tracks, nil
 }
 
-// Skip marks the exercise in the given language as skipped.
-func (c *Client) Skip(language, slug string) error {
-	url := fmt.Sprintf("%s/api/v1/iterations/%s/%s/skip?key=%s", c.APIHost, language, slug, c.APIKey)
+// Skip marks the exercise in the given language track as skipped.
+func (c *Client) Skip(trackID, slug string) error {
+	url := fmt.Sprintf("%s/api/v1/iterations/%s/%s/skip?key=%s", c.APIHost, trackID, slug, c.APIKey)
 
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -45,12 +45,12 @@ func TestFetchAllProblem(t *testing.T) {
 
 func TestFetchATrack(t *testing.T) {
 	var (
-		APIKey   = "mykey"
-		language = "go"
+		APIKey  = "mykey"
+		trackID = "go"
 	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		languageProblemsAPI := fmt.Sprintf("/v2/exercises/%s?key=%s", language, APIKey)
-		assert.Equal(t, languageProblemsAPI, req.RequestURI)
+		trackProblemsAPI := fmt.Sprintf("/v2/exercises/%s?key=%s", trackID, APIKey)
+		assert.Equal(t, trackProblemsAPI, req.RequestURI)
 
 		if err := respondWithFixture(w, "problems.json"); err != nil {
 			t.Fatal(err)
@@ -60,19 +60,19 @@ func TestFetchATrack(t *testing.T) {
 
 	client := NewClient(&config.Config{XAPI: ts.URL, APIKey: APIKey})
 
-	_, err := client.Fetch([]string{language})
+	_, err := client.Fetch([]string{trackID})
 	assert.NoError(t, err)
 }
 
 func TestFetchASpecificProblem(t *testing.T) {
 	var (
-		APIKey   = "mykey"
-		language = "go"
-		slug     = "leap"
+		APIKey  = "mykey"
+		trackID = "go"
+		slug    = "leap"
 	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		languageProblemsAPI := fmt.Sprintf("/v2/exercises/%s/%s", language, slug)
-		assert.Equal(t, languageProblemsAPI, req.RequestURI)
+		trackProblemsAPI := fmt.Sprintf("/v2/exercises/%s/%s", trackID, slug)
+		assert.Equal(t, trackProblemsAPI, req.RequestURI)
 
 		if err := respondWithFixture(w, "problems.json"); err != nil {
 			t.Fatal(err)
@@ -82,18 +82,18 @@ func TestFetchASpecificProblem(t *testing.T) {
 
 	client := NewClient(&config.Config{XAPI: ts.URL, APIKey: APIKey})
 
-	_, err := client.Fetch([]string{language, slug})
+	_, err := client.Fetch([]string{trackID, slug})
 	assert.NoError(t, err)
 }
 
 func TestSkipProblem(t *testing.T) {
 	var (
-		APIKey   = "mykey"
-		language = "go"
-		slug     = "leap"
+		APIKey  = "mykey"
+		trackID = "go"
+		slug    = "leap"
 	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		skipAPI := fmt.Sprintf("/api/v1/iterations/%s/%s/skip?key=%s", language, slug, APIKey)
+		skipAPI := fmt.Sprintf("/api/v1/iterations/%s/%s/skip?key=%s", trackID, slug, APIKey)
 		assert.Equal(t, skipAPI, req.RequestURI)
 
 		w.WriteHeader(http.StatusNoContent)
@@ -102,18 +102,18 @@ func TestSkipProblem(t *testing.T) {
 
 	client := NewClient(&config.Config{API: ts.URL, APIKey: APIKey})
 
-	err := client.Skip(language, slug)
+	err := client.Skip(trackID, slug)
 	assert.NoError(t, err)
 }
 
 func TestSkipProblemErrorResponse(t *testing.T) {
 	var (
-		APIKey   = "mykey"
-		language = "go"
-		slug     = "leap"
+		APIKey  = "mykey"
+		trackID = "go"
+		slug    = "leap"
 	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		skipAPI := fmt.Sprintf("/api/v1/iterations/%s/%s/skip?key=%s", language, slug, APIKey)
+		skipAPI := fmt.Sprintf("/api/v1/iterations/%s/%s/skip?key=%s", trackID, slug, APIKey)
 		assert.Equal(t, skipAPI, req.RequestURI)
 
 		w.Write([]byte(`{"error":"exercise skipped"}`))
@@ -122,19 +122,19 @@ func TestSkipProblemErrorResponse(t *testing.T) {
 
 	client := NewClient(&config.Config{API: ts.URL, APIKey: APIKey})
 
-	err := client.Skip(language, slug)
+	err := client.Skip(trackID, slug)
 	assert.Error(t, err)
 }
 
 func TestGetSubmission(t *testing.T) {
 	var (
-		APIKey   = "mykey"
-		language = "go"
-		slug     = "leap"
+		APIKey  = "mykey"
+		trackID = "go"
+		slug    = "leap"
 	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		languageProblemsAPI := fmt.Sprintf("/api/v1/submissions/%s/%s?key=%s", language, slug, APIKey)
-		assert.Equal(t, languageProblemsAPI, req.RequestURI)
+		trackProblemsAPI := fmt.Sprintf("/api/v1/submissions/%s/%s?key=%s", trackID, slug, APIKey)
+		assert.Equal(t, trackProblemsAPI, req.RequestURI)
 
 		if err := respondWithFixture(w, "submission.json"); err != nil {
 			t.Fatal(err)
@@ -143,7 +143,7 @@ func TestGetSubmission(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(&config.Config{API: ts.URL, APIKey: APIKey})
-	_, err := client.Submission(language, slug)
+	_, err := client.Submission(trackID, slug)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
This cleans up inconsistencies between track id / language, as well as exercise / slug.