### PR TITLE
Changes `exercism fetch` behavior to remove filesystem noise

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"path/filepath"
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/api"
@@ -31,7 +32,23 @@ func Fetch(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
+	dirs, err := filepath.Glob(filepath.Join(c.Dir, "*"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dirMap := make(map[string]bool)
+	for _, dir := range dirs {
+		dirMap[dir] = true
+	}
 	hw := user.NewHomework(problems, c)
+
+	if len(ctx.Args()) == 0 {
+		if err := hw.RejectMissingTracks(dirMap); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if err := hw.Save(); err != nil {
 		log.Fatal(err)
 	}

--- a/user/homework.go
+++ b/user/homework.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/exercism/cli/api"
@@ -54,6 +55,27 @@ func (hw *Homework) Save() error {
 			return err
 		}
 	}
+	return nil
+}
+
+// RejectMissingTracks removes any items that are part of tracks the user
+// doesn't currently have a folder for on their local machine. This
+// only happens when a user calls `exercism fetch` without any arguments.
+func (hw *Homework) RejectMissingTracks(dirMap map[string]bool) error {
+	items := []*Item{}
+	for _, item := range hw.Items {
+		dir := filepath.Join(item.dir, item.TrackID)
+		if dirMap[dir] {
+			items = append(items, item)
+		}
+	}
+	if len(items) == 0 {
+		return fmt.Errorf(`
+You have yet to start a language track!
+View all available language tracks with "exercism tracks"
+Fetch exercises for your first track with "exercism fetch TRACK_ID"`)
+	}
+	hw.Items = items
 	return nil
 }
 

--- a/user/homework_test.go
+++ b/user/homework_test.go
@@ -1,0 +1,47 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/config"
+)
+
+func TestRejectMissingtracks(t *testing.T) {
+	problem1 := &api.Problem{
+		TrackID:  "go",
+		Slug:     "clock",
+		Language: "Go",
+		Name:     "Clock",
+	}
+	problem2 := &api.Problem{
+		TrackID:  "ruby",
+		Slug:     "clock",
+		Language: "Ruby",
+		Name:     "Clock",
+	}
+	dirMap := map[string]bool{
+		"/tmp/go":      true,
+		"/tmp/haskell": true,
+	}
+	emptyDirMap := make(map[string]bool)
+
+	hw := NewHomework([]*api.Problem{problem1, problem2}, &config.Config{Dir: "/tmp"})
+	err := hw.RejectMissingTracks(dirMap)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(hw.Items) == 2 {
+		t.Error("Should have rejected the Ruby problem but did not reject any problems!")
+	}
+
+	if len(hw.Items) == 1 && hw.Items[0].TrackID == "ruby" {
+		t.Error("Should have rejected the Ruby problem and rejected the Go problem instead!")
+	}
+
+	if err := hw.RejectMissingTracks(emptyDirMap); err == nil {
+		t.Error("Should have returned error because user hasn't started any tracks but didn't!")
+	}
+}


### PR DESCRIPTION
This commit changes the behavior of `exercism fetch` when called without any arguments. Instead of fetching and writing exercises for all tracks, it will now fetch and update only tracks for which the user has folders in their local environment. If a user calls `exercism fetch` without having any language tracks in their exercises folder, a prompt is shown to the user to tell them how to list all available tracks and how to fetch their first track for a language of their choice.