### PR TITLE
show activity stream url after submission

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -99,5 +99,6 @@ func Submit(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%s - %s\n%s\n\n", submission.Language, submission.Name, submission.URL)
+	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
+	fmt.Printf("See related solutions and get involved here:\n%stracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
 }


### PR DESCRIPTION
Fixes #314 

Produces output like:

```text
Your Ruby solution for Hello World has been submitted. View it here:
http://localhost:4567/submissions/1d4b88fa148141a68ef15e522b6b980c

See related solutions and get involved here:
http://localhost:4567/tracks/ruby/exercises/hello-world
```