### PR TITLE
Add verbose logging to basic HTTP request/response

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -73,7 +73,7 @@ func (c *Client) NewRequest(method, url string, body io.Reader) (*http.Request, 
 
 // Do performs an http.Request and optionally parses the response body into the given interface.
 func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
-	debug.Println("Request", req.Method, req.URL)
+	debug.DumpRequest(req)
 
 	res, err := c.Client.Do(req)
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -79,7 +78,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	debug.Printf("Response StatusCode=%d\n", res.StatusCode)
+	debug.DumpResponse(res)
 
 	switch res.StatusCode {
 	case http.StatusNoContent:
@@ -91,11 +90,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 		if v != nil {
 			defer res.Body.Close()
 
-			var bodyCopy bytes.Buffer
-			body := io.TeeReader(res.Body, &bodyCopy)
-			debug.Printf("Response Body\n%s\n\n", bodyCopy.String())
-
-			if err := json.NewDecoder(body).Decode(v); err != nil {
+			if err := json.NewDecoder(res.Body).Decode(v); err != nil {
 				return nil, fmt.Errorf("unable to parse API response - %s", err)
 			}
 		}

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,8 +1,13 @@
 package debug
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
 	"os"
 )
 
@@ -24,4 +29,25 @@ func Printf(format string, args ...interface{}) {
 	if Verbose {
 		fmt.Fprintf(output, format, args...)
 	}
+}
+
+func DumpRequest(req *http.Request) {
+	if !Verbose {
+		return
+	}
+
+	var bodyCopy bytes.Buffer
+	body := io.TeeReader(req.Body, &bodyCopy)
+	req.Body = ioutil.NopCloser(body)
+
+	dump, err := httputil.DumpRequest(req, req.ContentLength > 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Println("\n========================= BEGIN DumpRequest =========================")
+	Println(string(dump))
+	Println("========================= END DumpRequest =========================\n")
+
+	req.Body = ioutil.NopCloser(&bodyCopy)
 }

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -51,3 +51,24 @@ func DumpRequest(req *http.Request) {
 
 	req.Body = ioutil.NopCloser(&bodyCopy)
 }
+
+func DumpResponse(res *http.Response) {
+	if !Verbose {
+		return
+	}
+
+	var bodyCopy bytes.Buffer
+	body := io.TeeReader(res.Body, &bodyCopy)
+	res.Body = ioutil.NopCloser(body)
+
+	dump, err := httputil.DumpResponse(res, res.ContentLength > 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Println("\n========================= BEGIN DumpResponse =========================")
+	Println(string(dump))
+	Println("========================= END DumpResponse =========================\n")
+
+	res.Body = ioutil.NopCloser(&bodyCopy)
+}


### PR DESCRIPTION
This runs a `http.Dump{Request,Response}` within the `client.Do()` which is used for most of the API calls used in the commands.