### PR TITLE
[nextercism] Fix the incorrect instructions for testing on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ go test $(go list ./... | grep -v vendor)
 On Windows, the command is more painful (sorry!):
 
 ```
-for /f "" %G in ('go list ./... ^| find /i /v "/vendor/"') do @go test %G
+for /f "" %%G in ('go list ./... ^| find /i /v "/vendor/"') do (go test %%G & IF ERRORLEVEL == 1 EXIT 1)
 ```
 
 As of Go 1.9 this is simplified to `go test ./...`.


### PR DESCRIPTION
The comment that I was directed to about how to test without vendor on
Windows turned out to not work.

Dave Cheney pointed me to something that does.

@robphoenix would you mind testing this on your Windows machine before we merge this?