### PR TITLE
[nextercism] Implement prepare command

### DIFF
--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 
+	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +14,7 @@ import (
 var prepareCmd = &cobra.Command{
 	Use:     "prepare",
 	Aliases: []string{"p"},
-	Short:   "Prepare does generic setup for Exercism and its tracks.",
+	Short:   "Prepare does setup for Exercism and its tracks.",
 	Long: `Prepare downloads settings and dependencies for Exercism and the language tracks.
 
 When called without any arguments, this downloads all the copy for the CLI so we
@@ -20,13 +24,73 @@ of the API endpoints to use.
 When called with a track ID, it will do specific setup for that track. This
 might include downloading the files that the track maintainers have said are
 necessary for the track in general. Any files that are only necessary for a specific
-exercise will only be downloaded with the exercise.
+exercise will be downloaded along with the exercise.
 
 To customize the CLI to suit your own preferences, use the configure command.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("prepare called")
+		track, err := cmd.Flags().GetString("track")
+		BailOnError(err)
+
+		if track == "" {
+			fmt.Println("prepare called")
+			return
+		}
+		err = prepareTrack(track)
+		BailOnError(err)
 	},
+}
+
+func prepareTrack(id string) error {
+	apiCfg, err := config.NewAPIConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClient()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf(apiCfg.URL("prepare-track"), id)
+
+	req, err := client.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	payload := &prepareTrackPayload{}
+	res, err := client.Do(req, payload)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return errors.New("api call failed")
+	}
+
+	cliCfg, err := config.NewCLIConfig()
+	if err != nil {
+		return err
+	}
+
+	t, ok := cliCfg.Tracks[id]
+	if !ok {
+		t = config.NewTrack(id)
+	}
+	if payload.Track.TestPattern != "" {
+		t.IgnorePatterns = append(t.IgnorePatterns, payload.Track.TestPattern)
+	}
+	cliCfg.Tracks[id] = t
+
+	return cliCfg.Write()
+}
+
+type prepareTrackPayload struct {
+	Track struct {
+		ID          string `json:"id"`
+		Language    string `json:"language"`
+		TestPattern string `json:"test_pattern"`
+	} `json:"track"`
 }
 
 func initPrepareCmd() {
@@ -35,4 +99,5 @@ func initPrepareCmd() {
 
 func init() {
 	RootCmd.AddCommand(prepareCmd)
+	initPrepareCmd()
 }

--- a/cmd/prepare_test.go
+++ b/cmd/prepare_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/exercism/cli/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareTrack(t *testing.T) {
+	cmdTest := &CommandTest{
+		Cmd:    prepareCmd,
+		InitFn: initPrepareCmd,
+		Args:   []string{"fakeapp", "prepare", "--track", "bogus"},
+	}
+	cmdTest.Setup(t)
+	defer cmdTest.Teardown(t)
+
+	fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := `
+		{
+			"track": {
+				"id": "bogus",
+				"language": "Bogus",
+				"test_pattern": "_spec[.]ext$"
+			}
+		}
+		`
+		fmt.Fprintln(w, payload)
+	})
+	ts := httptest.NewServer(fakeEndpoint)
+	defer ts.Close()
+
+	apiCfg := config.NewEmptyAPIConfig()
+	apiCfg.BaseURL = ts.URL
+	apiCfg.Endpoints = map[string]string{"prepare-track": "?%s"}
+	err := apiCfg.Write()
+	assert.NoError(t, err)
+
+	cmdTest.App.Execute()
+
+	cliCfg, err := config.NewCLIConfig()
+	assert.NoError(t, err)
+
+	expected := []string{
+		".*[.]md",
+		"[.]solution[.]json",
+		"_spec[.]ext$",
+	}
+	track := cliCfg.Tracks["bogus"]
+	if track == nil {
+		t.Fatal("track missing from config")
+	}
+	assert.Equal(t, expected, track.IgnorePatterns)
+}

--- a/config/api_config.go
+++ b/config/api_config.go
@@ -12,7 +12,7 @@ var (
 	defaultEndpoints = map[string]string{
 		"download":      "/solutions/%s",
 		"submit":        "/solutions/%s",
-		"prepare-track": "/tracks/%s/settings",
+		"prepare-track": "/tracks/%s",
 		"ping":          "/ping",
 	}
 )

--- a/config/cli_config_test.go
+++ b/config/cli_config_test.go
@@ -78,7 +78,7 @@ func TestCLIConfigSetDefaults(t *testing.T) {
 		Tracks: map[string]*Track{
 			"bogus": &Track{
 				ID:             "bogus",
-				IgnorePatterns: []string{".solution.json", "_spec[.]ext$"},
+				IgnorePatterns: []string{"[.]solution[.]json", "_spec[.]ext$"},
 			},
 		},
 	}

--- a/config/track.go
+++ b/config/track.go
@@ -6,8 +6,8 @@ import (
 )
 
 var defaultIgnorePatterns = []string{
-	".solution.json",
-	"README.md",
+	".*[.]md",
+	"[.]solution[.]json",
 }
 
 // Track holds the CLI-related settings for a track.


### PR DESCRIPTION
The prepare command will eventually need other things, but I don't know what they are yet. For now, we're just getting the test pattern from the track config so that we can filter files out when we submit them.

The prepare logic will also need to be called from the submit command in the case where we don't have the settings for the track yet. We need this when someone submits a solution by indicating a directory rather than a list of files, so that we can filter out files that shouldn't be submitted.

Closes #418 though I will be opening a new issue to deal with the auto-checking of last version etc, which still needs some hashing out.

We are also hashing out the details of the files to download during track setup (https://github.com/exercism/gnu-apl/pull/6). Once we've got that sorted, I'll open an issue describing what needs to be done.