### PR TITLE
[nextercism] Avoid stack overflow on workspace errors

### DIFF
--- a/workspace/errors.go
+++ b/workspace/errors.go
@@ -9,11 +9,11 @@ type ErrNotInWorkspace string
 type ErrNotExist string
 
 func (err ErrNotInWorkspace) Error() string {
-	return fmt.Sprintf("%s not within workspace", err)
+	return fmt.Sprintf("%s not within workspace", string(err))
 }
 
 func (err ErrNotExist) Error() string {
-	return fmt.Sprintf("%s not found", err)
+	return fmt.Sprintf("%s not found", string(err))
 }
 
 // IsNotInWorkspace checks if this is an ErrNotInWorkspace error.


### PR DESCRIPTION
Including an err in a format string calls Error() on it... including err in a format
string _in_ Error() calls Error() which calls Error() which calls Error()...

Yeah. So that happened.