### PR TITLE
Tweak API key flag in 'configure' usage statement

### DIFF
--- a/exercism/main.go
+++ b/exercism/main.go
@@ -80,7 +80,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "key, k",
-					Usage: "exercism.io API key (see http://exercism.io/account)",
+					Usage: "exercism.io API key (see http://exercism.io/account/key)",
 				},
 				cli.StringFlag{
 					Name:  "api, a",


### PR DESCRIPTION
We're referring to /account/key elsewhere which is only the api key stuff. This keeps the CLI consistent with the rest of the messaging.