### PR TITLE
Output configuration after calling configure command

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -35,6 +35,9 @@ func Configure(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("The configuration has been written to %s\n", c.File)
-	fmt.Printf("Your exercism directory can be found at %s\n", c.Dir)
+	fmt.Printf("\nConfiguration written to %s\n\n", c.File)
+	fmt.Printf("  --key=%s\n", c.APIKey)
+	fmt.Printf("  --dir=%s\n", c.Dir)
+	fmt.Printf("  --host=%s\n", c.API)
+	fmt.Printf("  --api=%s\n\n", c.XAPI)
 }


### PR DESCRIPTION
    $ exercism configure --key=abc123

    Configuration written to /Users/kytrinyx/.exercism.json
      --key=abc123
      --dir=/Users/kytrinyx/exercism
      --host=http://localhost:4567
      --api=http://x.exercism.io

By extension this will also give you your current config values if you
call configure without any flags. It's faster than the debug command
(because of the latency checks), and it's useful during development
when you might be talking to a local version of the app in one moment
and then need to switch to the production version the next.