### PR TITLE
[nextercism] Update cli release URL information

### DIFF
--- a/cli/asset.go
+++ b/cli/asset.go
@@ -15,7 +15,7 @@ type Asset struct {
 }
 
 func (a *Asset) download() (*bytes.Reader, error) {
-	downloadURL := fmt.Sprintf("https://api.github.com/repos/exercism/cli/releases/assets/%d", a.ID)
+	downloadURL := fmt.Sprintf("%s/assets/%d", ReleaseURL, a.ID)
 	req, err := http.NewRequest("GET", downloadURL, nil)
 	if err != nil {
 		return nil, err

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,8 +45,8 @@ var (
 var (
 	// HTTPClient is the client used to make HTTP calls in the cli package.
 	HTTPClient = &http.Client{Timeout: 10 * time.Second}
-	// LatestReleaseURL is the endpoint that provides information about the latest release.
-	LatestReleaseURL = "https://api.github.com/repos/exercism/cli/releases/latest"
+	// ReleaseURL is the endpoint that provides information about cli releases.
+	ReleaseURL = "https://api.github.com/repos/exercism/cli/releases"
 )
 
 // Updater is a simple upgradable file interface.
@@ -133,7 +133,8 @@ func (c *CLI) Upgrade() error {
 }
 
 func (c *CLI) fetchLatestRelease() error {
-	resp, err := HTTPClient.Get(LatestReleaseURL)
+	latestReleaseURL := fmt.Sprintf("%s/%s", ReleaseURL, "latest")
+	resp, err := HTTPClient.Get(latestReleaseURL)
 	if err != nil {
 		return err
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -55,11 +55,16 @@ func TestIsUpToDate(t *testing.T) {
 
 func TestIsUpToDateWithoutRelease(t *testing.T) {
 	fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Checking for the latest release should call latestReleaseURL endpoint.
+		// if the code below fails to return the proper response then the URL generation logic in pkg cli has changed.
+		if r.URL.Path != "/latest" {
+			fmt.Fprintln(w, "")
+		}
 		fmt.Fprintln(w, `{"tag_name": "v2.0.0"}`)
 	})
 	ts := httptest.NewServer(fakeEndpoint)
 	defer ts.Close()
-	LatestReleaseURL = ts.URL
+	ReleaseURL = ts.URL
 
 	c := &CLI{
 		Version: "1.0.0",

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -23,7 +23,7 @@ func TestVersionUpdateCheck(t *testing.T) {
 	})
 	ts := httptest.NewServer(fakeEndpoint)
 	defer ts.Close()
-	cli.LatestReleaseURL = ts.URL
+	cli.ReleaseURL = ts.URL
 
 	tests := []struct {
 		version  string


### PR DESCRIPTION
In an attempt to use this same CLI pkg in Configlet for updating Go binaries from GitHub I have generalized the generation of release URLs. This change allows users to pull CLI as package and change the ReleaseURL to update their respective CLIs via a similar upgrade command.