### PR TITLE
[nextercism] Implement configure command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"log"
+	"os"
+)
+
+// Bail handles exitable errors in commands.
+// TODO: figure out what goes here.
+func Bail(err error) {
+	log.Println(err)
+	os.Exit(1)
+}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/exercism/cli/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	viperUserConfig *viper.Viper
+	viperAPIConfig  *viper.Viper
 )
 
 // configureCmd configures the command-line client with user-specific settings.
@@ -20,10 +25,41 @@ places.
 You can also override certain default settings to suit your preferences.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("configure called")
+		usrCfg := config.NewEmptyUserConfig()
+		if err := usrCfg.Load(viperUserConfig); err != nil {
+			Bail(err)
+		}
+		if err := usrCfg.Write(); err != nil {
+			Bail(err)
+		}
+
+		apiCfg := config.NewEmptyAPIConfig()
+		if err := apiCfg.Load(viperAPIConfig); err != nil {
+			Bail(err)
+		}
+		if err := apiCfg.Write(); err != nil {
+			Bail(err)
+		}
+
+		return
 	},
+}
+
+func initConfigureCfg() {
+	configureCmd.Flags().StringP("token", "t", "", "authentication token used to connect to exercism.io")
+	configureCmd.Flags().StringP("workspace", "w", "", "directory for exercism exercises")
+	configureCmd.Flags().StringP("api", "a", "", "API base url")
+
+	viperUserConfig = viper.New()
+	viperUserConfig.BindPFlag("token", configureCmd.Flags().Lookup("token"))
+	viperUserConfig.BindPFlag("workspace", configureCmd.Flags().Lookup("workspace"))
+
+	viperAPIConfig = viper.New()
+	viperAPIConfig.BindPFlag("baseurl", configureCmd.Flags().Lookup("api"))
 }
 
 func init() {
 	RootCmd.AddCommand(configureCmd)
+
+	initConfigureCfg()
 }

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/exercism/cli/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigure(t *testing.T) {
+	// Make sure we put back the config env var.
+	cfgHomeKey := "EXERCISM_CONFIG_HOME"
+	cfgHome := os.Getenv(cfgHomeKey)
+	defer os.Setenv(cfgHomeKey, cfgHome)
+
+	// Make sure we put back the real command-line arguments.
+	osArgs := os.Args
+	defer func() {
+		os.Args = osArgs
+	}()
+
+	// Set up a bogus root command.
+	fakeCmd := &cobra.Command{}
+	// Add the real configureCmd to it.
+	fakeCmd.AddCommand(configureCmd)
+
+	tests := []struct {
+		args           []string
+		existingUsrCfg *config.UserConfig
+		expectedUsrCfg *config.UserConfig
+		existingAPICfg *config.APIConfig
+		expectedAPICfg *config.APIConfig
+	}{
+		{
+			// It writes the flags when there is no config file.
+			args:           []string{"fakeapp", "configure", "--token", "a", "--workspace", "/a", "--api", "http://example.com"},
+			existingUsrCfg: nil,
+			expectedUsrCfg: &config.UserConfig{Token: "a", Workspace: "/a"},
+			existingAPICfg: nil,
+			expectedAPICfg: &config.APIConfig{BaseURL: "http://example.com"},
+		},
+		{
+			// It overwrites the flags in the config file.
+			args:           []string{"fakeapp", "configure", "--token", "b", "--workspace", "/b", "--api", "http://example.com/v2"},
+			existingUsrCfg: &config.UserConfig{Token: "token-b", Workspace: "/workspace-b"},
+			expectedUsrCfg: &config.UserConfig{Token: "b", Workspace: "/b"},
+			existingAPICfg: &config.APIConfig{BaseURL: "http://example.com/v1"},
+			expectedAPICfg: &config.APIConfig{BaseURL: "http://example.com/v2"},
+		},
+		{
+			args: []string{"fakeapp", "configure", "--token", "c"},
+			// It overwrites the flags that are passed without losing the ones that are not.
+			existingUsrCfg: &config.UserConfig{Token: "token-c", Workspace: "/workspace-c"},
+			expectedUsrCfg: &config.UserConfig{Token: "c", Workspace: "/workspace-c"},
+			// It gets the default API base URL.
+			existingAPICfg: &config.APIConfig{},
+			expectedAPICfg: &config.APIConfig{BaseURL: "https://api.exercism.com/v1"},
+		},
+	}
+
+	for i, test := range tests {
+		// Create a fake config dir.
+		dir, err := ioutil.TempDir("", fmt.Sprintf("user-config-%d", i))
+		assert.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		// Override the environment to use the fake config dir.
+		os.Setenv(cfgHomeKey, dir)
+
+		if test.existingUsrCfg != nil {
+			// Write a fake config.
+			cfg := config.NewEmptyUserConfig()
+			cfg.Token = test.existingUsrCfg.Token
+			cfg.Workspace = test.existingUsrCfg.Workspace
+			err = cfg.Write()
+			assert.NoError(t, err)
+		}
+
+		// Fake out the command-line arguments with the correct subcommand.
+		os.Args = test.args
+
+		// Re-initialize the command so it picks up the fake environment.
+		configureCmd.ResetFlags()
+		// Rerun the config initialization so that the flags get bound properly.
+		initConfigureCfg()
+
+		// Finally. Execute the configure command.
+		fakeCmd.Execute()
+
+		// Now let's get a new config and see that it got written properly.
+		usrCfg, err := config.NewUserConfig()
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.expectedUsrCfg.Token, usrCfg.Token)
+		assert.Equal(t, test.expectedUsrCfg.Workspace, usrCfg.Workspace)
+
+		apiCfg, err := config.NewAPIConfig()
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.expectedAPICfg.BaseURL, apiCfg.BaseURL)
+	}
+}

--- a/config/api_config_test.go
+++ b/config/api_config_test.go
@@ -37,3 +37,32 @@ func TestAPIConfig(t *testing.T) {
 	assert.Equal(t, "/a", cfg.Endpoints["a"])
 	assert.Equal(t, "/b", cfg.Endpoints["b"])
 }
+
+func TestAPIConfigSetDefaults(t *testing.T) {
+	// All defaults.
+	cfg := &APIConfig{}
+	cfg.SetDefaults()
+	assert.Equal(t, "https://api.exercism.com/v1", cfg.BaseURL)
+	assert.Equal(t, "/solutions/%s", cfg.Endpoints["download"])
+	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
+
+	// Override just the base url.
+	cfg = &APIConfig{
+		BaseURL: "http://example.com/v1",
+	}
+	cfg.SetDefaults()
+	assert.Equal(t, "http://example.com/v1", cfg.BaseURL)
+	assert.Equal(t, "/solutions/%s", cfg.Endpoints["download"])
+	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
+
+	// Override just one of the endpoints.
+	cfg = &APIConfig{
+		Endpoints: map[string]string{
+			"download": "/download/%d",
+		},
+	}
+	cfg.SetDefaults()
+	assert.Equal(t, "https://api.exercism.com/v1", cfg.BaseURL)
+	assert.Equal(t, "/download/%d", cfg.Endpoints["download"])
+	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
+}


### PR DESCRIPTION

For now this takes a token, a workspace, and the base URL of the API.

We will eventually want to add more flags, but that should be trivial compared to figuring out how to combine all the pieces (and write tests) in the first place.

Closes https://github.com/exercism/cli/issues/417