### PR TITLE
Support the two most recent releases of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.6
   - 1.7
+  - 1.8
   - tip
 
 install: true


### PR DESCRIPTION
1.8 was released recently, let's remove support for 1.6 and add 1.8