### PR TITLE
[nextercism] Implement version command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -79,7 +79,7 @@ func (c *CLI) IsUpToDate() (bool, error) {
 		return false, fmt.Errorf("unable to parse current version (%s): %s", c.Version, err)
 	}
 
-	return rv.EQ(cv), nil
+	return cv.GTE(rv), nil
 }
 
 // Upgrade allows the user to upgrade to the latest version of the CLI.

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -15,8 +15,30 @@ func TestIsUpToDate(t *testing.T) {
 		releaseTag string
 		ok         bool
 	}{
-		{"1.0.0", "v1.0.1", false},
-		{"2.0.1", "v2.0.1", true},
+		{
+			// It returns false for versions less than release.
+			cliVersion: "1.0.0",
+			releaseTag: "v1.0.1",
+			ok:         false,
+		},
+		{
+			// It returns false for pre-release versions of release.
+			cliVersion: "1.0.1-alpha.1",
+			releaseTag: "v1.0.1",
+			ok:         false,
+		},
+		{
+			// It returns true for versions equal to release.
+			cliVersion: "2.0.1",
+			releaseTag: "v2.0.1",
+			ok:         true,
+		},
+		{
+			// It returns true for versions greater than release.
+			cliVersion: "2.0.2",
+			releaseTag: "v2.0.1",
+			ok:         true,
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/exercism/cli/cli"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentVersion(t *testing.T) {
+	expected := fmt.Sprintf("exercism version %s", Version)
+
+	actual := currentVersion()
+	assert.Equal(t, expected, actual)
+}
+
+func TestVersionUpdateCheck(t *testing.T) {
+	fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"tag_name": "v2.0.0"}`)
+	})
+	ts := httptest.NewServer(fakeEndpoint)
+	defer ts.Close()
+	cli.LatestReleaseURL = ts.URL
+
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{
+			// It returns new version available for versions older than latest.
+			version:  "1.0.0",
+			expected: "A new CLI version is available. Run `exercism upgrade` to update to 2.0.0",
+		},
+		{
+			// It returns up to date for versions matching latest.
+			version:  "2.0.0",
+			expected: "Your CLI version is up to date.",
+		},
+		{
+			// It returns up to date for versions newer than latest.
+			version:  "2.0.1",
+			expected: "Your CLI version is up to date.",
+		},
+	}
+
+	for _, test := range tests {
+		c := &cli.CLI{
+			Version: test.version,
+		}
+
+		actual, err := checkForUpdate(c)
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, actual)
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
First stab at the version command. I will most likely split the `func showVersion` up so that the command output can be tested. Also need to add mock test for checking latest against current version. 