### PR TITLE
clean up build scripts

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-CGO_ENABLED=0 go build -o out/exercism exercism/main.go

--- a/bin/env
+++ b/bin/env
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-SCRIPT_HOME=$( cd "$( dirname "$0" )" && pwd )
-
-base=$SCRIPT_HOME/..
-

--- a/bin/go
+++ b/bin/go
@@ -1,5 +1,0 @@
-#!/bin/bash 
-
-set -e
-
-exec $(dirname $0)/env go $@


### PR DESCRIPTION
These scripts are no longer used in the current build-all script and should be removed.