### PR TITLE
Guard against submitting _spec.* files and READMEs

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -21,4 +22,8 @@ func isTest(path string) bool {
 		return true
 	}
 	return regexp.MustCompile(`[\._-]?([tT]est|[sS]pec)`).MatchString(name)
+}
+
+func isREADME(path string) bool {
+	return strings.Contains(path, "README")
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,8 +17,8 @@ func isTest(path string) bool {
 
 	file := filepath.Base(path)
 	name := file[:len(file)-len(ext)]
-	if name == "test" {
+	if name == "test" || name == "spec" {
 		return true
 	}
-	return regexp.MustCompile(`[\._-]?[tT]est`).MatchString(name)
+	return regexp.MustCompile(`[\._-]?([tT]est|[sS]pec)`).MatchString(name)
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -43,6 +43,10 @@ func TestIsTest(t *testing.T) {
 			name:   "problem/Whatever.t", // perl
 			isTest: true,
 		},
+		{
+			name:   "whatever_spec.ext", // lua
+			isTest: true,
+		},
 	}
 
 	for _, tt := range testCases {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -55,3 +55,41 @@ func TestIsTest(t *testing.T) {
 		}
 	}
 }
+
+func TestIsREADME(t *testing.T) {
+	testCases := []struct {
+		name     string
+		isREADME bool
+	}{
+		{
+			name:     "problem/README.md",
+			isREADME: true,
+		},
+		{
+			name:     "problem/README",
+			isREADME: true,
+		},
+		{
+			name:     "problem/README.txt",
+			isREADME: true,
+		},
+		{
+			name:     "problem/some_problem.py",
+			isREADME: false,
+		},
+		{
+			name:     "problem/readme.lua",
+			isREADME: false,
+		},
+		{
+			name:     "problem/readme_spec.lua",
+			isREADME: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		if isREADME(tt.name) != tt.isREADME {
+			t.Fatalf("Expected isREADME(%s) to be %t", tt.name, tt.isREADME)
+		}
+	}
+}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -58,6 +58,10 @@ func Submit(ctx *cli.Context) {
 				"you want, please pass the --test flag to exercism submit.")
 		}
 
+		if isREADME(filename) {
+			log.Fatal("You cannot submit the README as a solution.")
+		}
+
 		file, err := filepath.Abs(filename)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Closes #272.

I see that we allow users to submit test files if they include a `--test` flag (#189) -- should we do the same to allow submitting READMEs? If so, I propose we change the `--test` flag to a `--force` flag and let it apply to READMEs and any other files we may want to complain about in the future.