### PR TITLE
Fix version flag to use --version and -v.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 
 ## Next Release
 * **Your contribution here**
+* [#264](https://github.com/exercism/cli/pull/264) Fix version flag to use --version and --v - [@Tonkpils](https://github.com/Tonkpils)
 
 ## v2.2.2 (2015-12-26)
 

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -43,7 +43,6 @@ func main() {
 	app.Name = "exercism"
 	app.Usage = "A command line tool to interact with http://exercism.io"
 	app.Version = Version
-	app.HideVersion = true
 	app.Before = func(ctx *cli.Context) error {
 		debug.Verbose = ctx.GlobalBool("verbose")
 		debug.Println("verbose logging enabled")
@@ -59,10 +58,6 @@ func main() {
 		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "turn on verbose logging",
-		},
-		cli.BoolFlag{
-			Name:  "version",
-			Usage: "print the version",
 		},
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
-v was reserved for verbose at https://github.com/exercism/cli/commit/f999e69e5290cec6c5c9933aecc6fddfad8cf019  but then removed https://github.com/exercism/cli/commit/4aa6a8665386a7ec5f4aff811b64f9f3aa862f0c because it caused issues with the cli package.

Fixes #263 