### PR TITLE
Add silent argument/option to the configure command to obfuscate output

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -22,6 +22,7 @@ func Configure(ctx *cli.Context) error {
 	host := ctx.String("host")
 	dir := ctx.String("dir")
 	api := ctx.String("api")
+	silent := ctx.Bool("silent")
 
 	if err := c.Update(key, host, dir, api); err != nil {
 		log.Fatalf("Error updating your configuration %s\n", err)
@@ -35,11 +36,13 @@ func Configure(ctx *cli.Context) error {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("\nConfiguration written to %s\n\n", c.File)
-	fmt.Printf("  --key=%s\n", c.APIKey)
-	fmt.Printf("  --dir=%s\n", c.Dir)
-	fmt.Printf("  --host=%s\n", c.API)
-	fmt.Printf("  --api=%s\n\n", c.XAPI)
+	if !silent {
+		fmt.Printf("\nConfiguration written to %s\n\n", c.File)
+		fmt.Printf("  --key=%s\n", c.APIKey)
+		fmt.Printf("  --dir=%s\n", c.Dir)
+		fmt.Printf("  --host=%s\n", c.API)
+		fmt.Printf("  --api=%s\n\n", c.XAPI)
+	}
 
 	return nil
 }

--- a/exercism/main.go
+++ b/exercism/main.go
@@ -81,6 +81,10 @@ func main() {
 					Name:  "api, a",
 					Usage: "exercism xapi host",
 				},
+				cli.BoolFlag{
+					Name:  "silent, s",
+					Usage: "Obfuscates configuration options from output",
+				},
 			},
 			Action: cmd.Configure,
 		},


### PR DESCRIPTION
Give users an option obfuscate/hide the output from the configure command.
My personal use case: Running exercism on Travis CI and my API key being publicly view-able in the output/logfile. 