### PR TITLE
[nextercism] Implement open command

### DIFF
--- a/workspace/solutions.go
+++ b/workspace/solutions.go
@@ -1,0 +1,65 @@
+package workspace
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Solutions is a collection of solutions to interactively choose from.
+type Solutions []Solution
+
+// Pick lets a user interactively select a solution from a list.
+func (sx Solutions) Pick(prompt string) (Solution, error) {
+	// If there's just one, then we're done here.
+	if len(sx) == 1 {
+		return sx[0], nil
+	}
+
+	fmt.Printf(prompt, sx.Display())
+
+	n, err := sx.ReadSelection(os.Stdin)
+	if err != nil {
+		return Solution{}, err
+	}
+
+	s, err := sx.Get(n)
+	if err != nil {
+		return Solution{}, err
+	}
+	return s, nil
+}
+
+// Display shows a numbered list of the solutions to choose from.
+// The list starts at 1, since that seems better in a user interface.
+func (sx Solutions) Display() string {
+	str := ""
+	for i, s := range sx {
+		str += fmt.Sprintf("  [%d] %s\n", i+1, s)
+	}
+	return str
+}
+
+// ReadSelection reads the user's selection and converts it to a number.
+func (sx Solutions) ReadSelection(r io.Reader) (int, error) {
+	reader := bufio.NewReader(r)
+	text, _ := reader.ReadString('\n')
+	n, err := strconv.Atoi(strings.TrimSpace(text))
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// Get returns the solution corresponding to the number.
+// The list starts at 1, since that seems better in a user interface.
+func (sx Solutions) Get(n int) (Solution, error) {
+	if n <= 0 || n > len(sx) {
+		return Solution{}, errors.New("can't do that")
+	}
+	return sx[n-1], nil
+}

--- a/workspace/solutions_test.go
+++ b/workspace/solutions_test.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSolutions(t *testing.T) {
+	solutions := []Solution{
+		{Track: "a", Exercise: "foo"},
+		{Track: "b", Exercise: "foo"},
+		{Track: "c", Exercise: "foo"},
+	}
+	sx := Solutions(solutions)
+	display := "  [1] a/foo\n  [2] b/foo\n  [3] c/foo\n"
+	assert.Equal(t, display, sx.Display())
+
+	_, err := sx.Get(0)
+	assert.Error(t, err)
+
+	a, err := sx.Get(1)
+	assert.NoError(t, err)
+	assert.Equal(t, "a", a.Track)
+
+	b, err := sx.Get(2)
+	assert.NoError(t, err)
+	assert.Equal(t, "b", b.Track)
+
+	c, err := sx.Get(3)
+	assert.NoError(t, err)
+	assert.Equal(t, "c", c.Track)
+
+	_, err = sx.Get(4)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This tries to be a little bit clever, but it's not yet smooth enough.

The command can open your own exercises or other people's. For other people's exercises, you need to specify the path to the exercise, as I imagine you'll quickly have a gajillion of these.

The logic here is: given the input, locate the possible matches. If there are no possible matches, we're done. If there are more than one match, we need to disambiguate. But if there are more than one, then it wasn't a search by path, it was a search by name. That means that we found everything by you _and_ other people. So we need to filter out the results that aren't yours.

Finally, provide an interactive selection, and let them pick the one that they want to open.

The error handling could use some work here, I just don't know where to go with it.

Closes #416 