### PR TITLE
[nextercism] Make the API URL function nicer and more useful

### DIFF
--- a/config/api_config.go
+++ b/config/api_config.go
@@ -55,8 +55,9 @@ func (cfg *APIConfig) SetDefaults() {
 }
 
 // URL provides the API URL for a given endpoint key.
-func (cfg *APIConfig) URL(key string) string {
-	return fmt.Sprintf("%s%s", cfg.BaseURL, cfg.Endpoints[key])
+func (cfg *APIConfig) URL(key string, args ...interface{}) string {
+	pattern := fmt.Sprintf("%s%s", cfg.BaseURL, cfg.Endpoints[key])
+	return fmt.Sprintf(pattern, args...)
 }
 
 // NewEmptyAPIConfig doesn't load the config from file or set default values.

--- a/config/api_config_test.go
+++ b/config/api_config_test.go
@@ -66,3 +66,16 @@ func TestAPIConfigSetDefaults(t *testing.T) {
 	assert.Equal(t, "/download/%d", cfg.Endpoints["download"])
 	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
 }
+
+func TestAPIConfigURL(t *testing.T) {
+	cfg := &APIConfig{
+		Endpoints: map[string]string{
+			"a": "a/%s/a",
+			"b": "b/%s/%d",
+			"c": "c/%s/%s/%s",
+		},
+	}
+	assert.Equal(t, "a/apple/a", cfg.URL("a", "apple"))
+	assert.Equal(t, "b/banana/2", cfg.URL("b", "banana", 2))
+	assert.Equal(t, "c/cherry/coca/cola", cfg.URL("c", "cherry", "coca", "cola"))
+}


### PR DESCRIPTION
This is used in some of the commands (other PRs and branches, some of which I've not submitted).

I had things like this:

```
url := fmt.Sprintf(apiCfg.URL("prepare-track"), id) 
```

Which I think is ugly and annoying. This lets us swap it out with 

```
url := apiCfg.URL("prepare-track", id) 
```

It's a variadic function, and we'll need to pay attention to what types of arguments each url placeholder takes, but we would have had to do that anyway.