### PR TITLE
Update the travis matrix to run against 1.8, 1.9, and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.7
   - 1.8
+  - 1.9
   - tip
 
 install:


### PR DESCRIPTION
We've been using the pattern of only supporting one release behind the current, by keeping the travis matrix to:

- previous release
- current release
- tip

Go 1.9 was released on August 24th.

This update goes against the nextercism branch—I've not touched master in a while.