### PR TITLE
[nextercism] Illustrate the interplay between the config and viper

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,13 +41,36 @@ func TestFakeConfig(t *testing.T) {
 	assert.Equal(t, dir, cfg.dir)
 	assert.Equal(t, "fake", cfg.name)
 
+	// We're going to load up a viper that is bound to some command-line flags.
+	// First we need flags.
+	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flagSet.IntP("number", "n", 0, "pick a number, any number")
+	flagSet.StringP("letter", "l", "", "something from a nice alphabet")
+	flagSet.Set("number", "1")
+	flagSet.Set("letter", "a")
+
+	// Bind the flags to a new viper value.
+	v := viper.New()
+	v.BindPFlag("number", flagSet.Lookup("number"))
+	v.BindPFlag("letter", flagSet.Lookup("letter"))
+
+	// Binding the flags loaded the values into viper.
+	assert.Equal(t, 1, v.Get("number"))
+	assert.Equal(t, "a", v.Get("letter"))
+
+	// Load viper into the config value.
+	err = cfg.load(v)
+	assert.NoError(t, err)
+
+	// The original flag values have been loaded into the struct value.
+	assert.Equal(t, 1, cfg.Number)
+	assert.Equal(t, "a", cfg.Letter)
+
 	// Write the file.
-	cfg.Letter = "a"
-	cfg.Number = 1
 	err = cfg.write()
 	assert.NoError(t, err)
 
-	// reload it
+	// Reload it.
 	cfg = &fakeConfig{
 		Config: New(dir, "fake"),
 	}


### PR DESCRIPTION
Viper can be tricky to test, as there are very few readable examples out there.
This will give us something to refer back to later. It also shows that the viper integration
actually works, which is never a bad thing.

This came out of experimentation I was doing to solve https://github.com/exercism/cli/issues/417