### PR TITLE
Normalize the init function name in configure

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -45,7 +45,7 @@ You can also override certain default settings to suit your preferences.
 	},
 }
 
-func initConfigureCfg() {
+func initConfigureCmd() {
 	configureCmd.Flags().StringP("token", "t", "", "authentication token used to connect to exercism.io")
 	configureCmd.Flags().StringP("workspace", "w", "", "directory for exercism exercises")
 	configureCmd.Flags().StringP("api", "a", "", "API base url")
@@ -61,5 +61,5 @@ func initConfigureCfg() {
 func init() {
 	RootCmd.AddCommand(configureCmd)
 
-	initConfigureCfg()
+	initConfigureCmd()
 }

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -86,7 +86,7 @@ func TestConfigure(t *testing.T) {
 		// Re-initialize the command so it picks up the fake environment.
 		configureCmd.ResetFlags()
 		// Rerun the config initialization so that the flags get bound properly.
-		initConfigureCfg()
+		initConfigureCmd()
 
 		// Finally. Execute the configure command.
 		fakeCmd.Execute()


### PR DESCRIPTION
Even though we're initializing configuration values here, the general concept is that
we're doing custom initialization for this particular command. In other commands we
will need to initialize flags but not config.

To make this a bit clearer I'm going with initSomethingCmd where Something is the name of
the command.

This is a tiny change and I'm just going to go ahead and merge it. Just wanted to give a heads up.

FYI - @robphoenix @nywilken @Tonkpils 