### PR TITLE
The url for related solutions are not correct.

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -101,7 +101,7 @@ func Submit(ctx *cli.Context) error {
 	}
 
 	solutionURL, _ := url.Parse(c.API)
-	solutionURL.Path += fmt.Sprintf("tracks/%s/exercises/%s", iteration.TrackID, iteration.Problem)
+	solutionURL.Path += fmt.Sprintf("/tracks/%s/exercises/%s", iteration.TrackID, iteration.Problem)
 	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
 	fmt.Printf("See related solutions and get involved here:\n%s\n\n", solutionURL)
 


### PR DESCRIPTION
When user submit an exercise, the url of related solutions will be printed
by the CLI.  The printed url missed one `/` which makes it not accessible.

Here is the error output:

```
See related solutions and get involved here:
http://exercism.iotracks/cpp/exercises/binary
```

The fix is to add the missing `/` between `exercism.io` and `tracks`.