### PR TITLE
Add missing slash to URL.

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -100,7 +100,7 @@ func Submit(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
-	fmt.Printf("See related solutions and get involved here:\n%stracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
+	fmt.Printf("See related solutions and get involved here:\n%s/tracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
 
 	return nil
 }


### PR DESCRIPTION
When I submitted the first exercise, I got this message:

```
$ exercism submit hello_world.go 
Your Go solution for Hello World has been submitted. View it here:
http://exercism.io/submissions/fda20a8b96444a7db4ea3256f5f6b9bd

See related solutions and get involved here:
http://exercism.iotracks/go/exercises/hello-world
```

I guess that last URL should start with exercism.io/tracks instead.