### PR TITLE
Fix `upgrade` command on some Linux systems

### DIFF
--- a/cmd/release_utils.go
+++ b/cmd/release_utils.go
@@ -85,19 +85,25 @@ func installTgz(source *bytes.Reader, dest string) error {
 			return err
 		}
 
-		// Remove the file before overwriting it.
+		// Move the old version to a backup path that we can recover from
+		// in case the upgrade fails
+		destBackup := dest + ".bak"
 		if _, err := os.Stat(dest); err == nil {
-			os.Remove(dest)
+			os.Rename(dest, destBackup)
 		}
 
 		fileCopy, err := os.OpenFile(dest, installFlag, hdr.FileInfo().Mode())
 		if err != nil {
+			os.Rename(destBackup, dest)
 			return err
 		}
 		defer fileCopy.Close()
 
 		if _, err = io.Copy(fileCopy, tr); err != nil {
+			os.Rename(destBackup, dest)
 			return err
+		} else {
+			os.Remove(destBackup)
 		}
 	}
 

--- a/cmd/release_utils.go
+++ b/cmd/release_utils.go
@@ -85,6 +85,11 @@ func installTgz(source *bytes.Reader, dest string) error {
 			return err
 		}
 
+		// Remove the file before overwriting it.
+		if _, err := os.Stat(dest); err == nil {
+			os.Remove(dest)
+		}
+
 		fileCopy, err := os.OpenFile(dest, installFlag, hdr.FileInfo().Mode())
 		if err != nil {
 			return err


### PR DESCRIPTION
Previously the still open executable file was directly written to, which caused the program to abort with a `text file busy` message on some systems.

Now the following approach is taken:

1. Move the old file to a backup path
2. Try to write to the original path
3. If opening/writing the original path fails: Move backup to old location
4. If upgrade is successful: Remove backup file