### PR TITLE
[nextercism] Interactive confirmation when submitting directory (#485)

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -36,13 +36,13 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // ...
 // cmdTest.App.Execute()
 type CommandTest struct {
-	App            *cobra.Command
-	Cmd            *cobra.Command
-	InitFn         func()
-	TmpDir         string
-	Args           []string
-	MockInput      string
-	OriginalValues struct {
+	App                     *cobra.Command
+	Cmd                     *cobra.Command
+	InitFn                  func()
+	TmpDir                  string
+	Args                    []string
+	MockInteractiveResponse string
+	OriginalValues          struct {
 		ConfigHome string
 		Args       []string
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -19,7 +19,7 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // in the Args will be ignored. These represent the command (e.g. exercism)
 // and the subcommand (e.g. download).
 // Pass any interactive responses needed for the test in a single
-// String in MockInput, separated by newlines.
+// String in MockInput, delimited by newlines.
 //
 // Finally, when you have done whatever other setup you need in your
 // test, call the command by calling Execute on the App.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -29,7 +29,7 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // 	Cmd:    myCmd,
 // 	InitFn: initMyCmd,
 // 	Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
-// 	MockInput: "first-input\nsecond\n",
+// 	MockInteractiveResponse: "first-input\nsecond\n",
 // }
 // cmdTest.Setup(t)
 // defer cmdTest.Teardown(t)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -29,7 +29,7 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // 	Cmd:    myCmd,
 // 	InitFn: initMyCmd,
 // 	Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
-//  MockInput: "first-input\nsecond\n"
+// 	MockInput: "first-input\nsecond\n",
 // }
 // cmdTest.Setup(t)
 // defer cmdTest.Teardown(t)
@@ -41,7 +41,7 @@ type CommandTest struct {
 	InitFn         func()
 	TmpDir         string
 	Args           []string
-	MockInput	   string
+	MockInput      string
 	OriginalValues struct {
 		ConfigHome string
 		Args       []string

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -18,6 +18,8 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // The args are the faked out os.Args. The first two arguments
 // in the Args will be ignored. These represent the command (e.g. exercism)
 // and the subcommand (e.g. download).
+// Pass any interactive responses needed for the test in a single
+// String in MockInput, separated by newlines.
 //
 // Finally, when you have done whatever other setup you need in your
 // test, call the command by calling Execute on the App.
@@ -27,6 +29,7 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // 	Cmd:    myCmd,
 // 	InitFn: initMyCmd,
 // 	Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
+//  MockInput: "first-input\nsecond\n"
 // }
 // cmdTest.Setup(t)
 // defer cmdTest.Teardown(t)
@@ -38,6 +41,7 @@ type CommandTest struct {
 	InitFn         func()
 	TmpDir         string
 	Args           []string
+	MockInput	   string
 	OriginalValues struct {
 		ConfigHome string
 		Args       []string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,8 @@ var (
 	BinaryName string
 	// Out is used to write to the required writer.
 	Out io.Writer
+	// In used for testing
+	In io.Reader
 )
 
 // RootCmd represents the base command when called without any subcommands.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ var (
 	BinaryName string
 	// Out is used to write to the required writer.
 	Out io.Writer
-	// In used for testing
+	// In is used to provide mocked test input (i.e. for prompts).
 	In io.Reader
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,5 +43,6 @@ func Execute() {
 func init() {
 	BinaryName = os.Args[0]
 	Out = os.Stdout
+	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -231,8 +231,8 @@ figuring things out if necessary.
 		}
 
 		if solution.AutoApprove == true {
-			fmt.Fprintf(Out, "Your solution has been submitted " +
-				"successfully and has been auto-approved. You can complete " +
+			fmt.Fprintf(Out, "Your solution has been submitted "+
+				"successfully and has been auto-approved. You can complete "+
 				"the exercise and unlock the next core exercise at %s\n",
 				solution.URL)
 		} else {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -96,12 +96,11 @@ figuring things out if necessary.
 			> `
 			option, err := selection.Pick(prompt)
 			if err != nil {
-				fmt.Println(err)
-				continue
+				return err
 			}
 			s, ok := option.(*workspace.Solution)
 			if !ok {
-				fmt.Println("something went wrong trying to pick that solution, not sure what happened")
+				fmt.Fprintf(Out, "something went wrong trying to pick that solution, not sure what happened")
 				continue
 			}
 			solution = s
@@ -156,18 +155,17 @@ figuring things out if necessary.
 				Prompt:       prompt,
 				DefaultValue: "y",
 				Reader:       In,
-				Writer:       os.Stdout,
+				Writer:       Out,
 			}
 			answer, err := confirmQuestion.Ask()
 			if err != nil {
-				fmt.Println(err)
 				return err
 			}
 			if answer != "y" {
-				fmt.Println("OK, try submitting files individually instead.")
+				fmt.Fprintf(Out, "OK, try submitting files individually instead.")
 				return nil
 			}
-			fmt.Println("OK, submitting files now...")
+			fmt.Fprintf(Out, "OK, submitting files now...")
 		}
 
 		for _, path := range paths {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -231,8 +231,8 @@ figuring things out if necessary.
 		}
 
 		if solution.AutoApprove == true {
-			fmt.Fprintf(Out, "Your solution has been submitted "+
-				"successfully and has been auto-approved. You can complete "+
+			fmt.Fprintf(Out, "Your solution has been submitted " +
+				"successfully and has been auto-approved. You can complete " +
 				"the exercise and unlock the next core exercise at %s\n",
 				solution.URL)
 		} else {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -144,21 +144,21 @@ figuring things out if necessary.
 			return errors.New("no files found to submit")
 		}
 
-		// if the user submits a directory, confirm the list of files
+		// If the user submits a directory, confirm the list of files.
 		if len(tx.ArgDirs) > 0 {
 			prompt := "You specified a directory. Here are the files you are submitting:\n"
 			for i, path := range paths {
 				prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
 			}
 			prompt += "\nPress ENTER to submit, or control + c to cancel: "
-			
-			conf_q := &comms.Question{
-				Prompt: prompt, 
+
+			confirmQuestion := &comms.Question{
+				Prompt:       prompt,
 				DefaultValue: "y",
-				Reader: In,
-				Writer: os.Stdout,
+				Reader:       In,
+				Writer:       os.Stdout,
 			}
-			answer, err := conf_q.Ask()
+			answer, err := confirmQuestion.Ask()
 			if err != nil {
 				fmt.Println(err)
 				return err

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -144,29 +144,33 @@ figuring things out if necessary.
 			return errors.New("no files found to submit")
 		}
 
-		// confirm list of files to submit with user
-		prompt := "These are the files you are submitting:\n"
-		for i, path := range paths {
-			prompt += fmt.Sprintf("  [%d] %s\n", i+1, path)
+		// if the user submits a directory, confirm the list of files
+		if len(tx.ArgDirs) > 0 {
+			prompt := "You specified a directory. Here are the files you are submitting:\n"
+			for i, path := range paths {
+				prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
+			}
+			prompt += "\nPress ENTER to submit, or control + c to cancel: "
+			
+			conf_q := &comms.Question{
+				Prompt: prompt, 
+				DefaultValue: "y",
+				Reader: os.Stdin,
+				Writer: os.Stdout,
+			}
+			answer, err := conf_q.Ask()
+			if err != nil {
+				fmt.Println(err)
+				return err
+			}
+			if answer != "y" {
+				fmt.Println("OK, try submitting files individually instead.")
+				return nil
+			}
+			fmt.Println("OK, submitting files now...")
 		}
-		prompt += "\n\n Press ENTER to submit, or control + c to cancel."
-		
-		conf_q := &comms.Question{
-			Prompt: prompt, 
-			DefaultValue: "y",
-			Reader: os.Stdin,
-			Writer: os.Stdout,
-		}
-		answer, err := conf_q.Ask()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-		if answer != "y" {
-			fmt.Println("OK, try submitting files individually then.")
-			return nil
-		}
-		fmt.Println("OK, submitting files now...")
+
+
 
 		for _, path := range paths {
 			// Don't submit empty files

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -155,7 +155,7 @@ figuring things out if necessary.
 			conf_q := &comms.Question{
 				Prompt: prompt, 
 				DefaultValue: "y",
-				Reader: os.Stdin,
+				Reader: In,
 				Writer: os.Stdout,
 			}
 			answer, err := conf_q.Ask()

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -161,7 +161,7 @@ figuring things out if necessary.
 			if err != nil {
 				return err
 			}
-			if answer != "y" {
+			if strings.ToLower(answer) != "y" {
 				fmt.Fprintf(Out, "OK, try submitting files individually instead.")
 				return nil
 			}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -144,6 +144,30 @@ figuring things out if necessary.
 			return errors.New("no files found to submit")
 		}
 
+		// confirm list of files to submit with user
+		prompt := "These are the files you are submitting:\n"
+		for i, path := range paths {
+			prompt += fmt.Sprintf("  [%d] %s\n", i+1, path)
+		}
+		prompt += "\n\n Press ENTER to submit, or control + c to cancel."
+		
+		conf_q := &comms.Question{
+			Prompt: prompt, 
+			DefaultValue: "y",
+			Reader: os.Stdin,
+			Writer: os.Stdout,
+		}
+		answer, err := conf_q.Ask()
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+		if answer != "y" {
+			fmt.Println("OK, try submitting files individually then.")
+			return nil
+		}
+		fmt.Println("OK, submitting files now...")
+
 		for _, path := range paths {
 			// Don't submit empty files
 			info, err := os.Stat(path)

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -145,7 +145,7 @@ figuring things out if necessary.
 
 		// If the user submits a directory, confirm the list of files.
 		if len(tx.ArgDirs) > 0 {
-			prompt := "You specified a directory. Here are the files you are submitting:\n"
+			prompt := "You specified a directory, which contains these files:\n"
 			for i, path := range paths {
 				prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
 			}
@@ -162,10 +162,10 @@ figuring things out if necessary.
 				return err
 			}
 			if strings.ToLower(answer) != "y" {
-				fmt.Fprintf(Out, "OK, try submitting files individually instead.")
+				fmt.Fprintf(Out, "Submit cancelled.\nTry submitting individually instead.")
 				return nil
 			}
-			fmt.Fprintf(Out, "OK, submitting files now...")
+			fmt.Fprintf(Out, "Submitting files now...")
 		}
 
 		for _, path := range paths {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -170,8 +170,6 @@ figuring things out if necessary.
 			fmt.Println("OK, submitting files now...")
 		}
 
-
-
 		for _, path := range paths {
 			// Don't submit empty files
 			info, err := os.Stat(path)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -24,7 +24,6 @@ func TestSubmit(t *testing.T) {
 	Out = ioutil.Discard
 	In = rdr
 
-
 	defer func() { Out = oldOut }()
 	defer func() { In = oldIn }()
 	defer os.Remove(tmpfile.Name()) // clean up

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -47,10 +47,10 @@ func TestSubmit(t *testing.T) {
 	}
 
 	cmdTest := &CommandTest{
-		Cmd:    submitCmd,
-		InitFn: initSubmitCmd,
+		Cmd:       submitCmd,
+		InitFn:    initSubmitCmd,
 		MockInput: "\n",
-		Args:   []string{"fakeapp", "submit", "bogus-exercise"},
+		Args:      []string{"fakeapp", "submit", "bogus-exercise"},
 	}
 	cmdTest.Setup(t)
 	defer cmdTest.Teardown(t)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -122,7 +122,7 @@ func TestSubmit(t *testing.T) {
 	err = apiCfg.Write()
 	assert.NoError(t, err)
 
-	// write some mock input for interactive commands
+	// Write mock interactive input for the CLI command.
 	tmpfile.WriteString(cmdTest.MockInput)
 
 	// Execute the command!

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -47,10 +47,10 @@ func TestSubmit(t *testing.T) {
 	}
 
 	cmdTest := &CommandTest{
-		Cmd:       submitCmd,
-		InitFn:    initSubmitCmd,
-		MockInput: "\n",
-		Args:      []string{"fakeapp", "submit", "bogus-exercise"},
+		Cmd:                     submitCmd,
+		InitFn:                  initSubmitCmd,
+		MockInteractiveResponse: "\n",
+		Args: []string{"fakeapp", "submit", "bogus-exercise"},
 	}
 	cmdTest.Setup(t)
 	defer cmdTest.Teardown(t)
@@ -123,7 +123,7 @@ func TestSubmit(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Write mock interactive input for the CLI command.
-	tmpfile.WriteString(cmdTest.MockInput)
+	tmpfile.WriteString(cmdTest.MockInteractiveResponse)
 
 	// Execute the command!
 	cmdTest.App.Execute()

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/exercism/cli/config"
@@ -14,19 +15,12 @@ import (
 )
 
 func TestSubmit(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
 	oldOut := Out
 	oldIn := In
-	rdr, _ := os.Open(tmpfile.Name())
 	Out = ioutil.Discard
-	In = rdr
 
 	defer func() { Out = oldOut }()
 	defer func() { In = oldIn }()
-	defer os.Remove(tmpfile.Name()) // clean up
 
 	type file struct {
 		relativePath string
@@ -65,7 +59,7 @@ func TestSubmit(t *testing.T) {
 		Exercise:    "bogus-exercise",
 		IsRequester: true,
 	}
-	err = solution.Write(dir)
+	err := solution.Write(dir)
 	assert.NoError(t, err)
 
 	for _, file := range []file{file1, file2, file3} {
@@ -122,8 +116,8 @@ func TestSubmit(t *testing.T) {
 	err = apiCfg.Write()
 	assert.NoError(t, err)
 
-	// Write mock interactive input for the CLI command.
-	tmpfile.WriteString(cmdTest.MockInteractiveResponse)
+	// Write mock interactive input to In for the CLI command.
+	In = strings.NewReader(cmdTest.MockInteractiveResponse)
 
 	// Execute the command!
 	cmdTest.App.Execute()

--- a/workspace/transmission.go
+++ b/workspace/transmission.go
@@ -9,7 +9,7 @@ import (
 type Transmission struct {
 	Files   []string
 	Dir     string
-	argDirs []string
+	ArgDirs []string
 }
 
 // NewTransmission processes the arguments to the submit command to prep a submission.
@@ -29,12 +29,12 @@ func NewTransmission(root string, args []string) (*Transmission, error) {
 			continue
 		}
 		// For our purposes, if it's not a file then it's a directory.
-		tx.argDirs = append(tx.argDirs, arg)
+		tx.ArgDirs = append(tx.ArgDirs, arg)
 	}
-	if len(tx.argDirs) > 1 {
+	if len(tx.ArgDirs) > 1 {
 		return nil, errors.New("more than one dir")
 	}
-	if len(tx.argDirs) > 0 && len(tx.Files) > 0 {
+	if len(tx.ArgDirs) > 0 && len(tx.Files) > 0 {
 		return nil, errors.New("mixing files and dirs")
 	}
 	if len(tx.Files) > 0 {
@@ -52,8 +52,8 @@ func NewTransmission(root string, args []string) (*Transmission, error) {
 			return nil, errors.New("files are from more than one solution")
 		}
 	}
-	if len(tx.argDirs) == 1 {
-		tx.Dir = tx.argDirs[0]
+	if len(tx.ArgDirs) == 1 {
+		tx.Dir = tx.ArgDirs[0]
 	}
 	return tx, nil
 }


### PR DESCRIPTION
When a user submits a directory, show them a list of (pre-filtered) files and allow them to confirm/pass on the whole selection.

Changes that support the interactive prompt:
 - made `Transmission.ArgDirs` public in order to check it in `submit.go`.

Otherwise, the interaction/prompts would need to take place inside code for a Transmission, which seemed like a bad separation of concerns. In our case, as long as `ArgDirs` == 1, then the user gave a whole directory, and we don't need to figure out anything else.

For testing:
 - added an In variable, like the Out, into `cmd/root`
 - added MockInput to `cmd_test`

This makes it possible to mock interactive responses in tests. There are several Issues talking about interactive submission/confirmation etc (#485, #480, #463, #462, #461 ), so I figured having the ability to test them would be nice. If the testing changes should be a separate PR, happy to split it out!