### PR TITLE
cmd/download.go: fix "track_ambiguous" error

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"io"
 	"net/http"
 	"os"
@@ -97,6 +98,7 @@ Download other people's solutions by providing the UUID.
 		if res.StatusCode != http.StatusOK {
 			switch payload.Error.Type {
 			case "track_ambiguous":
+				return fmt.Errorf("%s: %s", payload.Error.Message, strings.Join(payload.Error.PossibleTrackIDs, ", "))
 			default:
 				return errors.New(payload.Error.Message)
 			}


### PR DESCRIPTION
The `switch` didn't handle the `"track_ambiguous"` case. It now throws the provided error, with the possible track ids listed.