### PR TITLE
Add short flag `-m` for submit comment flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 * [#350](https://github.com/exercism/cli/pull/350) Add ARMv8 binaries to CLI releases - [@Tonkpils]
 * [#346](https://github.com/exercism/cli/pull/346) Fallback to UTF-8 if encoding is uncertain - [@petertseng]
 * [#344](https://github.com/exercism/cli/pull/344) Make the CLI config paths more XDG friendly - [@narqo]
+* [#344](https://github.com/exercism/cli/pull/359) Add short flag `-m` for submit comment flag  - [@jgsqware]
 * **Your contribution here**
 
 ## v2.3.0 (2016-08-07)

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -150,7 +150,7 @@ func main() {
 					Usage: "allow submission of test files",
 				},
 				cli.StringFlag{
-					Name:  "comment",
+					Name:  "comment, m",
 					Usage: "includes a comment with the submission",
 				},
 			},


### PR DESCRIPTION
It add the flag `-m` for the command `exercism submit --comment "message"` to be aligned with git/svn cli