### PR TITLE
Redact API key from debug output.

### DIFF
--- a/exercism/main.go
+++ b/exercism/main.go
@@ -85,8 +85,14 @@ func main() {
 			Action: cmd.Configure,
 		},
 		{
-			Name:   "debug",
-			Usage:  descDebug,
+			Name:  "debug",
+			Usage: descDebug,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "full-api-key",
+					Usage: "Displays the full API key without obfuscating it",
+				},
+			},
 			Action: cmd.Debug,
 		},
 		{


### PR DESCRIPTION
Also adds '--full-api-key' flag to print out the full API key if needed
Fixes https://github.com/exercism/cli/issues/357

Sample output

```
./exercism debug

**** Debug Information ****
Exercism CLI Version: 2.3.0
Exercism CLI Latest Release: 2.3.0
OS/Architecture: darwin/amd64
Build OS/Architecture darwin/amd64
Home Dir: /Users/leo
Config File: /Users/leo/.exercism.json
API Key: 9d19*************************996
Exercises Directory: /Users/leo/code/exercisms-dev
Testing API endpoints reachability
	* API: http://localhost:4567 [Get http://localhost:4567: dial tcp [::1]:4567: getsockopt: connection refused] 2.561129ms
	* GitHub API: https://api.github.com/ [connected] 318.750813ms
	* XAPI: http://x.exercism.io [connected] 653.905343ms
```