### PR TITLE
Makes tests pass on Windows.

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/exercism/cli/config"
@@ -76,7 +77,12 @@ func makeTest(tc testCase) func(*testing.T) {
 		cmdTest.App.Execute()
 
 		if tc.expectedUsrCfg != nil {
+			if runtime.GOOS == "windows" {
+				tc.expectedUsrCfg.Normalize()
+			}
+
 			usrCfg, err := config.NewUserConfig()
+
 			assert.NoError(t, err, tc.desc)
 			assert.Equal(t, tc.expectedUsrCfg.Token, usrCfg.Token, tc.desc)
 			assert.Equal(t, tc.expectedUsrCfg.Workspace, usrCfg.Workspace, tc.desc)

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
@@ -92,6 +93,7 @@ func makeTest(tc testCase) func(*testing.T) {
 			apiCfg, err := config.NewAPIConfig()
 			assert.NoError(t, err, tc.desc)
 			assert.Equal(t, tc.expectedAPICfg.BaseURL, apiCfg.BaseURL, tc.desc)
+			os.Remove(apiCfg.File())
 		}
 	}
 }

--- a/cmd/prepare_test.go
+++ b/cmd/prepare_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/exercism/cli/config"
@@ -43,6 +44,7 @@ func TestPrepareTrack(t *testing.T) {
 	cmdTest.App.Execute()
 
 	cliCfg, err := config.NewCLIConfig()
+	os.Remove(cliCfg.File())
 	assert.NoError(t, err)
 
 	expected := []string{

--- a/visibility/hide_file.go
+++ b/visibility/hide_file.go
@@ -6,3 +6,8 @@ package visibility
 func HideFile(string) error {
 	return nil
 }
+
+// ShowFile is a no-op for non-Windows systems.
+func ShowFile(path string) error {
+	return nil
+}

--- a/visibility/hide_file_windows.go
+++ b/visibility/hide_file_windows.go
@@ -6,6 +6,15 @@ import "syscall"
 // This is the equivalent of giving a filename on
 // Linux or MacOS a leading dot (e.g. .bash_rc).
 func HideFile(path string) error {
+	return setVisibility(path, false)
+}
+
+// ShowFile unsets a Windows file's 'hidden' attribute.
+func ShowFile(path string) error {
+	return setVisibility(path, true)
+}
+
+func setVisibility(path string, visible bool) error {
 	// This is based on the discussion in
 	// https://www.reddit.com/r/golang/comments/5t3ezd/hidden_files_directories/
 	// but instead of duplicating all the effort to write the file, this takes
@@ -22,6 +31,11 @@ func HideFile(path string) error {
 		return err
 	}
 
-	attributes |= syscall.FILE_ATTRIBUTE_HIDDEN
+	if visible {
+		attributes &^= syscall.FILE_ATTRIBUTE_HIDDEN
+	} else {
+		attributes |= syscall.FILE_ATTRIBUTE_HIDDEN
+	}
+
 	return syscall.SetFileAttributes(ptr, attributes)
 }

--- a/workspace/path_type_symlinks_test.go
+++ b/workspace/path_type_symlinks_test.go
@@ -1,0 +1,31 @@
+// +build !windows
+
+package workspace
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDetectPathTypeSymlink(t *testing.T) {
+	_, cwd, _, _ := runtime.Caller(0)
+	root := filepath.Join(cwd, "..", "..", "fixtures", "detect-path-type")
+
+	testCases := []detectPathTestCase{
+		{
+			desc: "symlinked dir",
+			path: filepath.Join(root, "symlinked-dir"),
+			pt:   TypeDir,
+		},
+		{
+			desc: "symlinked file",
+			path: filepath.Join(root, "symlinked-file.txt"),
+			pt:   TypeFile,
+		},
+	}
+
+	for _, tc := range testCases {
+		testDetectPathType(t, tc)
+	}
+}

--- a/workspace/path_type_test.go
+++ b/workspace/path_type_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testCase struct {
+type detectPathTestCase struct {
 	desc string
 	path string
 	pt   PathType
@@ -18,8 +18,8 @@ func TestDetectPathType(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "detect-path-type")
 
-	testCases := []testCase{
-		testCase{
+	testCases := []detectPathTestCase{
+		detectPathTestCase{
 			desc: "absolute dir",
 			path: filepath.Join(root, "a-dir"),
 			pt:   TypeDir,
@@ -27,11 +27,6 @@ func TestDetectPathType(t *testing.T) {
 		{
 			desc: "relative dir",
 			path: filepath.Join("..", "fixtures", "detect-path-type", "a-dir"),
-			pt:   TypeDir,
-		},
-		{
-			desc: "symlinked dir",
-			path: filepath.Join(root, "symlinked-dir"),
 			pt:   TypeDir,
 		},
 		{
@@ -45,11 +40,6 @@ func TestDetectPathType(t *testing.T) {
 			pt:   TypeFile,
 		},
 		{
-			desc: "symlinked file",
-			path: filepath.Join(root, "symlinked-file.txt"),
-			pt:   TypeFile,
-		},
-		{
 			desc: "exercise ID",
 			path: "a-file",
 			pt:   TypeExerciseID,
@@ -57,15 +47,12 @@ func TestDetectPathType(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.desc, makeTest(tc))
-
+		testDetectPathType(t, tc)
 	}
 }
 
-func makeTest(tc testCase) func(*testing.T) {
-	return func(t *testing.T) {
-		pt, err := DetectPathType(tc.path)
-		assert.NoError(t, err, tc.desc)
-		assert.Equal(t, tc.pt, pt, tc.desc)
-	}
+func testDetectPathType(t *testing.T, tc detectPathTestCase) {
+	pt, err := DetectPathType(tc.path)
+	assert.NoError(t, err, tc.desc)
+	assert.Equal(t, tc.pt, pt, tc.desc)
 }

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -66,8 +66,13 @@ func (s *Solution) Write(dir string) error {
 	if err != nil {
 		return err
 	}
+
 	path := filepath.Join(dir, solutionFilename)
-	if err := ioutil.WriteFile(path, b, os.FileMode(0644)); err != nil {
+
+	// Hack because ioutil.WriteFile fails on hidden files
+	visibility.ShowFile(path)
+
+	if err := ioutil.WriteFile(path, b, os.FileMode(0600)); err != nil {
 		return err
 	}
 	s.Dir = dir

--- a/workspace/transmission_test.go
+++ b/workspace/transmission_test.go
@@ -93,6 +93,6 @@ func TestTransmissionWithRelativePath(t *testing.T) {
 	file := filepath.Base(cwd)
 	tx, err := NewTransmission(dir, []string{file})
 	if assert.NoError(t, err) {
-		assert.Equal(t, cwd, tx.Files[0])
+		assert.Equal(t, filepath.Clean(cwd), tx.Files[0])
 	}
 }

--- a/workspace/workspace_symlinks_test.go
+++ b/workspace/workspace_symlinks_test.go
@@ -1,0 +1,49 @@
+// +build !windows
+
+package workspace
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLocateSymlinks(t *testing.T) {
+	_, cwd, _, _ := runtime.Caller(0)
+	root := filepath.Join(cwd, "..", "..", "fixtures", "locate-exercise")
+
+	wsSymbolic := New(filepath.Join(root, "symlinked-workspace"))
+	wsPrimary := New(filepath.Join(root, "workspace"))
+
+	testCases := []locateTestCase{
+		{
+			desc:      "find absolute path within symlinked workspace",
+			workspace: wsSymbolic,
+			in:        filepath.Join(wsSymbolic.Dir, "creatures", "horse"),
+			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
+		},
+		{
+			desc:      "find by name in a symlinked workspace",
+			workspace: wsSymbolic,
+			in:        "horse",
+			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
+		},
+		{
+			desc:      "don't be confused by a symlinked file named the same as an exercise",
+			workspace: wsPrimary,
+			in:        "date",
+			out:       []string{filepath.Join(wsPrimary.Dir, "actions", "date")},
+		},
+		{
+			desc:      "find exercises that are symlinks",
+			workspace: wsPrimary,
+			in:        "squash",
+			out: []string{
+				filepath.Join(wsPrimary.Dir, "..", "food", "squash"),
+				filepath.Join(wsPrimary.Dir, "actions", "squash"),
+			},
+		},
+	}
+
+	testLocate(testCases, t)
+}

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -55,29 +55,24 @@ func TestLocateErrors(t *testing.T) {
 	}
 }
 
+type locateTestCase struct {
+	desc      string
+	workspace Workspace
+	in        string
+	out       []string
+}
+
 func TestLocate(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "locate-exercise")
 
 	wsPrimary := New(filepath.Join(root, "workspace"))
-	wsSymbolic := New(filepath.Join(root, "symlinked-workspace"))
 
-	tests := []struct {
-		desc      string
-		workspace Workspace
-		in        string
-		out       []string
-	}{
+	testCases := []locateTestCase{
 		{
 			desc:      "find absolute path within workspace",
 			workspace: wsPrimary,
 			in:        filepath.Join(wsPrimary.Dir, "creatures", "horse"),
-			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
-		},
-		{
-			desc:      "find absolute path within symlinked workspace",
-			workspace: wsSymbolic,
-			in:        filepath.Join(wsSymbolic.Dir, "creatures", "horse"),
 			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
 		},
 		{
@@ -93,12 +88,6 @@ func TestLocate(t *testing.T) {
 			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
 		},
 		{
-			desc:      "find by name in a symlinked workspace",
-			workspace: wsSymbolic,
-			in:        "horse",
-			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "horse")},
-		},
-		{
 			desc:      "find by name in a subtree",
 			workspace: wsPrimary,
 			in:        "fly",
@@ -109,12 +98,6 @@ func TestLocate(t *testing.T) {
 			workspace: wsPrimary,
 			in:        "duck",
 			out:       []string{filepath.Join(wsPrimary.Dir, "creatures", "duck")},
-		},
-		{
-			desc:      "don't be confused by a symlinked file named the same as an exercise",
-			workspace: wsPrimary,
-			in:        "date",
-			out:       []string{filepath.Join(wsPrimary.Dir, "actions", "date")},
 		},
 		{
 			desc:      "find all the exercises with the same name",
@@ -134,25 +117,20 @@ func TestLocate(t *testing.T) {
 				filepath.Join(wsPrimary.Dir, "creatures", "crane-2"),
 			},
 		},
-		{
-			desc:      "find exercises that are symlinks",
-			workspace: wsPrimary,
-			in:        "squash",
-			out: []string{
-				filepath.Join(wsPrimary.Dir, "..", "food", "squash"),
-				filepath.Join(wsPrimary.Dir, "actions", "squash"),
-			},
-		},
 	}
 
-	for _, test := range tests {
-		dirs, err := test.workspace.Locate(test.in)
+	testLocate(testCases, t)
+}
+
+func testLocate(testCases []locateTestCase, t *testing.T) {
+	for _, tc := range testCases {
+		dirs, err := tc.workspace.Locate(tc.in)
 
 		sort.Strings(dirs)
-		sort.Strings(test.out)
+		sort.Strings(tc.out)
 
-		assert.NoError(t, err, test.desc)
-		assert.Equal(t, test.out, dirs, test.desc)
+		assert.NoError(t, err, tc.desc)
+		assert.Equal(t, tc.out, dirs, tc.desc)
 	}
 }
 


### PR DESCRIPTION
I hade 14 non passing tests under Widnows. I did not test to see if they passed undex linux or ios.

I kind of solved 10 ones (those in configure_test.go)

The solutions may not be perfect, but I wanted some feedback before I tried to continue. There is an issue.md file which contains my notes : it may be helpfull to understand what I did, but maybe you don't want to pick it in the merge.

Also I modified the big test in configure_test.go so it runs as several subtests. It allow test tools to give individual result. Maybe this can be ported to other tests that use a list of input/expected outputs.