### PR TITLE
Create small abstraction for interactive -uh- interactions

### DIFF
--- a/comms/question.go
+++ b/comms/question.go
@@ -1,0 +1,36 @@
+package comms
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Question provides an interactive session.
+type Question struct {
+	Reader       io.Reader
+	Writer       io.Writer
+	Prompt       string
+	DefaultValue string
+}
+
+// Read reads the user's input.
+func (q Question) Read(r io.Reader) (string, error) {
+	reader := bufio.NewReader(r)
+	s, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	s = strings.Trim(s, "\n")
+	if s == "" {
+		return q.DefaultValue, nil
+	}
+	return s, nil
+}
+
+// Ask displays the prompt, then records the response.
+func (q *Question) Ask() (string, error) {
+	fmt.Fprintf(q.Writer, q.Prompt)
+	return q.Read(q.Reader)
+}

--- a/comms/question_test.go
+++ b/comms/question_test.go
@@ -1,0 +1,33 @@
+package comms
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuestion(t *testing.T) {
+	tests := []struct {
+		desc     string
+		given    string
+		fallback string
+		expected string
+	}{
+		{"records interactive response", "hello\n", "", "hello"},
+		{"responds with default if response is empty", "\n", "Fine.", "Fine."},
+	}
+	for _, test := range tests {
+		q := &Question{
+			Reader:       strings.NewReader(test.given),
+			Writer:       ioutil.Discard,
+			Prompt:       "Say something: ",
+			DefaultValue: test.fallback,
+		}
+
+		answer, err := q.Ask()
+		assert.NoError(t, err)
+		assert.Equal(t, answer, test.expected, test.desc)
+	}
+}


### PR DESCRIPTION
If someone tries downloading or submitting something before
they've configured their token or workspace, we're going to want
to ask them to paste it to us.

For the workspace we want to be able to provide a default suggestion.

This Question abstraction provides a very small wrapper around such
an interaction, and makes it testable by providing the Reader/Writer
which can be overwritten with pre-populated readers, or a writer that
discards everything.

I wonder if something like this would make the basis for a good Exercism
exercise. It took me a while to figure out how to make this both clean
and testable. E.g. how to not print random stuff to STDOUT while running
tests and how to stub in responses from a fake STDIN.