### PR TITLE
Make verbose flag global to all commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,4 +45,5 @@ func init() {
 	Out = os.Stdout
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
+	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -49,5 +49,4 @@ func updateCLI(c cli.Updater) error {
 
 func init() {
 	RootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.Flags().BoolP("verbose", "v", false, "verbose output")
 }


### PR DESCRIPTION
We are going to want to add verbose logging to the entire package for
debugging purposes. This moves the local flag onto the root command as
a persistent flag so that all subcommands inherit it.

FYI @nywilken -- I'm hoping to do a fair amount of work on the nextercism CLI in the next few days. I'll be merging a lot myself, just to stay unblocked, but if you have a time to look at things and flag improvements that you'd like to see us make in subsequent PRs, that would be lovely.