### PR TITLE
add a slash between the API url and the rest of the track path

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -100,7 +100,7 @@ func Submit(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
-	fmt.Printf("See related solutions and get involved here:\n%stracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
+	fmt.Printf("See related solutions and get involved here:\n%s/tracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
 
 	return nil
 }


### PR DESCRIPTION
Hi folks,

Just installed the cli and tried a golang exercise. After submitting my first solution, I got the following output:

```
See related solutions and get involved here:
http://exercism.iotracks/go/exercises/hello-world
```

As you can see, there is a missing slash between the tld and the rest of the path. 

This patch, hopefully, fixes that. Since this is my first touch with golang, I wasn't sure how to test my change :-) 
