### PR TITLE
append solution URL path consistently

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -99,8 +100,10 @@ func Submit(ctx *cli.Context) error {
 		log.Fatal(err)
 	}
 
+	solutionURL, _ := url.Parse(c.API)
+	solutionURL.Path += fmt.Sprintf("tracks/%s/exercises/%s", iteration.TrackID, iteration.Problem)
 	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
-	fmt.Printf("See related solutions and get involved here:\n%stracks/%s/exercises/%s\n\n", c.API, iteration.TrackID, iteration.Problem)
+	fmt.Printf("See related solutions and get involved here:\n%s\n\n", solutionURL)
 
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 
@@ -170,6 +171,14 @@ func (c *Config) setDefaults() error {
 
 	if c.XAPI == "" {
 		c.XAPI = hostXAPI
+	}
+
+	if _, err := url.Parse(c.API); err != nil {
+		return fmt.Errorf("invalid API URL %s", err)
+	}
+
+	if _, err := url.Parse(c.XAPI); err != nil {
+		return fmt.Errorf("invalid xAPI URL %s", err)
 	}
 
 	c.Dir = paths.Exercises(c.Dir)


### PR DESCRIPTION
URL.Path adds the trailing '/' between the hostname and the path if it doesn't exist

Fixes https://github.com/exercism/cli/issues/327