### PR TITLE
Add newline when printing usage

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,7 +21,7 @@ func List(ctx *cli.Context) {
 	args := ctx.Args()
 
 	if len(args) != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: exercism list TRACK_ID")
+		fmt.Fprintf(os.Stderr, "Usage: exercism list TRACK_ID\n")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
A little thing, but annoying nonetheless: added newline to avoid command prompt being shifted to right when running `exercism list` and it displays usage.