### PR TITLE
[nextercism] Create solution metadata

### DIFF
--- a/visibility/hide_file.go
+++ b/visibility/hide_file.go
@@ -1,0 +1,7 @@
+// +build !windows
+package visibility
+
+// HideFile is a no-op for non-Windows systems.
+func HideFile(string) error {
+	return nil
+}

--- a/visibility/hide_file_windows.go
+++ b/visibility/hide_file_windows.go
@@ -1,0 +1,27 @@
+package visibility
+
+import "syscall"
+
+// HideFile sets a Windows file's 'hidden' attribute.
+// This is the equivalent of giving a filename on
+// Linux or MacOS a leading dot (e.g. .bash_rc).
+func HideFile(path string) error {
+	// This is based on the discussion in
+	// https://www.reddit.com/r/golang/comments/5t3ezd/hidden_files_directories/
+	// but instead of duplicating all the effort to write the file, this takes
+	// the path of a written file and then flips the bit on the relevant attribute.
+	// The attributes are a bitmask (uint32), so we can't call
+	// SetFileAttributes(ptr, syscall.File_ATTRIBUTE_HIDDEN) as suggested, since
+	// that would wipe out any existing attributes.
+	ptr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attributes, err := syscall.GetFileAttributes(ptr)
+	if err != nil {
+		return err
+	}
+
+	attributes |= syscall.FILE_ATTRIBUTE_HIDDEN
+	return syscall.SetFileAttributes(ptr, attributes)
+}

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/exercism/cli/visibility"
@@ -37,6 +38,13 @@ func NewSolution(dir string) (Solution, error) {
 	}
 	s.Dir = dir
 	return s, nil
+}
+
+// Suffix is the serial numeric value appended to an exercise directory.
+// This is appended to avoid name conflicts, and does not indicate a particular
+// iteration.
+func (s Solution) Suffix() string {
+	return strings.Trim(strings.Replace(filepath.Base(s.Dir), s.Exercise, "", 1), "-.")
 }
 
 // Write stores solution metadata to a file.

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -45,6 +46,17 @@ func NewSolution(dir string) (Solution, error) {
 // iteration.
 func (s Solution) Suffix() string {
 	return strings.Trim(strings.Replace(filepath.Base(s.Dir), s.Exercise, "", 1), "-.")
+}
+
+func (s Solution) String() string {
+	str := fmt.Sprintf("%s/%s", s.Track, s.Exercise)
+	if s.Suffix() != "" {
+		str = fmt.Sprintf("%s (%s)", str, s.Suffix())
+	}
+	if !s.IsRequester && s.Handle != "" {
+		str = fmt.Sprintf("%s by @%s", str, s.Handle)
+	}
+	return str
 }
 
 // Write stores solution metadata to a file.

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -1,0 +1,46 @@
+package workspace
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const solutionFilename = ".solution.json"
+
+// Solution contains metadata about a user's solution.
+type Solution struct {
+	Track       string    `json:"track"`
+	Exercise    string    `json:"exercise"`
+	ID          string    `json:"id"`
+	URL         string    `json:"url"`
+	Handle      string    `json:"handle"`
+	IsRequester bool      `json:"is_requester"`
+	SubmittedAt time.Time `json:"submitted_at"`
+}
+
+// NewSolution reads solution metadata from a file in the given directory.
+func NewSolution(dir string) (Solution, error) {
+	path := filepath.Join(dir, solutionFilename)
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return Solution{}, err
+	}
+	var s Solution
+	if err := json.Unmarshal(b, &s); err != nil {
+		return Solution{}, err
+	}
+	return s, nil
+}
+
+// Write stores solution metadata to a file.
+func (s Solution) Write(dir string) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, solutionFilename)
+	return ioutil.WriteFile(path, b, os.FileMode(0644))
+}

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/exercism/cli/visibility"
 )
 
 const solutionFilename = ".solution.json"
@@ -42,5 +44,8 @@ func (s Solution) Write(dir string) error {
 		return err
 	}
 	path := filepath.Join(dir, solutionFilename)
-	return ioutil.WriteFile(path, b, os.FileMode(0644))
+	if err := ioutil.WriteFile(path, b, os.FileMode(0644)); err != nil {
+		return err
+	}
+	return visibility.HideFile(path)
 }

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -21,6 +21,7 @@ type Solution struct {
 	Handle      string     `json:"handle"`
 	IsRequester bool       `json:"is_requester"`
 	SubmittedAt *time.Time `json:"submitted_at,omitempty"`
+	Dir         string     `json:"-"`
 }
 
 // NewSolution reads solution metadata from a file in the given directory.
@@ -34,6 +35,7 @@ func NewSolution(dir string) (Solution, error) {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return Solution{}, err
 	}
