### PR TITLE
Rename function for clarity

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -109,8 +109,8 @@ func (c *Client) Submissions() (map[string][]SubmissionInfo, error) {
 	return payload, nil
 }
 
-// Submission gets the latest submitted exercise for the given language track id and problem slug.
-func (c *Client) Submission(trackID, slug string) (*Submission, error) {
+// SubmissionURL gets the url of the latest iteration on the given language track id and problem slug.
+func (c *Client) SubmissionURL(trackID, slug string) (*Submission, error) {
 	url := fmt.Sprintf("%s/api/v1/submissions/%s/%s?key=%s", c.APIHost, trackID, slug, c.APIKey)
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -143,7 +143,7 @@ func TestGetSubmission(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(&config.Config{API: ts.URL, APIKey: APIKey})
-	_, err := client.Submission(trackID, slug)
+	_, err := client.SubmissionURL(trackID, slug)
 	assert.NoError(t, err)
 }
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -27,7 +27,7 @@ func Open(ctx *cli.Context) {
 
 	trackID := args[0]
 	slug := args[1]
-	submission, err := client.Submission(trackID, slug)
+	submission, err := client.SubmissionURL(trackID, slug)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The submission method on the api client doesn't return a submission, but rather a url.