### PR TITLE
Add missing newlines to usage strings

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -23,7 +23,7 @@ func Download(ctx *cli.Context) error {
 
 	args := ctx.Args()
 	if len(args) != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: exercism download SUBMISSION_ID")
+		fmt.Fprintf(os.Stderr, "Usage: exercism download SUBMISSION_ID\n")
 		os.Exit(1)
 	}
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -23,7 +23,7 @@ func Open(ctx *cli.Context) error {
 
 	args := ctx.Args()
 	if len(args) != 2 {
-		fmt.Fprintf(os.Stderr, "Usage: exercism open TRACK_ID PROBLEM")
+		fmt.Fprintf(os.Stderr, "Usage: exercism open TRACK_ID PROBLEM\n")
 		os.Exit(1)
 	}
 

--- a/cmd/skip.go
+++ b/cmd/skip.go
@@ -19,7 +19,7 @@ func Skip(ctx *cli.Context) error {
 	args := ctx.Args()
 
 	if len(args) != 2 {
-		fmt.Fprintf(os.Stderr, "Usage: exercism skip TRACK_ID PROBLEM")
+		fmt.Fprintf(os.Stderr, "Usage: exercism skip TRACK_ID PROBLEM\n")
 		os.Exit(1)
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -20,7 +20,7 @@ func Status(ctx *cli.Context) error {
 	args := ctx.Args()
 
 	if len(args) != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: exercism status TRACK_ID")
+		fmt.Fprintf(os.Stderr, "Usage: exercism status TRACK_ID\n")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Before the patch:
```
hjljo@x:~$ exercism status
Usage: exercism status TRACK_IDhjljo@x:~$
```

After:
```
hjljo@x:~$ exercism status
Usage: exercism status TRACK_ID
hjljo@x:~$
```