+	s.Dir = dir
 	return s, nil
 }
 

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -12,13 +12,13 @@ const solutionFilename = ".solution.json"
 
 // Solution contains metadata about a user's solution.
 type Solution struct {
-	Track       string    `json:"track"`
-	Exercise    string    `json:"exercise"`
-	ID          string    `json:"id"`
-	URL         string    `json:"url"`
-	Handle      string    `json:"handle"`
-	IsRequester bool      `json:"is_requester"`
-	SubmittedAt time.Time `json:"submitted_at"`
+	Track       string     `json:"track"`
+	Exercise    string     `json:"exercise"`
+	ID          string     `json:"id"`
+	URL         string     `json:"url"`
+	Handle      string     `json:"handle"`
+	IsRequester bool       `json:"is_requester"`
+	SubmittedAt *time.Time `json:"submitted_at,omitempty"`
 }
 
 // NewSolution reads solution metadata from a file in the given directory.

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -81,3 +81,62 @@ func TestSuffix(t *testing.T) {
 		assert.Equal(t, test.suffix, test.solution.Suffix())
 	}
 }
+
+func TestSolutionString(t *testing.T) {
+	tests := []struct {
+		solution Solution
+		desc     string
+	}{
+		{
+			solution: Solution{
+				Track:    "elixir",
+				Exercise: "secret-handshake",
+				Handle:   "",
+				Dir:      "",
+			},
+			desc: "elixir/secret-handshake",
+		},
+		{
+			solution: Solution{
+				Track:       "cpp",
+				Exercise:    "clock",
+				Handle:      "alice",
+				IsRequester: true,
+			},
+			desc: "cpp/clock",
+		},
+		{
+			solution: Solution{
+				Track:       "cpp",
+				Exercise:    "clock",
+				Handle:      "alice",
+				IsRequester: true,
+				Dir:         "/path/to/clock-2",
+			},
+			desc: "cpp/clock (2)",
+		},
+		{
+			solution: Solution{
+				Track:       "fsharp",
+				Exercise:    "hello-world",
+				Handle:      "bob",
+				IsRequester: false,
+			},
+			desc: "fsharp/hello-world by @bob",
+		},
+		{
+			solution: Solution{
+				Track:       "haskell",
+				Exercise:    "allergies",
+				Handle:      "charlie",
+				IsRequester: false,
+				Dir:         "/path/to/allergies-2",
+			},
+			desc: "haskell/allergies (2) by @charlie",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.desc, test.solution.String())
+	}
+}

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -21,6 +21,7 @@ func TestSolution(t *testing.T) {
 		URL:         "http://example.com",
 		Handle:      "alice",
 		IsRequester: true,
+		Dir:         dir,
 	}
 	err = s1.Write(dir)
 	assert.NoError(t, err)

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -41,3 +41,43 @@ func TestSolution(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, s2, s3)
 }
+
+func TestSuffix(t *testing.T) {
+	tests := []struct {
+		solution Solution
+		suffix   string
+	}{
+		{
+			solution: Solution{
+				Exercise: "bat",
+				Dir:      "",
+			},
+			suffix: "",
+		},
+		{
+			solution: Solution{
+				Exercise: "bat",
+				Dir:      "/path/to/bat",
+			},
+			suffix: "",
+		},
+		{
+			solution: Solution{
+				Exercise: "bat",
+				Dir:      "/path/to/bat-2",
+			},
+			suffix: "2",
+		},
+		{
+			solution: Solution{
+				Exercise: "bat",
+				Dir:      "/path/to/bat-200",
+			},
+			suffix: "200",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.suffix, test.solution.Suffix())
+	}
+}

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -21,13 +21,22 @@ func TestSolution(t *testing.T) {
 		URL:         "http://example.com",
 		Handle:      "alice",
 		IsRequester: true,
-		SubmittedAt: time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC),
 	}
 	err = s1.Write(dir)
 	assert.NoError(t, err)
 
 	s2, err := NewSolution(dir)
 	assert.NoError(t, err)
-
+	assert.Nil(t, s2.SubmittedAt)
 	assert.Equal(t, s1, s2)
+
+	ts := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
+	s2.SubmittedAt = &ts
+
+	err = s2.Write(dir)
+	assert.NoError(t, err)
+
+	s3, err := NewSolution(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, s2, s3)
 }

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -1,0 +1,33 @@
+package workspace
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSolution(t *testing.T) {
+	dir, err := ioutil.TempDir("", "solution")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s1 := Solution{
+		Track:       "a-track",
+		Exercise:    "bogus-exercise",
+		ID:          "abc",
+		URL:         "http://example.com",
+		Handle:      "alice",
+		IsRequester: true,
+		SubmittedAt: time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC),
+	}
+	err = s1.Write(dir)
+	assert.NoError(t, err)
+
+	s2, err := NewSolution(dir)
+	assert.NoError(t, err)
+
+	assert.Equal(t, s1, s2)
+}


### PR DESCRIPTION
We are going to store some metadata about a solution in a hidden file.
This currently only hides the file on Linux/MacOS.
I need to work out the hidden file for Windows, presumably using
`syscall.SetFileAttributes(f, syscall.FILE_ATTRIBUTE_HIDDEN)`.

We're going to use this in the `download` (store the metadata), `submit` (find the solution id), and `open` (look up the web url) commands.