### PR TITLE
[nextercism] Refactor Bail function to BailOnError

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,9 +5,11 @@ import (
 	"os"
 )
 
-// Bail handles exitable errors in commands.
+// BailOnError handles exitable errors in commands.
 // TODO: figure out what goes here.
-func Bail(err error) {
-	log.Println(err)
-	os.Exit(1)
+func BailOnError(err error) {
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -26,20 +26,20 @@ You can also override certain default settings to suit your preferences.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		usrCfg := config.NewEmptyUserConfig()
-		if err := usrCfg.Load(viperUserConfig); err != nil {
-			Bail(err)
-		}
-		if err := usrCfg.Write(); err != nil {
-			Bail(err)
-		}
+
+		err := usrCfg.Load(viperUserConfig)
+		BailOnError(err)
+
+		err = usrCfg.Write()
+		BailOnError(err)
 
 		apiCfg := config.NewEmptyAPIConfig()
-		if err := apiCfg.Load(viperAPIConfig); err != nil {
-			Bail(err)
-		}
-		if err := apiCfg.Write(); err != nil {
-			Bail(err)
-		}
+
+		err = apiCfg.Load(viperAPIConfig)
+		BailOnError(err)
+
+		err = apiCfg.Write()
+		BailOnError(err)
 
 		return
 	},


### PR DESCRIPTION
Ref https://github.com/exercism/cli/pull/410#discussion_r132183548

I briefly considered
```
BailOnError(usrCfg.Load(viperUserConfig))
```
but decided against for readability.

Not as much work as I thought it might be.