### PR TITLE
bin/build-all: strip golang debugger info

### DIFF
--- a/bin/build-all
+++ b/bin/build-all
@@ -35,7 +35,7 @@ createRelease() {
 
 	fi
 
-	ldflags="-X $OSVAR=$os -X $ARCHVAR=$arch"
+	ldflags="-s -w -X $OSVAR=$os -X $ARCHVAR=$arch"
 	if [ "$arm" ]
 	then
 		osarch=arm-v$arm


### PR DESCRIPTION
This strips debugging symbols to [decrease the build size](http://pliutau.com/optimize-go-binary-size/). Fixes #521.