### PR TITLE
Display post-submission call to action message from submission API response

### DIFF
--- a/api/submission.go
+++ b/api/submission.go
@@ -2,13 +2,14 @@ package api
 
 // Submission is an iteration that has been submitted to the API.
 type Submission struct {
-	URL           string            `json:"url"`
-	TrackID       string            `json:"track_id"`
-	Language      string            `json:"language"`
-	Slug          string            `json:"slug"`
-	Name          string            `json:"name"`
-	Username      string            `json:"username"`
-	ProblemFiles  map[string]string `json:"problem_files"`
-	SolutionFiles map[string]string `json:"solution_files"`
-	Iteration     int               `json:"iteration"`
+	URL                  string            `json:"url"`
+	TrackID              string            `json:"track_id"`
+	Language             string            `json:"language"`
+	Slug                 string            `json:"slug"`
+	Name                 string            `json:"name"`
+	Username             string            `json:"username"`
+	WhatNextInstructions string            `json:"what_next_instructions"`
+	ProblemFiles         map[string]string `json:"problem_files"`
+	SolutionFiles        map[string]string `json:"solution_files"`
+	Iteration            int               `json:"iteration"`
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -90,10 +90,14 @@ func Submit(ctx *cli.Context) error {
 		log.Fatal(err)
 	}
 
-	solutionURL, _ := url.Parse(c.API)
-	solutionURL.Path += fmt.Sprintf("tracks/%s/exercises/%s", iteration.TrackID, iteration.Problem)
-	fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
-	fmt.Printf("See related solutions and get involved here:\n%s\n\n", solutionURL)
+	if len(submission.WhatNextInstructions) > 0 {
+		fmt.Print(submission.WhatNextInstructions)
+	} else {
+		solutionURL, _ := url.Parse(c.API)
+		solutionURL.Path += fmt.Sprintf("tracks/%s/exercises/%s", iteration.TrackID, iteration.Problem)
+		fmt.Printf("Your %s solution for %s has been submitted. View it here:\n%s\n\n", submission.Language, submission.Name, submission.URL)
+		fmt.Printf("See related solutions and get involved here:\n%s\n\n", solutionURL)
+	}
 
 	return nil
 }


### PR DESCRIPTION
(was: Revamp the call to review action)

This is part of our gamification experiment (https://github.com/exercism/discussions/issues/123) and effort to increase review participation (https://github.com/exercism/discussions/issues/88).

*Update*: This wording will be provided by exercism.io API in the submission response. Both the wording and the timing will be controlled with feature flags in the same manner as the rest of the experiment.

I originally proposed this in https://github.com/exercism/discussions/issues/88:

> Now that you've completed this exercise, let's see how your solution compares to others: _[url]_
> To benefit the most from this exercise, find 3 or more submissions that you can
> learn something from, have questions about, or have suggestions for.
> Post your thoughts and questions in the comments, and start a discussion.
> Revise your solution to incorporate what you learned.

I'm instead now proposing this:

> Your _[language]_ solution for _[problem]_ has been submitted.
> 
> Programmers generally spend far more time reading code than writing it.
> To benefit the most from this exercise, find 3 or more submissions that you can
> learn something from, have questions about, or have suggestions for.
> Post your thoughts and questions in the comments, and start a discussion.
> Consider revising your solution to incorporate what you learn.
> 
> Yours and others' solutions to this problem:
> _[url]_

Goal: Set up elements of a [skill atom][]: goals, actions, challenge, motivation

- It maintains flow by describing reviewing code as the natural next step. I removed the link to your own submission, because it's going to be at the top of the list anyway, and I want to suggest one clear path forward.
- It reminds you that your motivation is to learn and helps fulfill that motivation. I.e. informational and not controlling.
- It suggests goals and actions aligned with that motivation, appropriate for people at all levels: learn, ask, incorporate, suggest.
- It challenges you to find at least 3 interesting submissions and to participate.
- _I removed the competition bit, in favor of [the exercism way][]._

[skill atom]: https://github.com/exercism/discussions/issues/123#user-content-skill-atoms
[the exercism way]: https://github.com/exercism/exercism.io/blob/master/docs/the-exercism-way.md
