### PR TITLE
Fix the base URL for the v2 API

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -42,7 +42,7 @@ func TestConfigure(t *testing.T) {
 			desc:           "It gets the default API base URL.",
 			args:           []string{"fakeapp", "configure"},
 			existingAPICfg: &config.APIConfig{},
-			expectedAPICfg: &config.APIConfig{BaseURL: "https://api.exercism.io/v1"},
+			expectedAPICfg: &config.APIConfig{BaseURL: "https://v2.exercism.io/api/v1"},
 		},
 	}
 

--- a/config/api_config.go
+++ b/config/api_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	defaultBaseURL   = "https://api.exercism.io/v1"
+	defaultBaseURL   = "https://v2.exercism.io/api/v1"
 	defaultEndpoints = map[string]string{
 		"download":      "/solutions/%s",
 		"submit":        "/solutions/%s",

--- a/config/api_config_test.go
+++ b/config/api_config_test.go
@@ -42,7 +42,7 @@ func TestAPIConfigSetDefaults(t *testing.T) {
 	// All defaults.
 	cfg := &APIConfig{}
 	cfg.SetDefaults()
-	assert.Equal(t, "https://api.exercism.io/v1", cfg.BaseURL)
+	assert.Equal(t, "https://v2.exercism.io/api/v1", cfg.BaseURL)
 	assert.Equal(t, "/solutions/%s", cfg.Endpoints["download"])
 	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
 
@@ -62,7 +62,7 @@ func TestAPIConfigSetDefaults(t *testing.T) {
 		},
 	}
 	cfg.SetDefaults()
-	assert.Equal(t, "https://api.exercism.io/v1", cfg.BaseURL)
+	assert.Equal(t, "https://v2.exercism.io/api/v1", cfg.BaseURL)
 	assert.Equal(t, "/download/%d", cfg.Endpoints["download"])
 	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
 }


### PR DESCRIPTION
We will need to update this before we cut the final release of the new CLI
for launch, since the domain will move from v2.exercism.io to exercism.io.