### PR TITLE
[nextercism] Handle config directories that don't exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,5 +46,17 @@ func Write(f filer) error {
 	if err != nil {
 		return err
 	}
+	if err := ensureDir(f); err != nil {
+		return err
+	}
 	return ioutil.WriteFile(f.File(), b, os.FileMode(0644))
+}
+
+func ensureDir(f filer) error {
+	dir := filepath.Dir(f.File())
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(dir, os.FileMode(0755))
+	}
+	return err
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -25,9 +26,12 @@ func (cfg *fakeConfig) load(v *viper.Viper) error {
 }
 
 func TestFakeConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fake-config")
+	tmpDir, err := ioutil.TempDir("", "fake-config")
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(tmpDir)
+
+	// Set the config directory to a directory that doesn't exist.
+	dir := filepath.Join(tmpDir, "exercism")
 
 	// It has access to the embedded fields.
 	cfg := &fakeConfig{


### PR DESCRIPTION
While the normal config home, `~/.config` typically exists, we're
defining the app's config home to be a directory 'exercism' within
that directory, and that will almost certainly not exist.

Came across this problem as I was working on https://github.com/exercism/cli/issues/417