### PR TITLE
[nextercism] Document the upgrade behavior on Windows

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -15,6 +15,10 @@ var upgradeCmd = &cobra.Command{
 
 	This finds and downloads the latest release, if you don't
 	already have it.
+
+	On Windows the old CLI will be left on disk, marked as hidden.
+	The next time you upgrade, the hidden file will be overwritten.
+	You can always delete this file.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("upgrade called")


### PR DESCRIPTION
We haven't implemented the upgrade command yet, but it's going
to be a straight port from the 2.x client. This adds the caveat
about the old CLI getting left on disk on Windows.

Closes #403