### PR TITLE
iadded suppoert for linux with ppc64

### DIFF
--- a/bin/build-all
+++ b/bin/build-all
@@ -27,8 +27,12 @@ createRelease() {
 	if [ "$arch" = amd64 ]
 	then
 		osarch=64bit
-	else
+	elif [ "$os" = linux ] && [ "$arch" = ppc64 ]
+        then
+                osarch=ppc64
+        else
 		osarch=32bit
+
 	fi
 
 	ldflags="-X $OSVAR=$os -X $ARCHVAR=$arch"

--- a/bin/build-all
+++ b/bin/build-all
@@ -77,6 +77,9 @@ createRelease() {
 createRelease darwin 386
 createRelease darwin amd64
 
+# PowerPC Releases
+createRelease linux ppc64
+
 # Linux Releases
 createRelease linux 386
 createRelease linux amd64


### PR DESCRIPTION
I have my go 1.8 in my g5 ppc64 linux ubuntu xenial and now I compile exercism from master source and it is working ok. I added some code to build-all script in order to build ppc64. I tested the script in my linux ppc64 and Crete all releases I do not know what happen  if you run the build-all in amd64..