### PR TITLE
Enhance debug output when api key is absent

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -64,10 +64,14 @@ func Debug(ctx *cli.Context) {
 
 	if configured {
 		fmt.Printf("Config file: %s\n", c.File)
-		fmt.Printf("API Key: %s\n", c.APIKey)
+		if c.APIKey != "" {
+			fmt.Printf("API Key: %s\n", c.APIKey)
+		} else {
+			fmt.Println("API Key: Please set your API Key to access all of the CLI features")
+		}
 	} else {
 		fmt.Println("Config file: <not configured>")
-		fmt.Println("API Key: <not configured>")
+		fmt.Println("API Key: Please set your API Key to access all of the CLI features")
 	}
 	fmt.Printf("Exercises Directory: %s\n", c.Dir)
 


### PR DESCRIPTION
Previously if the API key was not, some of the features of exercism cli would
not work, for example exercism status.

This commit just prompts the user to set their API key to access the full
features of exercism cli, when its not set.

This fix was suggested in https://github.com/exercism/cli/issues/296 by @Tonkpils 