### PR TITLE
Turn on verbose mode across the board if verbose flag is present

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,11 @@ var RootCmd = &cobra.Command{
 
 Download exercises and submit your solutions.`,
 	SilenceUsage: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+			debug.Verbose = verbose
+		}
+	},
 }
 
 // Execute adds all child commands to the root command.

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/exercism/cli/cli"
-	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
 )
 
@@ -23,10 +22,6 @@ The next time you upgrade, the hidden file will be overwritten.
 You can always delete this file.
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
-			debug.Verbose = verbose
-		}
-
 		c := cli.New(Version)
 		return updateCLI(c)
 	},


### PR DESCRIPTION
I was originally going to add the verbose flag check to every command, but then I realized that there probably was a better way, and found the persistent pre-run function.