### PR TITLE
Remove random encouragement after submitting

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/codegangsta/cli"
 	"github.com/exercism/cli/api"
@@ -96,38 +94,5 @@ func Submit(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
-	msg := `
-Submitted %s in %s.
-Your submission can be found online at %s
-`
-
-	if submission.Iteration == 1 {
-		msg += `
-To get the next exercise, run "exercism fetch" again.
-`
-		rand.Seed(time.Now().UTC().UnixNano())
-		phrases := []string{
-			"For bonus points",
-			"Don't stop now: The fun's just begun",
-			"Some tips to continue",
-		}
-		msg += fmt.Sprintf("\n## %s\n", phrases[rand.Intn(len(phrases))])
-		msg += tips
-	}
-
-	fmt.Printf(msg, submission.Name, submission.Language, submission.URL)
+	fmt.Printf("%s - %s\n%s\n\n", submission.Language, submission.Name, submission.URL)
 }
-
-const tips = `
-Did you get the tests passing and the code clean? If you want to, these are some
-additional things you could try:
-
-* Remove as much duplication as you possibly can.
-* Optimize for readability, even if it means introducing duplication.
-* If you've removed all the duplication, do you have a lot of conditionals? Try
-  finding ways to reduce or remove them. How does this affect your code's
-  readability? Its performance?
-
-Then please share your thoughts in a comment on the submission. Did this
-experiment make the code better? Worse? Did you learn anything from it?
-`


### PR DESCRIPTION
The post-submit message turned out to not work. After seeing it
the first time it just becomes noise, and you end up hunting for the
important information.

This simplifies the message, removing unnecessary noise. The only
information necessary is: language track, problem name, and the
URL of your iteration.

I put the url of the iteration alone on its own line instead of saying
"your submission can be found online at URL", since the extra verbiage
is superfluous, and it also prevents double-clicking on the line to
highlight the url and paste it easily into the browser.