### PR TITLE
[nextercism] Normalize the user config before writing it

### DIFF
--- a/config/user_config.go
+++ b/config/user_config.go
@@ -87,5 +87,9 @@ func (cfg *UserConfig) resolve(path string) string {
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path)
 	}
-	return filepath.Join(cfg.Home, path)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(cwd, path)
 }

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -62,7 +62,7 @@ func userHome() string {
 	} else {
 		dir = os.Getenv("HOME")
 		if dir != "" {
-			return ""
+			return dir
 		}
 	}
 	// If all else fails, use the current directory.

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -20,7 +20,6 @@ type UserConfig struct {
 // NewUserConfig loads a user configuration if it exists.
 func NewUserConfig() (*UserConfig, error) {
 	cfg := NewEmptyUserConfig()
-	cfg.Home = userHome()
 
 	if err := cfg.Load(viper.New()); err != nil {
 		return nil, err
@@ -36,9 +35,17 @@ func NewEmptyUserConfig() *UserConfig {
 	}
 }
 
+// Normalize ensures that we have proper values where possible.
+func (cfg *UserConfig) Normalize() {
+	if cfg.Home == "" {
+		cfg.Home = userHome()
+	}
+	cfg.Workspace = cfg.resolve(cfg.Workspace)
+}
+
 // Write stores the config to disk.
 func (cfg *UserConfig) Write() error {
-	cfg.Workspace = cfg.resolve(cfg.Workspace)
+	cfg.Normalize()
 	return Write(cfg)
 }
 
@@ -71,6 +78,9 @@ func userHome() string {
 }
 
 func (cfg *UserConfig) resolve(path string) string {
+	if path == "" {
+		return ""
+	}
 	if strings.HasPrefix(path, "~"+string(os.PathSeparator)) {
 		return strings.Replace(path, "~", cfg.Home, 1)
 	}

--- a/config/user_config_darwin_test.go
+++ b/config/user_config_darwin_test.go
@@ -12,6 +12,7 @@ func TestNormalizeWorkspace(t *testing.T) {
 	tests := []struct {
 		in, out string
 	}{
+		{"", ""}, // don't make wild guesses
 		{"/home/alice///foobar", "/home/alice/foobar"},
 		{"~/foobar", "/home/alice/foobar"},
 		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
@@ -21,6 +22,8 @@ func TestNormalizeWorkspace(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.out, cfg.resolve(test.in))
+		cfg.Workspace = test.in
+		cfg.Normalize()
+		assert.Equal(t, test.out, cfg.Workspace)
 	}
 }

--- a/config/user_config_darwin_test.go
+++ b/config/user_config_darwin_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -8,6 +9,9 @@ import (
 )
 
 func TestNormalizeWorkspace(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
 	cfg := &UserConfig{Home: "/home/alice"}
 	tests := []struct {
 		in, out string
@@ -17,8 +21,8 @@ func TestNormalizeWorkspace(t *testing.T) {
 		{"~/foobar", "/home/alice/foobar"},
 		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
 		{"/no/modification", "/no/modification"},
-		{"relative", filepath.Join(cfg.Home, "relative")},
-		{"relative///path", filepath.Join(cfg.Home, "relative", "path")},
+		{"relative", filepath.Join(cwd, "relative")},
+		{"relative///path", filepath.Join(cwd, "relative", "path")},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Set home on the config in the normalize method rather than always setting it.

As I was troubleshooting this I discovered a silly bug where I was returning an empty string for the home directory if I found one.

This is related to the work I'm doing for https://github.com/exercism/cli/issues/417

