### PR TITLE
Don't run status command if API key is missing.

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -24,6 +24,10 @@ func Status(ctx *cli.Context) error {
 		os.Exit(1)
 	}
 
+	if !c.IsAuthenticated() {
+		log.Fatal(msgPleaseAuthenticate)
+	}
+
 	client := api.NewClient(c)
 	trackID := args[0]
 	status, err := client.Status(trackID)


### PR DESCRIPTION
Running `exercism status ruby` command when API is missing (f.i. I've deleted config file) will make actual HTTP request and cause PANIC: `%!v(PANIC=runtime error: invalid memory address or nil pointer dereference)`. I believe it should behave in the same way like `submit` command (prevent any requests and print message).