### PR TITLE
[nextercism] Implement submit success message pending AutoApprove

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -93,6 +93,7 @@ Download other people's solutions by providing the UUID.
 		}
 
 		solution := workspace.Solution{
+			AutoApprove: payload.Solution.Exercise.AutoApprove,
 			Track:       payload.Solution.Exercise.Track.ID,
 			Exercise:    payload.Solution.Exercise.ID,
 			ID:          payload.Solution.ID,

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -105,7 +105,7 @@ func TestDownload(t *testing.T) {
 		},
 		{
 			path:     filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", ".solution.json"),
-			contents: `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":true}`,
+			contents: `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":true,"auto_approve":false}`,
 		},
 	}
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -202,7 +202,15 @@ figuring things out if necessary.
 			return err
 		}
 
-		fmt.Fprintf(Out, "Submitted. View at %s\n", solution.URL)
+		if solution.AutoApprove == true {
+			fmt.Fprintf(Out, "Your solution has been submitted " +
+				"successfully and has been auto-approved. You can complete " +
+				"the exercise and unlock the next core exercise at %s\n",
+				solution.URL)
+		} else {
+			//TODO
+		}
+
 		return nil
 	},
 }

--- a/config/api_config.go
+++ b/config/api_config.go
@@ -57,7 +57,11 @@ func (cfg *APIConfig) SetDefaults() {
 // URL provides the API URL for a given endpoint key.
 func (cfg *APIConfig) URL(key string, args ...interface{}) string {
 	pattern := fmt.Sprintf("%s%s", cfg.BaseURL, cfg.Endpoints[key])
-	return fmt.Sprintf(pattern, args...)
+	if args != nil {
+		return fmt.Sprintf(pattern, args...)
+	}
+
+	return pattern
 }
 
 // NewEmptyAPIConfig doesn't load the config from file or set default values.

--- a/config/api_config.go
+++ b/config/api_config.go
@@ -57,11 +57,10 @@ func (cfg *APIConfig) SetDefaults() {
 // URL provides the API URL for a given endpoint key.
 func (cfg *APIConfig) URL(key string, args ...interface{}) string {
 	pattern := fmt.Sprintf("%s%s", cfg.BaseURL, cfg.Endpoints[key])
-	if args != nil {
-		return fmt.Sprintf(pattern, args...)
+	if args == nil {
+		return pattern
 	}
-
-	return pattern
+	return fmt.Sprintf(pattern, args...)
 }
 
 // NewEmptyAPIConfig doesn't load the config from file or set default values.

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -24,6 +24,7 @@ type Solution struct {
 	IsRequester bool       `json:"is_requester"`
 	SubmittedAt *time.Time `json:"submitted_at,omitempty"`
 	Dir         string     `json:"-"`
+	AutoApprove bool       `json:"auto_approve"`
 }
 
 // NewSolution reads solution metadata from a file in the given directory.


### PR DESCRIPTION
This will implement the success message upon submit, "Your solution has been submitted successfully and has been auto-approved. You can complete the exercise and unlock the next core exercise at $URL." in the case of `auto_approved: true`.
