### PR TITLE
Use go-update and semver for a better upgrade experience

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,15 +1,27 @@
 {
 	"ImportPath": "github.com/exercism/cli",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v63",
+	"GoVersion": "go1.8",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
-			"ImportPath": "github.com/urfave/cli",
-			"Comment": "v1.17.0-57-gedb24d0",
-			"Rev": "edb24d02aa3cea2319c33f2836d4a5133907fe4c"
+			"ImportPath": "github.com/blang/semver",
+			"Comment": "v3.5.0-3-g4a1e882",
+			"Rev": "4a1e882c79dcf4ec00d2e29fac74b9c8938d5052"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/go-update",
+			"Rev": "8152e7eb6ccf8679a64582a66b78519688d156ad"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/go-update/internal/binarydist",
+			"Rev": "8152e7eb6ccf8679a64582a66b78519688d156ad"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/go-update/internal/osext",
+			"Rev": "8152e7eb6ccf8679a64582a66b78519688d156ad"
 		},
 		{
 			"ImportPath": "github.com/kardianos/osext",
@@ -21,11 +33,64 @@
 			"Rev": "f3960ab1f9664ecc4e27c78af27cc9063d745a43"
 		},
 		{
+			"ImportPath": "github.com/urfave/cli",
+			"Comment": "v1.17.0-57-gedb24d0",
+			"Rev": "edb24d02aa3cea2319c33f2836d4a5133907fe4c"
+		},
+		{
 			"ImportPath": "golang.org/x/net/html",
 			"Rev": "5d0a0f8cd486626821d2ba44d471ab1c9271d38f"
 		},
 		{
+			"ImportPath": "golang.org/x/net/html/atom",
+			"Rev": "5d0a0f8cd486626821d2ba44d471ab1c9271d38f"
+		},
+		{
+			"ImportPath": "golang.org/x/net/html/charset",
+			"Rev": "5d0a0f8cd486626821d2ba44d471ab1c9271d38f"
+		},
+		{
 			"ImportPath": "golang.org/x/text/encoding",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/charmap",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/htmlindex",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/ianaindex",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/internal",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/internal/identifier",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/japanese",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/korean",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/simplifiedchinese",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/traditionalchinese",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/encoding/unicode",
 			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
 		},
 		{
@@ -38,6 +103,10 @@
 		},
 		{
 			"ImportPath": "golang.org/x/text/language",
+			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
+		},
+		{
+			"ImportPath": "golang.org/x/text/language/display",
 			"Rev": "cf4986612c83df6c55578ba198316d1684a9a287"
 		},
 		{

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -31,11 +31,15 @@ func Debug(ctx *cli.Context) error {
 	fmt.Printf("\n**** Debug Information ****\n")
 	fmt.Printf("Exercism CLI Version: %s\n", ctx.App.Version)
 
-	rel, err := fetchLatestRelease(*client)
+	u, err := NewUpgrader(client)
 	if err != nil {
 		log.Println("unable to fetch latest release: " + err.Error())
 	} else {
-		if rel.Version() != ctx.App.Version {
+		rel := u.release
+		needed, err := u.IsUpgradeNeeded(ctx.App.Version)
+		if err != nil {
+			log.Printf("unable to check semver: %s\n", err)
+		} else if needed {
 			defer fmt.Printf("\nA newer version of the CLI (%s) can be downloaded here: %s\n", rel.TagName, rel.Location)
 		}
 		fmt.Printf("Exercism CLI Latest Release: %s\n", rel.Version())

--- a/cmd/release_utils.go
+++ b/cmd/release_utils.go
@@ -1,31 +1,11 @@
 package cmd
 
 import (
-	"archive/tar"
-	"archive/zip"
 	"bytes"
-	"compress/gzip"
-	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
-)
-
-var (
-	osMap = map[string]string{
-		"darwin":  "mac",
-		"linux":   "linux",
-		"windows": "windows",
-	}
-
-	archMap = map[string]string{
-		"amd64": "64bit",
-		"386":   "32bit",
-		"arm":   "arm",
-	}
 )
 
 type asset struct {
@@ -64,91 +44,4 @@ type release struct {
 
 func (r *release) Version() string {
 	return strings.TrimPrefix(r.TagName, "v")
-}
-
-const installFlag = os.O_RDWR | os.O_CREATE | os.O_TRUNC
-
-func installTgz(source *bytes.Reader, dest string) error {
-	gr, err := gzip.NewReader(source)
-	if err != nil {
-		return err
-	}
-	defer gr.Close()
-
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		// Move the old version to a backup path that we can recover from
-		// in case the upgrade fails
-		destBackup := dest + ".bak"
-		if _, err := os.Stat(dest); err == nil {
-			os.Rename(dest, destBackup)
-		}
-
-		fileCopy, err := os.OpenFile(dest, installFlag, hdr.FileInfo().Mode())
-		if err != nil {
-			os.Rename(destBackup, dest)
-			return err
-		}
-		defer fileCopy.Close()
-
-		if _, err = io.Copy(fileCopy, tr); err != nil {
-			os.Rename(destBackup, dest)
-			return err
-		} else {
-			os.Remove(destBackup)
-		}
-	}
-
-	return nil
-}
-
-func installZip(source *bytes.Reader, dest string) error {
-	zr, err := zip.NewReader(source, int64(source.Len()))
-	if err != nil {
-		return err
-	}
-
-	for _, f := range zr.File {
-		fileCopy, err := os.OpenFile(dest, installFlag, f.Mode())
-		if err != nil {
-			return err
-		}
-		defer fileCopy.Close()
-
-		rc, err := f.Open()
-		if err != nil {
-			return err
-		}
-		defer rc.Close()
-
-		_, err = io.Copy(fileCopy, rc)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func fetchLatestRelease(client http.Client) (*release, error) {
-	resp, err := client.Get("https://api.github.com/repos/exercism/cli/releases/latest")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var rel release
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-		return nil, err
-	}
-
-	return &rel, nil
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,15 +1,22 @@
 package cmd
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"runtime"
 	"strings"
 	"time"
 
-	"github.com/kardianos/osext"
+	"github.com/blang/semver"
+	"github.com/inconshreveable/go-update"
 	"github.com/urfave/cli"
 )
 
@@ -22,71 +29,182 @@ var (
 	BuildARCH string
 )
 
-// Upgrade allows the user to upgrade to the latest version of the CLI.
-func Upgrade(ctx *cli.Context) error {
-	client := http.Client{Timeout: 10 * time.Second}
-	rel, err := fetchLatestRelease(client)
+var (
+	osMap = map[string]string{
+		"darwin":  "mac",
+		"linux":   "linux",
+		"windows": "windows",
+	}
+
+	archMap = map[string]string{
+		"amd64": "64bit",
+		"386":   "32bit",
+		"arm":   "arm",
+	}
+)
+
+type upgrader struct {
+	client  *http.Client
+	release *release
+}
+
+func (u *upgrader) fetchLatestRelease() (*release, error) {
+	resp, err := u.client.Get("https://api.github.com/repos/exercism/cli/releases/latest")
 	if err != nil {
-		log.Fatal("unable to check latest release version: " + err.Error())
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var rel release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, err
 	}
 
-	// TODO: This checks strings against string
-	// Version 2.2.0 against release 2.1.0
-	// will trigger an upgrade...
-	// should probably parse semver and compare
-	if rel.Version() == ctx.App.Version {
-		fmt.Println("Your CLI is up to date!")
-		return nil
-	}
+	return &rel, nil
+}
 
-	// Locate the path to the current `exercism` executable.
-	dest, err := osext.Executable()
+func (u *upgrader) IsUpgradeNeeded(currentVersion string) (bool, error) {
+	rel := u.release
+	latestVer, err := semver.Make(rel.Version())
 	if err != nil {
-		log.Fatalf("Unable to find current executable path: %s", err)
+		return false, fmt.Errorf("Unable to parse latest version (%s): %s", rel.Version(), err)
+	}
+	currentVer, err := semver.Make(currentVersion)
+	if err != nil {
+		return false, fmt.Errorf("Unable to parse current version (%s): %s", currentVersion, err)
 	}
 
+	return latestVer.GT(currentVer), nil
+}
+
+func NewUpgrader(client *http.Client) (*upgrader, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	u := &upgrader{client: client}
+	rel, err := u.fetchLatestRelease()
+	if err != nil {
+		return nil, err
+	}
+	u.release = rel
+	return u, nil
+}
+
+func (u *upgrader) Upgrade() error {
 	var (
 		OS   = osMap[runtime.GOOS]
 		ARCH = archMap[runtime.GOARCH]
 	)
 
 	if OS == "" || ARCH == "" {
-		log.Fatalf("unable to upgrade: OS %s ARCH %s", OS, ARCH)
+		return fmt.Errorf("unable to upgrade: OS %s ARCH %s", OS, ARCH)
 	}
 
 	buildName := fmt.Sprintf("%s-%s", OS, ARCH)
 	if BuildARCH == "arm" {
 		if BuildARM == "" {
-			log.Fatalf("unable to upgrade: arm version not found")
+			return fmt.Errorf("unable to upgrade: arm version not found")
 		}
 		buildName = fmt.Sprintf("%s-v%s", buildName, BuildARM)
 	}
 
 	var downloadRC *bytes.Reader
-	for _, a := range rel.Assets {
+	for _, a := range u.release.Assets {
 		if strings.Contains(a.Name, buildName) {
+			// TODO: This should be debug
 			fmt.Printf("Downloading %s\n", a.Name)
+			var err error
 			downloadRC, err = a.download()
 			if err != nil {
-				log.Fatalf("error downloading executable: %s\n", err)
+				return fmt.Errorf("error downloading executable: %s", err)
 			}
 			break
 		}
 	}
 	if downloadRC == nil {
-		log.Fatalf("No executable found for %s/%s%s", BuildOS, BuildARCH, BuildARM)
+		return fmt.Errorf("no executable found for %s/%s%s", BuildOS, BuildARCH, BuildARM)
 	}
 
-	if OS == "windows" {
-		err = installZip(downloadRC, dest)
-	} else {
-		err = installTgz(downloadRC, dest)
+	bin, err := u.extractBinary(downloadRC, OS)
+	if err != nil {
+		return err
 	}
+	defer bin.Close()
+
+	if err := update.Apply(bin, update.Options{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (u *upgrader) extractBinary(source *bytes.Reader, os string) (binary io.ReadCloser, err error) {
+	if os == "windows" {
+		zr, err := zip.NewReader(source, int64(source.Len()))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, f := range zr.File {
+			return f.Open()
+		}
+	} else {
+		gr, err := gzip.NewReader(source)
+		if err != nil {
+			return nil, err
+		}
+		defer gr.Close()
+
+		tr := tar.NewReader(gr)
+		for {
+			_, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			tmpfile, err := ioutil.TempFile("", "temp-exercism")
+			if err != nil {
+				return nil, err
+			}
+
+			if _, err = io.Copy(tmpfile, tr); err != nil {
+				return nil, err
+			} else {
+				if _, err := tmpfile.Seek(0, 0); err != nil {
+					return nil, err
+				}
+
+				binary = tmpfile
+			}
+		}
+	}
+
+	return binary, nil
+}
+
+// Upgrade allows the user to upgrade to the latest version of the CLI.
+func Upgrade(ctx *cli.Context) error {
+	u, err := NewUpgrader(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println("Successfully upgraded!")
+	upgradeNeeded, err := u.IsUpgradeNeeded(ctx.App.Version)
+	if err != nil {
+		log.Fatalf("unable to check for upgrade: %s", err)
+		return err
+	}
 
+	if !upgradeNeeded {
+		fmt.Println("Your CLI is up to date!")
+		return nil
+	}
+
+	if err := u.Upgrade(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Successfully upgraded!")
 	return nil
 }

--- a/vendor/github.com/blang/semver/.travis.yml
+++ b/vendor/github.com/blang/semver/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+matrix:
+  include:
+  - go: 1.4.3
+  - go: 1.5.4
+  - go: 1.6.3
+  - go: 1.7
+  - go: tip
+  allow_failures:
+  - go: tip
+install:
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/mattn/goveralls
+script:
+- echo "Test and track coverage" ; $HOME/gopath/bin/goveralls -package "." -service=travis-ci
+  -repotoken $COVERALLS_TOKEN
+- echo "Build examples" ; cd examples && go build
+- echo "Check if gofmt'd" ; diff -u <(echo -n) <(gofmt -d -s .)
+env:
+  global:
+    secure: HroGEAUQpVq9zX1b1VIkraLiywhGbzvNnTZq2TMxgK7JHP8xqNplAeF1izrR2i4QLL9nsY+9WtYss4QuPvEtZcVHUobw6XnL6radF7jS1LgfYZ9Y7oF+zogZ2I5QUMRLGA7rcxQ05s7mKq3XZQfeqaNts4bms/eZRefWuaFZbkw=

--- a/vendor/github.com/blang/semver/LICENSE
+++ b/vendor/github.com/blang/semver/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/README.md
+++ b/vendor/github.com/blang/semver/README.md
@@ -1,0 +1,194 @@
+semver for golang [![Build Status](https://travis-ci.org/blang/semver.svg?branch=master)](https://travis-ci.org/blang/semver) [![GoDoc](https://godoc.org/github.com/blang/semver?status.png)](https://godoc.org/github.com/blang/semver) [![Coverage Status](https://img.shields.io/coveralls/blang/semver.svg)](https://coveralls.io/r/blang/semver?branch=master)
+======
+
+semver is a [Semantic Versioning](http://semver.org/) library written in golang. It fully covers spec version `2.0.0`.
+
+Usage
+-----
+```bash
+$ go get github.com/blang/semver
+```
+Note: Always vendor your dependencies or fix on a specific version tag.
+
+```go
+import github.com/blang/semver
+v1, err := semver.Make("1.0.0-beta")
+v2, err := semver.Make("2.0.0-beta")
+v1.Compare(v2)
+```
+
+Also check the [GoDocs](http://godoc.org/github.com/blang/semver).
+
+Why should I use this lib?
+-----
+
+- Fully spec compatible
+- No reflection
+- No regex
+- Fully tested (Coverage >99%)
+- Readable parsing/validation errors
+- Fast (See [Benchmarks](#benchmarks))
+- Only Stdlib
+- Uses values instead of pointers
+- Many features, see below
+
+
+Features
+-----
+
+- Parsing and validation at all levels
+- Comparator-like comparisons
+- Compare Helper Methods
+- InPlace manipulation
+- Ranges `>=1.0.0 <2.0.0 || >=3.0.0 !3.0.1-beta.1`
+- Wildcards `>=1.x`, `<=2.5.x`
+- Sortable (implements sort.Interface)
+- database/sql compatible (sql.Scanner/Valuer)
+- encoding/json compatible (json.Marshaler/Unmarshaler)
+
+Ranges
+------
+
+A `Range` is a set of conditions which specify which versions satisfy the range.
+
+A condition is composed of an operator and a version. The supported operators are:
+
+- `<1.0.0` Less than `1.0.0`
+- `<=1.0.0` Less than or equal to `1.0.0`
+- `>1.0.0` Greater than `1.0.0`
+- `>=1.0.0` Greater than or equal to `1.0.0`
+- `1.0.0`, `=1.0.0`, `==1.0.0` Equal to `1.0.0`
+- `!1.0.0`, `!=1.0.0` Not equal to `1.0.0`. Excludes version `1.0.0`.
+
+Note that spaces between the operator and the version will be gracefully tolerated.
+
+A `Range` can link multiple `Ranges` separated by space:
+
+Ranges can be linked by logical AND:
+
+  - `>1.0.0 <2.0.0` would match between both ranges, so `1.1.1` and `1.8.7` but not `1.0.0` or `2.0.0`
+  - `>1.0.0 <3.0.0 !2.0.3-beta.2` would match every version between `1.0.0` and `3.0.0` except `2.0.3-beta.2`
+
+Ranges can also be linked by logical OR:
+
+  - `<2.0.0 || >=3.0.0` would match `1.x.x` and `3.x.x` but not `2.x.x`
+
+AND has a higher precedence than OR. It's not possible to use brackets.
+
+Ranges can be combined by both AND and OR
+
+  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+
+Range usage:
+
+```
+v, err := semver.Parse("1.2.3")
+range, err := semver.ParseRange(">1.0.0 <2.0.0 || >=3.0.0")
+if range(v) {
+    //valid
+}
+
+```
+
+Example
+-----
+
+Have a look at full examples in [examples/main.go](examples/main.go)
+
+```go
+import github.com/blang/semver
+
+v, err := semver.Make("0.0.1-alpha.preview+123.github")
+fmt.Printf("Major: %d\n", v.Major)
+fmt.Printf("Minor: %d\n", v.Minor)
+fmt.Printf("Patch: %d\n", v.Patch)
+fmt.Printf("Pre: %s\n", v.Pre)
+fmt.Printf("Build: %s\n", v.Build)
+
+// Prerelease versions array
+if len(v.Pre) > 0 {
+    fmt.Println("Prerelease versions:")
+    for i, pre := range v.Pre {
+        fmt.Printf("%d: %q\n", i, pre)
+    }
+}
+
+// Build meta data array
+if len(v.Build) > 0 {
+    fmt.Println("Build meta data:")
+    for i, build := range v.Build {
+        fmt.Printf("%d: %q\n", i, build)
+    }
+}
+
+v001, err := semver.Make("0.0.1")
+// Compare using helpers: v.GT(v2), v.LT, v.GTE, v.LTE
+v001.GT(v) == true
+v.LT(v001) == true
+v.GTE(v) == true
+v.LTE(v) == true
+
+// Or use v.Compare(v2) for comparisons (-1, 0, 1):
+v001.Compare(v) == 1
+v.Compare(v001) == -1
+v.Compare(v) == 0
+
+// Manipulate Version in place:
+v.Pre[0], err = semver.NewPRVersion("beta")
+if err != nil {
+    fmt.Printf("Error parsing pre release version: %q", err)
+}
+
+fmt.Println("\nValidate versions:")
+v.Build[0] = "?"
+
+err = v.Validate()
+if err != nil {
+    fmt.Printf("Validation failed: %s\n", err)
+}
+```
+
+
+Benchmarks
+-----
+
+    BenchmarkParseSimple-4           5000000    390    ns/op    48 B/op   1 allocs/op
+    BenchmarkParseComplex-4          1000000   1813    ns/op   256 B/op   7 allocs/op
+    BenchmarkParseAverage-4          1000000   1171    ns/op   163 B/op   4 allocs/op
+    BenchmarkStringSimple-4         20000000    119    ns/op    16 B/op   1 allocs/op
+    BenchmarkStringLarger-4         10000000    206    ns/op    32 B/op   2 allocs/op
+    BenchmarkStringComplex-4         5000000    324    ns/op    80 B/op   3 allocs/op
+    BenchmarkStringAverage-4         5000000    273    ns/op    53 B/op   2 allocs/op
+    BenchmarkValidateSimple-4      200000000      9.33 ns/op     0 B/op   0 allocs/op
+    BenchmarkValidateComplex-4       3000000    469    ns/op     0 B/op   0 allocs/op
+    BenchmarkValidateAverage-4       5000000    256    ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareSimple-4       100000000     11.8  ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareComplex-4       50000000     30.8  ns/op     0 B/op   0 allocs/op
+    BenchmarkCompareAverage-4       30000000     41.5  ns/op     0 B/op   0 allocs/op
+    BenchmarkSort-4                  3000000    419    ns/op   256 B/op   2 allocs/op
+    BenchmarkRangeParseSimple-4      2000000    850    ns/op   192 B/op   5 allocs/op
+    BenchmarkRangeParseAverage-4     1000000   1677    ns/op   400 B/op  10 allocs/op
+    BenchmarkRangeParseComplex-4      300000   5214    ns/op  1440 B/op  30 allocs/op
+    BenchmarkRangeMatchSimple-4     50000000     25.6  ns/op     0 B/op   0 allocs/op
+    BenchmarkRangeMatchAverage-4    30000000     56.4  ns/op     0 B/op   0 allocs/op
+    BenchmarkRangeMatchComplex-4    10000000    153    ns/op     0 B/op   0 allocs/op
+
+See benchmark cases at [semver_test.go](semver_test.go)
+
+
+Motivation
+-----
+
+I simply couldn't find any lib supporting the full spec. Others were just wrong or used reflection and regex which i don't like.
+
+
+Contribution
+-----
+
+Feel free to make a pull request. For bigger changes create a issue first to discuss about it.
+
+
+License
+-----
+
+See [LICENSE](LICENSE) file.

--- a/vendor/github.com/blang/semver/json.go
+++ b/vendor/github.com/blang/semver/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/package.json
+++ b/vendor/github.com/blang/semver/package.json
@@ -1,0 +1,17 @@
+{
+  "author": "blang",
+  "bugs": {
+    "URL": "https://github.com/blang/semver/issues",
+    "url": "https://github.com/blang/semver/issues"
+  },
+  "gx": {
+    "dvcsimport": "github.com/blang/semver"
+  },
+  "gxVersion": "0.10.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "semver",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "3.5.0"
+}
+

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Index(ap, "x") != -1 {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -1,0 +1,418 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precendence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (vp *Version, err error) {
+	v, err := Parse(s)
+	vp = &v
+	return
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
+// with only major and minor components specified
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+		s = strings.Join(parts, ".")
+	}
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}

--- a/vendor/github.com/blang/semver/sort.go
+++ b/vendor/github.com/blang/semver/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/sql.go
+++ b/vendor/github.com/blang/semver/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("Version.Scan: cannot convert %T to string.", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}

--- a/vendor/github.com/inconshreveable/go-update/LICENSE
+++ b/vendor/github.com/inconshreveable/go-update/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Alan Shreve
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/inconshreveable/go-update/README.md
+++ b/vendor/github.com/inconshreveable/go-update/README.md
@@ -1,0 +1,65 @@
+# go-update: Build self-updating Go programs [![godoc reference](https://godoc.org/github.com/inconshreveable/go-update?status.png)](https://godoc.org/github.com/inconshreveable/go-update)
+
+Package update provides functionality to implement secure, self-updating Go programs (or other single-file targets)
+A program can update itself by replacing its executable file with a new version.
+
+It provides the flexibility to implement different updating user experiences
+like auto-updating, or manual user-initiated updates. It also boasts
+advanced features like binary patching and code signing verification.
+
+Example of updating from a URL:
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/inconshreveable/go-update"
+)
+
+func doUpdate(url string) error {
+    resp, err := http.Get(url)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+    err := update.Apply(resp.Body, update.Options{})
+    if err != nil {
+        // error handling
+    }
+    return err
+}
+```
+
+## Features
+
+- Cross platform support (Windows too!)
+- Binary patch application
+- Checksum verification
+- Code signing verification
+- Support for updating arbitrary files
+
+## [equinox.io](https://equinox.io)
+[equinox.io](https://equinox.io) is a complete ready-to-go updating solution built on top of go-update that provides:
+
+- Hosted updates
+- Update channels (stable, beta, nightly, ...)
+- Dynamically computed binary diffs
+- Automatic key generation and code
+- Release tooling with proper code signing
+- Update/download metrics
+
+## API Compatibility Promises
+The master branch of `go-update` is *not* guaranteed to have a stable API over time. For any production application, you should vendor
+your dependency on `go-update` with a tool like git submodules, [gb](http://getgb.io/) or [govendor](https://github.com/kardianos/govendor).
+
+The `go-update` package makes the following promises about API compatibility:
+1. A list of all API-breaking changes will be documented in this README.
+1. `go-update` will strive for as few API-breaking changes as possible.
+
+## API Breaking Changes
+- **Sept 3, 2015**: The `Options` struct passed to `Apply` was changed to be passed by value instead of passed by pointer. Old API at `28de026`.
+- **Aug 9, 2015**: 2.0 API. Old API at `221d034` or `gopkg.in/inconshreveable/go-update.v0`.
+
+## License
+Apache

--- a/vendor/github.com/inconshreveable/go-update/apply.go
+++ b/vendor/github.com/inconshreveable/go-update/apply.go
@@ -1,0 +1,322 @@
+package update
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/inconshreveable/go-update/internal/osext"
+)
+
+var (
+	openFile = os.OpenFile
+)
+
+// Apply performs an update of the current executable (or opts.TargetFile, if set) with the contents of the given io.Reader.
+//
+// Apply performs the following actions to ensure a safe cross-platform update:
+//
+// 1. If configured, applies the contents of the update io.Reader as a binary patch.
+//
+// 2. If configured, computes the checksum of the new executable and verifies it matches.
+//
+// 3. If configured, verifies the signature with a public key.
+//
+// 4. Creates a new file, /path/to/.target.new with the TargetMode with the contents of the updated file
+//
+// 5. Renames /path/to/target to /path/to/.target.old
+//
+// 6. Renames /path/to/.target.new to /path/to/target
+//
+// 7. If the final rename is successful, deletes /path/to/.target.old, returns no error. On Windows,
+// the removal of /path/to/target.old always fails, so instead Apply hides the old file instead.
+//
+// 8. If the final rename fails, attempts to roll back by renaming /path/to/.target.old
+// back to /path/to/target.
+//
+// If the roll back operation fails, the file system is left in an inconsistent state (betweet steps 5 and 6) where
+// there is no new executable file and the old executable file could not be be moved to its original location. In this
+// case you should notify the user of the bad news and ask them to recover manually. Applications can determine whether
+// the rollback failed by calling RollbackError, see the documentation on that function for additional detail.
+func Apply(update io.Reader, opts Options) error {
+	// validate
+	verify := false
+	switch {
+	case opts.Signature != nil && opts.PublicKey != nil:
+		// okay
+		verify = true
+	case opts.Signature != nil:
+		return errors.New("no public key to verify signature with")
+	case opts.PublicKey != nil:
+		return errors.New("No signature to verify with")
+	}
+
+	// set defaults
+	if opts.Hash == 0 {
+		opts.Hash = crypto.SHA256
+	}
+	if opts.Verifier == nil {
+		opts.Verifier = NewECDSAVerifier()
+	}
+	if opts.TargetMode == 0 {
+		opts.TargetMode = 0755
+	}
+
+	// get target path
+	var err error
+	opts.TargetPath, err = opts.getPath()
+	if err != nil {
+		return err
+	}
+
+	var newBytes []byte
+	if opts.Patcher != nil {
+		if newBytes, err = opts.applyPatch(update); err != nil {
+			return err
+		}
+	} else {
+		// no patch to apply, go on through
+		if newBytes, err = ioutil.ReadAll(update); err != nil {
+			return err
+		}
+	}
+
+	// verify checksum if requested
+	if opts.Checksum != nil {
+		if err = opts.verifyChecksum(newBytes); err != nil {
+			return err
+		}
+	}
+
+	if verify {
+		if err = opts.verifySignature(newBytes); err != nil {
+			return err
+		}
+	}
+
+	// get the directory the executable exists in
+	updateDir := filepath.Dir(opts.TargetPath)
+	filename := filepath.Base(opts.TargetPath)
+
+	// Copy the contents of newbinary to a new executable file
+	newPath := filepath.Join(updateDir, fmt.Sprintf(".%s.new", filename))
+	fp, err := openFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, opts.TargetMode)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	_, err = io.Copy(fp, bytes.NewReader(newBytes))
+	if err != nil {
+		return err
+	}
+
+	// if we don't call fp.Close(), windows won't let us move the new executable
+	// because the file will still be "in use"
+	fp.Close()
+
+	// this is where we'll move the executable to so that we can swap in the updated replacement
+	oldPath := opts.OldSavePath
+	removeOld := opts.OldSavePath == ""
+	if removeOld {
+		oldPath = filepath.Join(updateDir, fmt.Sprintf(".%s.old", filename))
+	}
+
+	// delete any existing old exec file - this is necessary on Windows for two reasons:
+	// 1. after a successful update, Windows can't remove the .old file because the process is still running
+	// 2. windows rename operations fail if the destination file already exists
+	_ = os.Remove(oldPath)
+
+	// move the existing executable to a new file in the same directory
+	err = os.Rename(opts.TargetPath, oldPath)
+	if err != nil {
+		return err
+	}
+
+	// move the new exectuable in to become the new program
+	err = os.Rename(newPath, opts.TargetPath)
+
+	if err != nil {
+		// move unsuccessful
+		//
+		// The filesystem is now in a bad state. We have successfully
+		// moved the existing binary to a new location, but we couldn't move the new
+		// binary to take its place. That means there is no file where the current executable binary
+		// used to be!
+		// Try to rollback by restoring the old binary to its original path.
+		rerr := os.Rename(oldPath, opts.TargetPath)
+		if rerr != nil {
+			return &rollbackErr{err, rerr}
+		}
+
+		return err
+	}
+
+	// move successful, remove the old binary if needed
+	if removeOld {
+		errRemove := os.Remove(oldPath)
+
+		// windows has trouble with removing old binaries, so hide it instead
+		if errRemove != nil {
+			_ = hideFile(oldPath)
+		}
+	}
+
+	return nil
+}
+
+// RollbackError takes an error value returned by Apply and returns the error, if any,
+// that occurred when attempting to roll back from a failed update. Applications should
+// always call this function on any non-nil errors returned by Apply.
+//
+// If no rollback was needed or if the rollback was successful, RollbackError returns nil,
+// otherwise it returns the error encountered when trying to roll back.
+func RollbackError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if rerr, ok := err.(*rollbackErr); ok {
+		return rerr.rollbackErr
+	}
+	return nil
+}
+
+type rollbackErr struct {
+	error             // original error
+	rollbackErr error // error encountered while rolling back
+}
+
+type Options struct {
+	// TargetPath defines the path to the file to update.
+	// The emptry string means 'the executable file of the running program'.
+	TargetPath string
+
+	// Create TargetPath replacement with this file mode. If zero, defaults to 0755.
+	TargetMode os.FileMode
+
+	// Checksum of the new binary to verify against. If nil, no checksum or signature verification is done.
+	Checksum []byte
+
+	// Public key to use for signature verification. If nil, no signature verification is done.
+	PublicKey crypto.PublicKey
+
+	// Signature to verify the updated file. If nil, no signature verification is done.
+	Signature []byte
+
+	// Pluggable signature verification algorithm. If nil, ECDSA is used.
+	Verifier Verifier
+
+	// Use this hash function to generate the checksum. If not set, SHA256 is used.
+	Hash crypto.Hash
+
+	// If nil, treat the update as a complete replacement for the contents of the file at TargetPath.
+	// If non-nil, treat the update contents as a patch and use this object to apply the patch.
+	Patcher Patcher
+
+	// Store the old executable file at this path after a successful update.
+	// The empty string means the old executable file will be removed after the update.
+	OldSavePath string
+}
+
+// CheckPermissions determines whether the process has the correct permissions to
+// perform the requested update. If the update can proceed, it returns nil, otherwise
+// it returns the error that would occur if an update were attempted.
+func (o *Options) CheckPermissions() error {
+	// get the directory the file exists in
+	path, err := o.getPath()
+	if err != nil {
+		return err
+	}
+
+	fileDir := filepath.Dir(path)
+	fileName := filepath.Base(path)
+
+	// attempt to open a file in the file's directory
+	newPath := filepath.Join(fileDir, fmt.Sprintf(".%s.new", fileName))
+	fp, err := openFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, o.TargetMode)
+	if err != nil {
+		return err
+	}
+	fp.Close()
+
+	_ = os.Remove(newPath)
+	return nil
+}
+
+// SetPublicKeyPEM is a convenience method to set the PublicKey property
+// used for checking a completed update's signature by parsing a
+// Public Key formatted as PEM data.
+func (o *Options) SetPublicKeyPEM(pembytes []byte) error {
+	block, _ := pem.Decode(pembytes)
+	if block == nil {
+		return errors.New("couldn't parse PEM data")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+	o.PublicKey = pub
+	return nil
+}
+
+func (o *Options) getPath() (string, error) {
+	if o.TargetPath == "" {
+		return osext.Executable()
+	} else {
+		return o.TargetPath, nil
+	}
+}
+
+func (o *Options) applyPatch(patch io.Reader) ([]byte, error) {
+	// open the file to patch
+	old, err := os.Open(o.TargetPath)
+	if err != nil {
+		return nil, err
+	}
+	defer old.Close()
+
+	// apply the patch
+	var applied bytes.Buffer
+	if err = o.Patcher.Patch(old, &applied, patch); err != nil {
+		return nil, err
+	}
+
+	return applied.Bytes(), nil
+}
+
+func (o *Options) verifyChecksum(updated []byte) error {
+	checksum, err := checksumFor(o.Hash, updated)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(o.Checksum, checksum) {
+		return fmt.Errorf("Updated file has wrong checksum. Expected: %x, got: %x", o.Checksum, checksum)
+	}
+	return nil
+}
+
+func (o *Options) verifySignature(updated []byte) error {
+	checksum, err := checksumFor(o.Hash, updated)
+	if err != nil {
+		return err
+	}
+	return o.Verifier.VerifySignature(checksum, o.Signature, o.Hash, o.PublicKey)
+}
+
+func checksumFor(h crypto.Hash, payload []byte) ([]byte, error) {
+	if !h.Available() {
+		return nil, errors.New("requested hash function not available")
+	}
+	hash := h.New()
+	hash.Write(payload) // guaranteed not to error
+	return hash.Sum([]byte{}), nil
+}

--- a/vendor/github.com/inconshreveable/go-update/doc.go
+++ b/vendor/github.com/inconshreveable/go-update/doc.go
@@ -1,0 +1,172 @@
+/*
+Package update provides functionality to implement secure, self-updating Go programs (or other single-file targets).
+
+For complete updating solutions please see Equinox (https://equinox.io) and go-tuf (https://github.com/flynn/go-tuf).
+
+Basic Example
+
+This example shows how to update a program remotely from a URL.
+
+	import (
+		"fmt"
+		"net/http"
+
+		"github.com/inconshreveable/go-update"
+	)
+
+	func doUpdate(url string) error {
+		// request the new file
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		err := update.Apply(resp.Body, update.Options{})
+		if err != nil {
+			if rerr := update.RollbackError(err); rerr != nil {
+				fmt.Println("Failed to rollback from bad update: %v", rerr)
+			}
+		}
+		return err
+	}
+
+
+Binary Patching
+
+Go binaries can often be large. It can be advantageous to only ship a binary patch to a client
+instead of the complete program text of a new version.
+
+This example shows how to update a program with a bsdiff binary patch. Other patch formats
+may be applied by implementing the Patcher interface.
+
+	import (
+		"encoding/hex"
+		"io"
+
+		"github.com/inconshreveable/go-update"
+	)
+
+	func updateWithPatch(patch io.Reader) error {
+		err := update.Apply(patch, update.Options{
+			Patcher: update.NewBSDiffPatcher()
+		})
+		if err != nil {
+			// error handling
+		}
+		return err
+	}
+
+Checksum Verification
+
+Updating executable code on a computer can be a dangerous operation unless you
+take the appropriate steps to guarantee the authenticity of the new code. While
+checksum verification is important, it should always be combined with signature
+verification (next section) to guarantee that the code came from a trusted party.
+
+go-update validates SHA256 checksums by default, but this is pluggable via the Hash
+property on the Options struct.
+
+This example shows how to guarantee that the newly-updated binary is verified to
+have an appropriate checksum (that was otherwise retrived via a secure channel)
+specified as a hex string.
+
+	import (
+		"crypto"
+		_ "crypto/sha256"
+		"encoding/hex"
+		"io"
+
+		"github.com/inconshreveable/go-update"
+	)
+
+	func updateWithChecksum(binary io.Reader, hexChecksum string) error {
+		checksum, err := hex.DecodeString(hexChecksum)
+		if err != nil {
+			return err
+		}
+		err = update.Apply(binary, update.Options{
+			Hash: crypto.SHA256, 	// this is the default, you don't need to specify it
+			Checksum: checksum,
+		})
+		if err != nil {
+			// error handling
+		}
+		return err
+	}
+
+Cryptographic Signature Verification
+
+Cryptographic verification of new code from an update is an extremely important way to guarantee the
+security and integrity of your updates.
+
+Verification is performed by validating the signature of a hash of the new file. This
+means nothing changes if you apply your update with a patch.
+
+This example shows how to add signature verification to your updates. To make all of this work
+an application distributor must first create a public/private key pair and embed the public key
+into their application. When they issue a new release, the issuer must sign the new executable file
+with the private key and distribute the signature along with the update.
+
+	import (
+		"crypto"
+		_ "crypto/sha256"
+		"encoding/hex"
+		"io"
+
+		"github.com/inconshreveable/go-update"
+	)
+
+	var publicKey = []byte(`
+	-----BEGIN PUBLIC KEY-----
+	MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtrVmBxQvheRArXjg2vG1xIprWGuCyESx
+	MMY8pjmjepSy2kuz+nl9aFLqmr+rDNdYvEBqQaZrYMc6k29gjvoQnQ==
+	-----END PUBLIC KEY-----
+	`)
+
+	func verifiedUpdate(binary io.Reader, hexChecksum, hexSignature string) {
+		checksum, err := hex.DecodeString(hexChecksum)
+		if err != nil {
+			return err
+		}
+		signature, err := hex.DecodeString(hexSignature)
+		if err != nil {
+			return err
+		}
+		opts := update.Options{
+			Checksum: checksum,
+			Signature: signature,
+			Hash: crypto.SHA256, 	                 // this is the default, you don't need to specify it
+			Verifier: update.NewECDSAVerifier(),   // this is the default, you don't need to specify it
+		}
+		err = opts.SetPublicKeyPEM(publicKey)
+		if err != nil {
+			return err
+		}
+		err = update.Apply(binary, opts)
+		if err != nil {
+			// error handling
+		}
+		return err
+	}
+
+
+Building Single-File Go Binaries
+
+In order to update a Go application with go-update, you must distributed it as a single executable.
+This is often easy, but some applications require static assets (like HTML and CSS asset files or TLS certificates).
+In order to update applications like these, you'll want to make sure to embed those asset files into
+the distributed binary with a tool like go-bindata (my favorite): https://github.com/jteeuwen/go-bindata
+
+Non-Goals
+
+Mechanisms and protocols for determining whether an update should be applied and, if so, which one are
+out of scope for this package. Please consult go-tuf (https://github.com/flynn/go-tuf) or Equinox (https://equinox.io)
+for more complete solutions.
+
+go-update only works for self-updating applications that are distributed as a single binary, i.e.
+applications that do not have additional assets or dependency files.
+Updating application that are distributed as mutliple on-disk files is out of scope, although this
+may change in future versions of this library.
+
+*/
+package update

--- a/vendor/github.com/inconshreveable/go-update/hide_noop.go
+++ b/vendor/github.com/inconshreveable/go-update/hide_noop.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package update
+
+func hideFile(path string) error {
+	return nil
+}

--- a/vendor/github.com/inconshreveable/go-update/hide_windows.go
+++ b/vendor/github.com/inconshreveable/go-update/hide_windows.go
@@ -1,0 +1,19 @@
+package update
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func hideFile(path string) error {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	setFileAttributes := kernel32.NewProc("SetFileAttributesW")
+
+	r1, _, err := setFileAttributes.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))), 2)
+
+	if r1 == 0 {
+		return err
+	} else {
+		return nil
+	}
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/License
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/License
@@ -1,0 +1,22 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/Readme.md
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/Readme.md
@@ -1,0 +1,7 @@
+# binarydist
+
+Package binarydist implements binary diff and patch as described on
+<http://www.daemonology.net/bsdiff/>. It reads and writes files
+compatible with the tools there.
+
+Documentation at <http://go.pkgdoc.org/github.com/kr/binarydist>.

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/bzip2.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/bzip2.go
@@ -1,0 +1,40 @@
+package binarydist
+
+import (
+	"io"
+	"os/exec"
+)
+
+type bzip2Writer struct {
+	c *exec.Cmd
+	w io.WriteCloser
+}
+
+func (w bzip2Writer) Write(b []byte) (int, error) {
+	return w.w.Write(b)
+}
+
+func (w bzip2Writer) Close() error {
+	if err := w.w.Close(); err != nil {
+		return err
+	}
+	return w.c.Wait()
+}
+
+// Package compress/bzip2 implements only decompression,
+// so we'll fake it by running bzip2 in another process.
+func newBzip2Writer(w io.Writer) (wc io.WriteCloser, err error) {
+	var bw bzip2Writer
+	bw.c = exec.Command("bzip2", "-c")
+	bw.c.Stdout = w
+
+	if bw.w, err = bw.c.StdinPipe(); err != nil {
+		return nil, err
+	}
+
+	if err = bw.c.Start(); err != nil {
+		return nil, err
+	}
+
+	return bw, nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/diff.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/diff.go
@@ -1,0 +1,408 @@
+package binarydist
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+)
+
+func swap(a []int, i, j int) { a[i], a[j] = a[j], a[i] }
+
+func split(I, V []int, start, length, h int) {
+	var i, j, k, x, jj, kk int
+
+	if length < 16 {
+		for k = start; k < start+length; k += j {
+			j = 1
+			x = V[I[k]+h]
+			for i = 1; k+i < start+length; i++ {
+				if V[I[k+i]+h] < x {
+					x = V[I[k+i]+h]
+					j = 0
+				}
+				if V[I[k+i]+h] == x {
+					swap(I, k+i, k+j)
+					j++
+				}
+			}
+			for i = 0; i < j; i++ {
+				V[I[k+i]] = k + j - 1
+			}
+			if j == 1 {
+				I[k] = -1
+			}
+		}
+		return
+	}
+
+	x = V[I[start+length/2]+h]
+	jj = 0
+	kk = 0
+	for i = start; i < start+length; i++ {
+		if V[I[i]+h] < x {
+			jj++
+		}
+		if V[I[i]+h] == x {
+			kk++
+		}
+	}
+	jj += start
+	kk += jj
+
+	i = start
+	j = 0
+	k = 0
+	for i < jj {
+		if V[I[i]+h] < x {
+			i++
+		} else if V[I[i]+h] == x {
+			swap(I, i, jj+j)
+			j++
+		} else {
+			swap(I, i, kk+k)
+			k++
+		}
+	}
+
+	for jj+j < kk {
+		if V[I[jj+j]+h] == x {
+			j++
+		} else {
+			swap(I, jj+j, kk+k)
+			k++
+		}
+	}
+
+	if jj > start {
+		split(I, V, start, jj-start, h)
+	}
+
+	for i = 0; i < kk-jj; i++ {
+		V[I[jj+i]] = kk - 1
+	}
+	if jj == kk-1 {
+		I[jj] = -1
+	}
+
+	if start+length > kk {
+		split(I, V, kk, start+length-kk, h)
+	}
+}
+
+func qsufsort(obuf []byte) []int {
+	var buckets [256]int
+	var i, h int
+	I := make([]int, len(obuf)+1)
+	V := make([]int, len(obuf)+1)
+
+	for _, c := range obuf {
+		buckets[c]++
+	}
+	for i = 1; i < 256; i++ {
+		buckets[i] += buckets[i-1]
+	}
+	copy(buckets[1:], buckets[:])
+	buckets[0] = 0
+
+	for i, c := range obuf {
+		buckets[c]++
+		I[buckets[c]] = i
+	}
+
+	I[0] = len(obuf)
+	for i, c := range obuf {
+		V[i] = buckets[c]
+	}
+
+	V[len(obuf)] = 0
+	for i = 1; i < 256; i++ {
+		if buckets[i] == buckets[i-1]+1 {
+			I[buckets[i]] = -1
+		}
+	}
+	I[0] = -1
+
+	for h = 1; I[0] != -(len(obuf) + 1); h += h {
+		var n int
+		for i = 0; i < len(obuf)+1; {
+			if I[i] < 0 {
+				n -= I[i]
+				i -= I[i]
+			} else {
+				if n != 0 {
+					I[i-n] = -n
+				}
+				n = V[I[i]] + 1 - i
+				split(I, V, i, n, h)
+				i += n
+				n = 0
+			}
+		}
+		if n != 0 {
+			I[i-n] = -n
+		}
+	}
+
+	for i = 0; i < len(obuf)+1; i++ {
+		I[V[i]] = i
+	}
+	return I
+}
+
+func matchlen(a, b []byte) (i int) {
+	for i < len(a) && i < len(b) && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+func search(I []int, obuf, nbuf []byte, st, en int) (pos, n int) {
+	if en-st < 2 {
+		x := matchlen(obuf[I[st]:], nbuf)
+		y := matchlen(obuf[I[en]:], nbuf)
+
+		if x > y {
+			return I[st], x
+		} else {
+			return I[en], y
+		}
+	}
+
+	x := st + (en-st)/2
+	if bytes.Compare(obuf[I[x]:], nbuf) < 0 {
+		return search(I, obuf, nbuf, x, en)
+	} else {
+		return search(I, obuf, nbuf, st, x)
+	}
+	panic("unreached")
+}
+
+// Diff computes the difference between old and new, according to the bsdiff
+// algorithm, and writes the result to patch.
+func Diff(old, new io.Reader, patch io.Writer) error {
+	obuf, err := ioutil.ReadAll(old)
+	if err != nil {
+		return err
+	}
+
+	nbuf, err := ioutil.ReadAll(new)
+	if err != nil {
+		return err
+	}
+
+	pbuf, err := diffBytes(obuf, nbuf)
+	if err != nil {
+		return err
+	}
+
+	_, err = patch.Write(pbuf)
+	return err
+}
+
+func diffBytes(obuf, nbuf []byte) ([]byte, error) {
+	var patch seekBuffer
+	err := diff(obuf, nbuf, &patch)
+	if err != nil {
+		return nil, err
+	}
+	return patch.buf, nil
+}
+
+func diff(obuf, nbuf []byte, patch io.WriteSeeker) error {
+	var lenf int
+	I := qsufsort(obuf)
+	db := make([]byte, len(nbuf))
+	eb := make([]byte, len(nbuf))
+	var dblen, eblen int
+
+	var hdr header
+	hdr.Magic = magic
+	hdr.NewSize = int64(len(nbuf))
+	err := binary.Write(patch, signMagLittleEndian{}, &hdr)
+	if err != nil {
+		return err
+	}
+
+	// Compute the differences, writing ctrl as we go
+	pfbz2, err := newBzip2Writer(patch)
+	if err != nil {
+		return err
+	}
+	var scan, pos, length int
+	var lastscan, lastpos, lastoffset int
+	for scan < len(nbuf) {
+		var oldscore int
+		scan += length
+		for scsc := scan; scan < len(nbuf); scan++ {
+			pos, length = search(I, obuf, nbuf[scan:], 0, len(obuf))
+
+			for ; scsc < scan+length; scsc++ {
+				if scsc+lastoffset < len(obuf) &&
+					obuf[scsc+lastoffset] == nbuf[scsc] {
+					oldscore++
+				}
+			}
+
+			if (length == oldscore && length != 0) || length > oldscore+8 {
+				break
+			}
+
+			if scan+lastoffset < len(obuf) && obuf[scan+lastoffset] == nbuf[scan] {
+				oldscore--
+			}
+		}
+
+		if length != oldscore || scan == len(nbuf) {
+			var s, Sf int
+			lenf = 0
+			for i := 0; lastscan+i < scan && lastpos+i < len(obuf); {
+				if obuf[lastpos+i] == nbuf[lastscan+i] {
+					s++
+				}
+				i++
+				if s*2-i > Sf*2-lenf {
+					Sf = s
+					lenf = i
+				}
+			}
+
+			lenb := 0
+			if scan < len(nbuf) {
+				var s, Sb int
+				for i := 1; (scan >= lastscan+i) && (pos >= i); i++ {
+					if obuf[pos-i] == nbuf[scan-i] {
+						s++
+					}
+					if s*2-i > Sb*2-lenb {
+						Sb = s
+						lenb = i
+					}
+				}
+			}
+
+			if lastscan+lenf > scan-lenb {
+				overlap := (lastscan + lenf) - (scan - lenb)
+				s := 0
+				Ss := 0
+				lens := 0
+				for i := 0; i < overlap; i++ {
+					if nbuf[lastscan+lenf-overlap+i] == obuf[lastpos+lenf-overlap+i] {
+						s++
+					}
+					if nbuf[scan-lenb+i] == obuf[pos-lenb+i] {
+						s--
+					}
+					if s > Ss {
+						Ss = s
+						lens = i + 1
+					}
+				}
+
+				lenf += lens - overlap
+				lenb -= lens
+			}
+
+			for i := 0; i < lenf; i++ {
+				db[dblen+i] = nbuf[lastscan+i] - obuf[lastpos+i]
+			}
+			for i := 0; i < (scan-lenb)-(lastscan+lenf); i++ {
+				eb[eblen+i] = nbuf[lastscan+lenf+i]
+			}
+
+			dblen += lenf
+			eblen += (scan - lenb) - (lastscan + lenf)
+
+			err = binary.Write(pfbz2, signMagLittleEndian{}, int64(lenf))
+			if err != nil {
+				pfbz2.Close()
+				return err
+			}
+
+			val := (scan - lenb) - (lastscan + lenf)
+			err = binary.Write(pfbz2, signMagLittleEndian{}, int64(val))
+			if err != nil {
+				pfbz2.Close()
+				return err
+			}
+
+			val = (pos - lenb) - (lastpos + lenf)
+			err = binary.Write(pfbz2, signMagLittleEndian{}, int64(val))
+			if err != nil {
+				pfbz2.Close()
+				return err
+			}
+
+			lastscan = scan - lenb
+			lastpos = pos - lenb
+			lastoffset = pos - scan
+		}
+	}
+	err = pfbz2.Close()
+	if err != nil {
+		return err
+	}
+
+	// Compute size of compressed ctrl data
+	l64, err := patch.Seek(0, 1)
+	if err != nil {
+		return err
+	}
+	hdr.CtrlLen = int64(l64 - 32)
+
+	// Write compressed diff data
+	pfbz2, err = newBzip2Writer(patch)
+	if err != nil {
+		return err
+	}
+	n, err := pfbz2.Write(db[:dblen])
+	if err != nil {
+		pfbz2.Close()
+		return err
+	}
+	if n != dblen {
+		pfbz2.Close()
+		return io.ErrShortWrite
+	}
+	err = pfbz2.Close()
+	if err != nil {
+		return err
+	}
+
+	// Compute size of compressed diff data
+	n64, err := patch.Seek(0, 1)
+	if err != nil {
+		return err
+	}
+	hdr.DiffLen = n64 - l64
+
+	// Write compressed extra data
+	pfbz2, err = newBzip2Writer(patch)
+	if err != nil {
+		return err
+	}
+	n, err = pfbz2.Write(eb[:eblen])
+	if err != nil {
+		pfbz2.Close()
+		return err
+	}
+	if n != eblen {
+		pfbz2.Close()
+		return io.ErrShortWrite
+	}
+	err = pfbz2.Close()
+	if err != nil {
+		return err
+	}
+
+	// Seek to the beginning, write the header, and close the file
+	_, err = patch.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	err = binary.Write(patch, signMagLittleEndian{}, &hdr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/doc.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/doc.go
@@ -1,0 +1,24 @@
+// Package binarydist implements binary diff and patch as described on
+// http://www.daemonology.net/bsdiff/. It reads and writes files
+// compatible with the tools there.
+package binarydist
+
+var magic = [8]byte{'B', 'S', 'D', 'I', 'F', 'F', '4', '0'}
+
+// File format:
+//   0       8    "BSDIFF40"
+//   8       8    X
+//   16      8    Y
+//   24      8    sizeof(newfile)
+//   32      X    bzip2(control block)
+//   32+X    Y    bzip2(diff block)
+//   32+X+Y  ???  bzip2(extra block)
+// with control block a set of triples (x,y,z) meaning "add x bytes
+// from oldfile to x bytes from the diff block; copy y bytes from the
+// extra block; seek forwards in oldfile by z bytes".
+type header struct {
+	Magic   [8]byte
+	CtrlLen int64
+	DiffLen int64
+	NewSize int64
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/encoding.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/encoding.go
@@ -1,0 +1,53 @@
+package binarydist
+
+// SignMagLittleEndian is the numeric encoding used by the bsdiff tools.
+// It implements binary.ByteOrder using a sign-magnitude format
+// and little-endian byte order. Only methods Uint64 and String
+// have been written; the rest panic.
+type signMagLittleEndian struct{}
+
+func (signMagLittleEndian) Uint16(b []byte) uint16 { panic("unimplemented") }
+
+func (signMagLittleEndian) PutUint16(b []byte, v uint16) { panic("unimplemented") }
+
+func (signMagLittleEndian) Uint32(b []byte) uint32 { panic("unimplemented") }
+
+func (signMagLittleEndian) PutUint32(b []byte, v uint32) { panic("unimplemented") }
+
+func (signMagLittleEndian) Uint64(b []byte) uint64 {
+	y := int64(b[0]) |
+		int64(b[1])<<8 |
+		int64(b[2])<<16 |
+		int64(b[3])<<24 |
+		int64(b[4])<<32 |
+		int64(b[5])<<40 |
+		int64(b[6])<<48 |
+		int64(b[7]&0x7f)<<56
+
+	if b[7]&0x80 != 0 {
+		y = -y
+	}
+	return uint64(y)
+}
+
+func (signMagLittleEndian) PutUint64(b []byte, v uint64) {
+	x := int64(v)
+	neg := x < 0
+	if neg {
+		x = -x
+	}
+
+	b[0] = byte(x)
+	b[1] = byte(x >> 8)
+	b[2] = byte(x >> 16)
+	b[3] = byte(x >> 24)
+	b[4] = byte(x >> 32)
+	b[5] = byte(x >> 40)
+	b[6] = byte(x >> 48)
+	b[7] = byte(x >> 56)
+	if neg {
+		b[7] |= 0x80
+	}
+}
+
+func (signMagLittleEndian) String() string { return "signMagLittleEndian" }

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/patch.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/patch.go
@@ -1,0 +1,109 @@
+package binarydist
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"encoding/binary"
+	"errors"
+	"io"
+	"io/ioutil"
+)
+
+var ErrCorrupt = errors.New("corrupt patch")
+
+// Patch applies patch to old, according to the bspatch algorithm,
+// and writes the result to new.
+func Patch(old io.Reader, new io.Writer, patch io.Reader) error {
+	var hdr header
+	err := binary.Read(patch, signMagLittleEndian{}, &hdr)
+	if err != nil {
+		return err
+	}
+	if hdr.Magic != magic {
+		return ErrCorrupt
+	}
+	if hdr.CtrlLen < 0 || hdr.DiffLen < 0 || hdr.NewSize < 0 {
+		return ErrCorrupt
+	}
+
+	ctrlbuf := make([]byte, hdr.CtrlLen)
+	_, err = io.ReadFull(patch, ctrlbuf)
+	if err != nil {
+		return err
+	}
+	cpfbz2 := bzip2.NewReader(bytes.NewReader(ctrlbuf))
+
+	diffbuf := make([]byte, hdr.DiffLen)
+	_, err = io.ReadFull(patch, diffbuf)
+	if err != nil {
+		return err
+	}
+	dpfbz2 := bzip2.NewReader(bytes.NewReader(diffbuf))
+
+	// The entire rest of the file is the extra block.
+	epfbz2 := bzip2.NewReader(patch)
+
+	obuf, err := ioutil.ReadAll(old)
+	if err != nil {
+		return err
+	}
+
+	nbuf := make([]byte, hdr.NewSize)
+
+	var oldpos, newpos int64
+	for newpos < hdr.NewSize {
+		var ctrl struct{ Add, Copy, Seek int64 }
+		err = binary.Read(cpfbz2, signMagLittleEndian{}, &ctrl)
+		if err != nil {
+			return err
+		}
+
+		// Sanity-check
+		if newpos+ctrl.Add > hdr.NewSize {
+			return ErrCorrupt
+		}
+
+		// Read diff string
+		_, err = io.ReadFull(dpfbz2, nbuf[newpos:newpos+ctrl.Add])
+		if err != nil {
+			return ErrCorrupt
+		}
+
+		// Add old data to diff string
+		for i := int64(0); i < ctrl.Add; i++ {
+			if oldpos+i >= 0 && oldpos+i < int64(len(obuf)) {
+				nbuf[newpos+i] += obuf[oldpos+i]
+			}
+		}
+
+		// Adjust pointers
+		newpos += ctrl.Add
+		oldpos += ctrl.Add
+
+		// Sanity-check
+		if newpos+ctrl.Copy > hdr.NewSize {
+			return ErrCorrupt
+		}
+
+		// Read extra string
+		_, err = io.ReadFull(epfbz2, nbuf[newpos:newpos+ctrl.Copy])
+		if err != nil {
+			return ErrCorrupt
+		}
+
+		// Adjust pointers
+		newpos += ctrl.Copy
+		oldpos += ctrl.Seek
+	}
+
+	// Write the new file
+	for len(nbuf) > 0 {
+		n, err := new.Write(nbuf)
+		if err != nil {
+			return err
+		}
+		nbuf = nbuf[n:]
+	}
+
+	return nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/binarydist/seek.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/binarydist/seek.go
@@ -1,0 +1,43 @@
+package binarydist
+
+import (
+	"errors"
+)
+
+type seekBuffer struct {
+	buf []byte
+	pos int
+}
+
+func (b *seekBuffer) Write(p []byte) (n int, err error) {
+	n = copy(b.buf[b.pos:], p)
+	if n == len(p) {
+		b.pos += n
+		return n, nil
+	}
+	b.buf = append(b.buf, p[n:]...)
+	b.pos += len(p)
+	return len(p), nil
+}
+
+func (b *seekBuffer) Seek(offset int64, whence int) (ret int64, err error) {
+	var abs int64
+	switch whence {
+	case 0:
+		abs = offset
+	case 1:
+		abs = int64(b.pos) + offset
+	case 2:
+		abs = int64(len(b.buf)) + offset
+	default:
+		return 0, errors.New("binarydist: invalid whence")
+	}
+	if abs < 0 {
+		return 0, errors.New("binarydist: negative position")
+	}
+	if abs >= 1<<31 {
+		return 0, errors.New("binarydist: position out of range")
+	}
+	b.pos = int(abs)
+	return abs, nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/LICENSE
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/README.md
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/README.md
@@ -1,0 +1,16 @@
+### Extensions to the "os" package.
+
+## Find the current Executable and ExecutableFolder.
+
+There is sometimes utility in finding the current executable file
+that is running. This can be used for upgrading the current executable
+or finding resources located relative to the executable file. Both
+working directory and the os.Args[0] value are arbitrary and cannot
+be relied on; os.Args[0] can be "faked".
+
+Multi-platform and supports:
+ * Linux
+ * OS X
+ * Windows
+ * Plan 9
+ * BSDs.

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/osext.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/osext.go
@@ -1,0 +1,27 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext
+
+import "path/filepath"
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name and any trailing slash.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/osext_plan9.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/osext_plan9.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func executable() (string, error) {
+	f, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/osext_procfs.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/osext_procfs.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux netbsd openbsd solaris dragonfly
+
+package osext
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		const deletedTag = " (deleted)"
+		execpath, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return execpath, err
+		}
+		execpath = strings.TrimSuffix(execpath, deletedTag)
+		execpath = strings.TrimPrefix(execpath, deletedTag)
+		return execpath, nil
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "openbsd", "dragonfly":
+		return os.Readlink("/proc/curproc/file")
+	case "solaris":
+		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/osext_sysctl.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/osext_sysctl.go
@@ -1,0 +1,79 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd
+
+package osext
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var initCwd, initCwdErr = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	}
+
+	n := uintptr(0)
+	// Get length.
+	_, _, errNum := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, errNum = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	for i, v := range buf {
+		if v == 0 {
+			buf = buf[:i]
+			break
+		}
+	}
+	var err error
+	execPath := string(buf)
+	// execPath will not be empty due to above checks.
+	// Try to get the absolute path if the execPath is not rooted.
+	if execPath[0] != '/' {
+		execPath, err = getAbs(execPath)
+		if err != nil {
+			return execPath, err
+		}
+	}
+	// For darwin KERN_PROCARGS may return the path to a symlink rather than the
+	// actual executable.
+	if runtime.GOOS == "darwin" {
+		if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+			return execPath, err
+		}
+	}
+	return execPath, nil
+}
+
+func getAbs(execPath string) (string, error) {
+	if initCwdErr != nil {
+		return execPath, initCwdErr
+	}
+	// The execPath may begin with a "../" or a "./" so clean it first.
+	// Join the two paths, trailing and starting slashes undetermined, so use
+	// the generic Join function.
+	return filepath.Join(initCwd, filepath.Clean(execPath)), nil
+}

--- a/vendor/github.com/inconshreveable/go-update/internal/osext/osext_windows.go
+++ b/vendor/github.com/inconshreveable/go-update/internal/osext/osext_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}

--- a/vendor/github.com/inconshreveable/go-update/patcher.go
+++ b/vendor/github.com/inconshreveable/go-update/patcher.go
@@ -1,0 +1,24 @@
+package update
+
+import (
+	"io"
+
+	"github.com/inconshreveable/go-update/internal/binarydist"
+)
+
+// Patcher defines an interface for applying binary patches to an old item to get an updated item.
+type Patcher interface {
+	Patch(old io.Reader, new io.Writer, patch io.Reader) error
+}
+
+type patchFn func(io.Reader, io.Writer, io.Reader) error
+
+func (fn patchFn) Patch(old io.Reader, new io.Writer, patch io.Reader) error {
+	return fn(old, new, patch)
+}
+
+// NewBSDifferPatcher returns a new Patcher that applies binary patches using
+// the bsdiff algorithm. See http://www.daemonology.net/bsdiff/
+func NewBSDiffPatcher() Patcher {
+	return patchFn(binarydist.Patch)
+}

--- a/vendor/github.com/inconshreveable/go-update/verifier.go
+++ b/vendor/github.com/inconshreveable/go-update/verifier.go
@@ -1,0 +1,74 @@
+package update
+
+import (
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/asn1"
+	"errors"
+	"math/big"
+)
+
+// Verifier defines an interface for verfiying an update's signature with a public key.
+type Verifier interface {
+	VerifySignature(checksum, signature []byte, h crypto.Hash, publicKey crypto.PublicKey) error
+}
+
+type verifyFn func([]byte, []byte, crypto.Hash, crypto.PublicKey) error
+
+func (fn verifyFn) VerifySignature(checksum []byte, signature []byte, hash crypto.Hash, publicKey crypto.PublicKey) error {
+	return fn(checksum, signature, hash, publicKey)
+}
+
+// NewRSAVerifier returns a Verifier that uses the RSA algorithm to verify updates.
+func NewRSAVerifier() Verifier {
+	return verifyFn(func(checksum, signature []byte, hash crypto.Hash, publicKey crypto.PublicKey) error {
+		key, ok := publicKey.(*rsa.PublicKey)
+		if !ok {
+			return errors.New("not a valid RSA public key")
+		}
+		return rsa.VerifyPKCS1v15(key, hash, checksum, signature)
+	})
+}
+
+type rsDER struct {
+	R *big.Int
+	S *big.Int
+}
+
+// NewECDSAVerifier returns a Verifier that uses the ECDSA algorithm to verify updates.
+func NewECDSAVerifier() Verifier {
+	return verifyFn(func(checksum, signature []byte, hash crypto.Hash, publicKey crypto.PublicKey) error {
+		key, ok := publicKey.(*ecdsa.PublicKey)
+		if !ok {
+			return errors.New("not a valid ECDSA public key")
+		}
+		var rs rsDER
+		if _, err := asn1.Unmarshal(signature, &rs); err != nil {
+			return err
+		}
+		if !ecdsa.Verify(key, checksum, rs.R, rs.S) {
+			return errors.New("failed to verify ecsda signature")
+		}
+		return nil
+	})
+}
+
+// NewDSAVerifier returns a Verifier that uses the DSA algorithm to verify updates.
+func NewDSAVerifier() Verifier {
+	return verifyFn(func(checksum, signature []byte, hash crypto.Hash, publicKey crypto.PublicKey) error {
+		key, ok := publicKey.(*dsa.PublicKey)
+		if !ok {
+			return errors.New("not a valid DSA public key")
+		}
+		var rs rsDER
+		if _, err := asn1.Unmarshal(signature, &rs); err != nil {
+			return err
+		}
+		if !dsa.Verify(key, checksum, rs.R, rs.S) {
+			return errors.New("failed to verify ecsda signature")
+		}
+		return nil
+	})
+}

--- a/vendor/golang.org/x/net/AUTHORS
+++ b/vendor/golang.org/x/net/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/net/CONTRIBUTORS
+++ b/vendor/golang.org/x/net/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/text/AUTHORS
+++ b/vendor/golang.org/x/text/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/text/CONTRIBUTORS
+++ b/vendor/golang.org/x/text/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.


### PR DESCRIPTION
This should resolve https://github.com/exercism/cli/issues/381

I haven't gotten a chance to test this on Windows but if the unzipping works correctly, `go-update` should handle the upgrade correctly. 

I will be writing tests for this shortly. Just wanted to get something out there to iterate over. 