### PR TITLE
Be a XDG-friendly tool

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -70,7 +70,7 @@ func Debug(ctx *cli.Context) error {
 			fmt.Println("API Key: Please set your API Key to access all of the CLI features")
 		}
 	} else {
-		fmt.Println("Config file: <not configured>")
+		fmt.Printf("Config file: %s (not configured)\n", c.File)
 		fmt.Println("API Key: Please set your API Key to access all of the CLI features")
 	}
 	fmt.Printf("Exercises Directory: %s\n", c.Dir)

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,20 @@ type Config struct {
 
 // New returns a configuration struct with content from the exercism.json file
 func New(path string) (*Config, error) {
-	c := &Config{}
-	err := c.load(paths.Config(path))
+	configPath := paths.Config(path)
+	_, err := os.Stat(configPath)
+	if err != nil && os.IsNotExist(err) {
+		if path == "" {
+			configPath = paths.DefaultConfig
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	c := &Config{
+		File: configPath,
+	}
+	err = c.load()
 	return c, err
 }
 
@@ -84,9 +96,7 @@ func (c *Config) Write() error {
 	return nil
 }
 
-func (c *Config) load(argPath string) error {
-	c.File = argPath
-
+func (c *Config) load() error {
 	if err := c.read(); err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,15 +17,19 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	configPath := filepath.Join(tmpDir, "config.json")
+
+	paths.Home = tmpDir
+	paths.ConfigHome = tmpDir
+	paths.DefaultConfig = filepath.Join(tmpDir, "default.json")
+
+	configPath := filepath.Join(paths.ConfigHome, "config.json")
 	if err := os.Link(fixturePath(t, "config.json"), configPath); err != nil {
 		t.Fatal(err)
 	}
-	dirtyPath := filepath.Join(tmpDir, "dirty.json")
+	dirtyPath := filepath.Join(paths.ConfigHome, "dirty.json")
 	if err := os.Link(fixturePath(t, "dirty.json"), dirtyPath); err != nil {
 		t.Fatal(err)
 	}
-	paths.Home = tmpDir
 
 	testCases := []struct {
 		desc                string
@@ -36,7 +40,7 @@ func TestLoad(t *testing.T) {
 		{
 			desc: "defaults",
 			in:   "",
-			out:  paths.Config(""),
+			out:  paths.DefaultConfig,
 			dir:  paths.Exercises(""),
 			key:  "",
 			api:  hostAPI,

--- a/paths/paths_test.go
+++ b/paths/paths_test.go
@@ -12,11 +12,19 @@ func TestHome(t *testing.T) {
 	assert.Equal(t, os.Getenv("HOME"), Home)
 }
 
+func TestConfigHome(t *testing.T) {
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		assert.Equal(t, filepath.Join(Home, ".config"), ConfigHome)
+	} else {
+		assert.Equal(t, xdgConfigHome, ConfigHome)
+	}
+}
+
 func TestExercises(t *testing.T) {
 	dir, err := os.Getwd()
 	assert.NoError(t, err)
 	Home = "/test/home"
-	Recalculate()
 
 	testCases := []struct {
 		givenPath    string
@@ -40,7 +48,7 @@ func TestConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	Home = dir
-	Recalculate()
+	ConfigHome = dir
 
 	testCases := []struct {
 		desc         string
@@ -50,7 +58,7 @@ func TestConfig(t *testing.T) {
 		{
 			"blank path",
 			"",
-			filepath.Join(Home, ".exercism.json"),
+			filepath.Join(ConfigHome, File),
 		},
 		{
 			"unknown path is expanded, but not modified",
@@ -73,11 +81,4 @@ func TestConfig(t *testing.T) {
 		actual := Config(tc.givenPath)
 		assert.Equal(t, tc.expectedPath, actual, tc.desc)
 	}
-}
-
-func TestXDGConfig(t *testing.T) {
-	XDGConfigHome = "/home/user/.xdg_config"
-
-	assert.Equal(t, filepath.Join(XDGConfigHome, File), Config(""))
-
 }


### PR DESCRIPTION
Search for config in common paths (e.g. `~/.config/exercism.json`, ~/.exercism.json`).

In case `$XDG_CONFIG_HOME` is set, tests of paths package fail as config home was not mocked properly.

The patch simplifies paths' internals and introduces a more flexible way to mock globals of `paths` package.