### PR TITLE
Add ARMv8 support for release script

### DIFF
--- a/bin/build-all
+++ b/bin/build-all
@@ -33,6 +33,10 @@ createRelease() {
 	then
 		osarch=arm-v$arm
 		ldflags="$ldflags -X $ARMVAR=$arm"
+	elif [ "$arch" = arm64 ]
+	then
+		osarch=arm-v8
+		ldflags="$ldflags -X $ARMVAR=8"
 	fi
 
 	binname=exercism
@@ -74,6 +78,7 @@ createRelease linux amd64
 createRelease linux arm 5
 createRelease linux arm 6
 createRelease linux arm 7
+createRelease linux arm64
 
 # Windows Releases
 createRelease windows 386


### PR DESCRIPTION
Per https://github.com/golang/go/wiki/GoArm#supported-architectures ARMv8 binary can be created by passing `arm64` to the `GOARCH` env var. 

Fixes https://github.com/exercism/cli/issues/349