### PR TITLE
Stops panic for troubleshoot cmd when missing token

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -145,7 +145,7 @@ func newConfigurationStatus(status *Status) configurationStatus {
 		Token:     status.cfg.Token,
 		TokenURL:  "http://exercism.io/account/key",
 	}
-	if status.Censor {
+	if status.Censor && status.cfg.Token != "" {
 		cs.Token = redactToken(status.cfg.Token)
 	}
 	return cs


### PR DESCRIPTION
When running the "troubleshoot" sub-command for nexercism without having an API token set, the command will panic like so:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/exercism/cli/cli.redactToken(0x0, 0x0, 0x27, 0xc4200864c0)
	/home/andrew/go/src/github.com/exercism/cli/cli/status.go:170 +0xdb
github.com/exercism/cli/cli.newConfigurationStatus(0xc4200c48c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/andrew/go/src/github.com/exercism/cli/cli/status.go:149 +0x12b
github.com/exercism/cli/cli.(*Status).Check(0xc4200c48c0, 0xc4200c48c0, 0x0, 0xbd3d80, 0x4)
	/home/andrew/go/src/github.com/exercism/cli/cli/status.go:72 +0x117
github.com/exercism/cli/cmd.glob..func6(0xbd5a80, 0xc128b0, 0x0, 0x0, 0x0, 0x0)
	/home/andrew/go/src/github.com/exercism/cli/cmd/troubleshoot.go:37 +0x24f
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).execute(0xbd5a80, 0xc128b0, 0x0, 0x0, 0xbd5a80, 0xc128b0)
	/home/andrew/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:649 +0x456
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xbd5600, 0xc420072058, 0x0, 0x1)
	/home/andrew/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:728 +0x2fe
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).Execute(0xbd5600, 0x0, 0x0)
	/home/andrew/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:687 +0x2b
github.com/exercism/cli/cmd.Execute()
	/home/andrew/go/src/github.com/exercism/cli/cmd/root.go:36 +0x2d
main.main()
	/home/andrew/go/src/github.com/exercism/cli/exercism/main.go:6 +0x20
```

The patch checks to make sure that there is a token and if not, skips the redact function which causes the token to just be printed out as `<not configured>` with a link to where the user can get their token.