### PR TITLE
[nextercism] Replace references of os.Stdout with cmd.Out

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/exercism/cli/config"
@@ -41,7 +40,7 @@ You can also override certain default settings to suit your preferences.
 		BailOnError(err)
 
 		if show {
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			w := tabwriter.NewWriter(Out, 0, 0, 2, ' ', 0)
 			defer w.Flush()
 
 			fmt.Fprintln(w, "")

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -167,7 +167,7 @@ figuring things out if necessary.
 		_, err = bb.ReadFrom(resp.Body)
 		BailOnError(err)
 
-		fmt.Fprintf(out, "Submitted. View at %s\n", solution.URL)
+		fmt.Fprintf(Out, "Submitted. View at %s\n", solution.URL)
 	},
 }
 

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestSubmit(t *testing.T) {
-	oldOut := out
-	out = ioutil.Discard
-	defer func() { out = oldOut }()
+	oldOut := Out
+	Out = ioutil.Discard
+	defer func() { Out = oldOut }()
 
 	type file struct {
 		relativePath string

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -2,15 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/exercism/cli/cli"
 	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
 )
-
-var out io.Writer
 
 // upgradeCmd downloads and installs the most recent version of the CLI.
 var upgradeCmd = &cobra.Command{
@@ -45,7 +41,7 @@ func updateCLI(c cli.Updater) error {
 	}
 
 	if ok {
-		fmt.Fprintln(out, "Your CLI version is up to date.")
+		fmt.Fprintln(Out, "Your CLI version is up to date.")
 		return nil
 	}
 
@@ -55,5 +51,4 @@ func updateCLI(c cli.Updater) error {
 func init() {
 	RootCmd.AddCommand(upgradeCmd)
 	upgradeCmd.Flags().BoolP("verbose", "v", false, "verbose output")
-	out = os.Stdout
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -22,9 +22,9 @@ func (fc *fakeCLI) Upgrade() error {
 }
 
 func TestUpgrade(t *testing.T) {
-	oldOut := out
-	out = ioutil.Discard
-	defer func() { out = oldOut }()
+	oldOut := Out
+	Out = ioutil.Discard
+	defer func() { Out = oldOut }()
 
 	tests := []struct {
 		desc     string


### PR DESCRIPTION
This will consolidate command outputting to a package level io.Writer.