### PR TITLE
Fix string format error in prepare command

### DIFF
--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -56,7 +56,7 @@ func prepareTrack(id string) error {
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf(apiCfg.URL("prepare-track"), id)
+	url := apiCfg.URL("prepare-track", id)
 
 	req, err := client.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
We changed the apiCfg to have a URL method which takes the URL identifier (e.g. prepare-track) and a slug. Then I forgot to pass the track ID to the method.

This re-arranges things to make the call correctly.

@aldraco this will fix the error you're seeing when calling `prepare`.