### PR TITLE
Only display "to get the next exercise" message if the server responds with the correct iteration value.

### DIFF
--- a/api/submission.go
+++ b/api/submission.go
@@ -10,4 +10,5 @@ type Submission struct {
 	Username      string            `json:"username"`
 	ProblemFiles  map[string]string `json:"problem_files"`
 	SolutionFiles map[string]string `json:"solution_files"`
+	Iteration     int               `json:"iteration"`
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -92,8 +92,13 @@ func Submit(ctx *cli.Context) {
 	msg := `
 Submitted %s in %s.
 Your submission can be found online at %s
+`
 
+	if submission.Iteration == 1 {
+		msg += `
 To get the next exercise, run "exercism fetch" again.
 `
+	}
+
 	fmt.Printf(msg, submission.Name, submission.Language, submission.URL)
 }

--- a/fixtures/submit.json
+++ b/fixtures/submit.json
@@ -2,5 +2,6 @@
   "error": null,
   "url": "a url",
   "track_id": "a track_id",
-  "language": "ruby"
+  "language": "ruby",
+  "iteration": 1
 }


### PR DESCRIPTION
Hi all,

I've had a go at #187, hopefully I've understood the issue properly.

I checked exercism.io for the added iteration key on the submit endpoint and I tested it against my own account using my local build of the cli.

Any and all feedback welcome, I'm trying to get into Go more.

The main thing I'm not so sure about is the `+=` string concatenation, I'm not too sure that's the best way to go about it in idomatic Go.

Thanks,
Pete