### PR TITLE
Uninstall probot-stale on this repository

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-# Configuration for probot-stale - https://github.com/probot/stale


### PR DESCRIPTION
We have a lot of work that needs to be done, and we tend to work in spurts. Probot Stale
hasn't really helped much, and recently (while I was not paying attention) it closed a bunch
of issues that I'd prefer to keep open (nextercism stuff).