### PR TITLE
Handle unstable releases in the version command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -88,6 +88,26 @@ func (c *CLI) IsUpToDate() (bool, error) {
 	return cv.GTE(rv), nil
 }
 
+// IsCuttingEdge compares the current version to that of the latest release.
+func (c *CLI) IsCuttingEdge() (bool, error) {
+	if c.LatestRelease == nil {
+		if err := c.fetchLatestRelease(); err != nil {
+			return false, err
+		}
+	}
+
+	rv, err := semver.Make(c.LatestRelease.Version())
+	if err != nil {
+		return false, fmt.Errorf("unable to parse latest version (%s): %s", c.LatestRelease.Version(), err)
+	}
+	cv, err := semver.Make(c.Version)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse current version (%s): %s", c.Version, err)
+	}
+
+	return cv.GT(rv), nil
+}
+
 // Upgrade allows the user to upgrade to the latest version of the CLI.
 func (c *CLI) Upgrade() error {
 	var (

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -75,3 +75,53 @@ func TestIsUpToDateWithoutRelease(t *testing.T) {
 	assert.False(t, ok)
 	assert.NotNil(t, c.LatestRelease)
 }
+
+func TestIsCuttingEdge(t *testing.T) {
+	tests := []struct {
+		cliVersion string
+		releaseTag string
+		ok         bool
+	}{
+		{
+			// It returns false for versions less than release.
+			cliVersion: "1.0.0",
+			releaseTag: "v1.0.1",
+			ok:         false,
+		},
+		{
+			// It returns true for pre-release versions greater than release.
+			cliVersion: "1.0.1-alpha.1",
+			releaseTag: "v1.0.0",
+			ok:         true,
+		},
+		{
+			// It returns false for pre-release versions for current release.
+			cliVersion: "1.0.0-alpha.1",
+			releaseTag: "v1.0.0",
+			ok:         false,
+		},
+		{
+			// It returns false for versions equal to release.
+			cliVersion: "2.0.1",
+			releaseTag: "v2.0.1",
+			ok:         false,
+		},
+		{
+			// It returns true for versions greater than release.
+			cliVersion: "2.0.2",
+			releaseTag: "v2.0.1",
+			ok:         true,
+		},
+	}
+
+	for _, test := range tests {
+		c := &CLI{
+			Version:       test.cliVersion,
+			LatestRelease: &Release{TagName: test.releaseTag},
+		}
+
+		ok, err := c.IsCuttingEdge()
+		assert.NoError(t, err)
+		assert.Equal(t, test.ok, ok, fmt.Sprintf("Latest release: %s, CLI version: %s", test.releaseTag, test.cliVersion))
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -60,7 +60,16 @@ func checkForUpdate(c *cli.CLI) (string, error) {
 		return "Your CLI version is up to date.", nil
 	}
 
-	// Anything but ok is out of date.
+	ok, err = c.IsCuttingEdge()
+	if err != nil {
+		return "", err
+	}
+
+	if ok {
+		return "Your CLI version is newer than the most recent stable release.", nil
+	}
+
+	// The client is outdated.
 	msg := fmt.Sprintf("A new CLI version is available. Run `exercism upgrade` to update to %s", c.LatestRelease.Version())
 	return msg, nil
 


### PR DESCRIPTION
I originally thought that we'd never want to check for a version newer than the latest release... then realized that this gets confusing if you're trying out the beta.

This still isn't perfect, since it won't mention that there's a newer unstable release available if you're already on an unstable release. Not sure if that's important enough to jump through hoops for.