### PR TITLE
Fix broken CLI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The CLI provides a way to do the problems on [exercism.io](http://exercism.io).
 
-**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/cli)
+**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/cli) [link broken as of 22nd April 2017]
 
 This CLI ships as a binary with no additional runtime requirements. This means
 that if you're doing the Haskell problems on exercism you don't need a working

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The CLI provides a way to do the problems on [exercism.io](http://exercism.io).
 
-**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/cli) [link broken as of 22nd April 2017]
+**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/client/cli)
 
 This CLI ships as a binary with no additional runtime requirements. This means
 that if you're doing the Haskell problems on exercism you don't need a working

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The CLI provides a way to do the problems on [exercism.io](http://exercism.io).
 
-**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/client/cli)
+**Important**: If you're looking for instructions on how to install the CLI. Please read [Installing the CLI](http://exercism.io/clients/cli)
 
 This CLI ships as a binary with no additional runtime requirements. This means
 that if you're doing the Haskell problems on exercism you don't need a working


### PR DESCRIPTION
The page exercism.io/cli gives 404; better indicate that in README or fix it.