### PR TITLE
Add 401 status code case

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -86,6 +86,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	case http.StatusInternalServerError:
 		// TODO: if it's json, and it has an error key, print the message.
 		return nil, fmt.Errorf("%s", res.Status)
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("unauthorized request. Please run the configure command to set the api token found at https://v2.exercism.io/my/settings")
 	default:
 		if v != nil {
 			defer res.Body.Close()


### PR DESCRIPTION
Handles #529 

One question I did have -- what is the origin of the current error messages? 401 is handled in the FETCH command currently with the message:

2018/05/14 20:51:13 unable to submit (HTTP: 401) - unknown api key 'key-from-config-here', please check http://exercism.io/account/key and reconfigure

and sort of exists with SUBMIT (something about please check your api key)