### PR TITLE
Break out test into subtests.

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -18,19 +18,20 @@ func TestNewRequestSetsDefaultHeaders(t *testing.T) {
 
 	UserAgent = "BogusAgent"
 
-	tests := []struct {
+	testCases := []struct {
+		desc        string
 		client      *Client
 		auth        string
 		contentType string
 	}{
 		{
-			// Use defaults.
+			desc:        "User defaults",
 			client:      &Client{},
 			auth:        "",
 			contentType: "application/json",
 		},
 		{
-			// Override defaults.
+			desc: "Override defaults",
 			client: &Client{
 				UserConfig:  &config.UserConfig{Token: "abc123"},
 				ContentType: "bogus",
@@ -40,12 +41,14 @@ func TestNewRequestSetsDefaultHeaders(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		req, err := test.client.NewRequest("GET", ts.URL, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, "BogusAgent", req.Header.Get("User-Agent"))
-		assert.Equal(t, test.contentType, req.Header.Get("Content-Type"))
-		assert.Equal(t, test.auth, req.Header.Get("Authorization"))
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			req, err := tc.client.NewRequest("GET", ts.URL, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, "BogusAgent", req.Header.Get("User-Agent"))
+			assert.Equal(t, tc.contentType, req.Header.Get("Content-Type"))
+			assert.Equal(t, tc.auth, req.Header.Get("Authorization"))
+		})
 	}
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -10,46 +10,49 @@ import (
 )
 
 func TestIsUpToDate(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
+		desc       string
 		cliVersion string
 		releaseTag string
 		ok         bool
 	}{
 		{
-			// It returns false for versions less than release.
+			desc:       "It returns false for versions less than release.",
 			cliVersion: "1.0.0",
 			releaseTag: "v1.0.1",
 			ok:         false,
 		},
 		{
-			// It returns false for pre-release versions of release.
+			desc:       "It returns false for pre-release versions of release.",
 			cliVersion: "1.0.1-alpha.1",
 			releaseTag: "v1.0.1",
 			ok:         false,
 		},
 		{
-			// It returns true for versions equal to release.
+			desc:       "It returns true for versions equal to release.",
 			cliVersion: "2.0.1",
 			releaseTag: "v2.0.1",
 			ok:         true,
 		},
 		{
-			// It returns true for versions greater than release.
+			desc:       "It returns true for versions greater than release.",
 			cliVersion: "2.0.2",
 			releaseTag: "v2.0.1",
 			ok:         true,
 		},
 	}
 
-	for _, test := range tests {
-		c := &CLI{
-			Version:       test.cliVersion,
-			LatestRelease: &Release{TagName: test.releaseTag},
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			c := &CLI{
+				Version:       tc.cliVersion,
+				LatestRelease: &Release{TagName: tc.releaseTag},
+			}
 
-		ok, err := c.IsUpToDate()
-		assert.NoError(t, err)
-		assert.Equal(t, test.ok, ok, test.cliVersion)
+			ok, err := c.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.ok, ok, tc.cliVersion)
+		})
 	}
 }
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -91,19 +91,23 @@ func TestDownload(t *testing.T) {
 	err = apiCfg.Write()
 	assert.NoError(t, err)
 
-	tests := []struct {
+	testCases := []struct {
+		desc     string
 		path     string
 		contents string
 	}{
 		{
+			desc:     "path with no subdir",
 			path:     filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", "file-1.txt"),
 			contents: "this is file 1",
 		},
 		{
+			desc:     "path with subdir",
 			path:     filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", "subdir", "file-2.txt"),
 			contents: "this is file 2",
 		},
 		{
+			desc:     "solution file",
 			path:     filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", ".solution.json"),
 			contents: `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":true,"auto_approve":false}`,
 		},
@@ -111,14 +115,15 @@ func TestDownload(t *testing.T) {
 
 	cmdTest.App.Execute()
 
-	for _, test := range tests {
-		b, err := ioutil.ReadFile(test.path)
-		assert.NoError(t, err)
-		assert.Equal(t, test.contents, string(b))
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			b, err := ioutil.ReadFile(tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.contents, string(b), "content of "+tc.path)
+		})
 	}
 
-	// It doesn't write the empty file.
 	path := filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", path3)
 	_, err = os.Lstat(path)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, os.IsNotExist(err), "It doesn't write the empty file.")
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -26,7 +26,7 @@ func TestUpgrade(t *testing.T) {
 	Out = ioutil.Discard
 	defer func() { Out = oldOut }()
 
-	tests := []struct {
+	testCases := []struct {
 		desc     string
 		upToDate bool
 		expected bool
@@ -43,11 +43,13 @@ func TestUpgrade(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		fc := &fakeCLI{UpToDate: test.upToDate}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fc := &fakeCLI{UpToDate: tc.upToDate}
 
-		err := updateCLI(fc)
-		assert.NoError(t, err)
-		assert.Equal(t, test.expected, fc.UpgradeCalled, test.desc)
+			err := updateCLI(fc)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, fc.UpgradeCalled)
+		})
 	}
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -25,36 +25,39 @@ func TestVersionUpdateCheck(t *testing.T) {
 	defer ts.Close()
 	cli.ReleaseURL = ts.URL
 
-	tests := []struct {
+	testCases := []struct {
+		desc     string
 		version  string
 		expected string
 	}{
 		{
-			// It returns new version available for versions older than latest.
+			desc:     "It returns new version available for versions older than latest.",
 			version:  "1.0.0",
 			expected: "A new CLI version is available. Run `exercism upgrade` to update to 2.0.0",
 		},
 		{
-			// It returns up to date for versions matching latest.
+			desc:     "It returns up to date for versions matching latest.",
 			version:  "2.0.0",
 			expected: "Your CLI version is up to date.",
 		},
 		{
-			// It returns up to date for versions newer than latest.
+			desc:     "It returns up to date for versions newer than latest.",
 			version:  "2.0.1",
 			expected: "Your CLI version is up to date.",
 		},
 	}
 
-	for _, test := range tests {
-		c := &cli.CLI{
-			Version: test.version,
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			c := &cli.CLI{
+				Version: tc.version,
+			}
 
-		actual, err := checkForUpdate(c)
+			actual, err := checkForUpdate(c)
 
-		assert.NoError(t, err)
-		assert.NotEmpty(t, actual)
-		assert.Equal(t, test.expected, actual)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, actual)
+			assert.Equal(t, tc.expected, actual)
+		})
 	}
 }

--- a/comms/question_test.go
+++ b/comms/question_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestQuestion(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		desc     string
 		given    string
 		fallback string
@@ -18,16 +18,18 @@ func TestQuestion(t *testing.T) {
 		{"records interactive response", "hello\n", "", "hello"},
 		{"responds with default if response is empty", "\n", "Fine.", "Fine."},
 	}
-	for _, test := range tests {
-		q := &Question{
-			Reader:       strings.NewReader(test.given),
-			Writer:       ioutil.Discard,
-			Prompt:       "Say something: ",
-			DefaultValue: test.fallback,
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			q := &Question{
+				Reader:       strings.NewReader(tc.given),
+				Writer:       ioutil.Discard,
+				Prompt:       "Say something: ",
+				DefaultValue: tc.fallback,
+			}
 
-		answer, err := q.Ask()
-		assert.NoError(t, err)
-		assert.Equal(t, answer, test.expected, test.desc)
+			answer, err := q.Ask()
+			assert.NoError(t, err)
+			assert.Equal(t, answer, tc.expected)
+		})
 	}
 }

--- a/comms/selection_test.go
+++ b/comms/selection_test.go
@@ -78,7 +78,7 @@ func TestSelectionRead(t *testing.T) {
 }
 
 func TestSelectionPick(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		desc      string
 		selection Selection
 		things    []thing
@@ -111,16 +111,18 @@ func TestSelectionPick(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		test.selection.Writer = ioutil.Discard
-		for _, th := range test.things {
-			test.selection.Items = append(test.selection.Items, th)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tc.selection.Writer = ioutil.Discard
+			for _, th := range tc.things {
+				tc.selection.Items = append(tc.selection.Items, th)
+			}
 
-		item, err := test.selection.Pick("which one? %s")
-		assert.NoError(t, err)
-		th, ok := item.(thing)
-		assert.True(t, ok)
-		assert.Equal(t, test.expected, th.name)
+			item, err := tc.selection.Pick("which one? %s")
+			assert.NoError(t, err)
+			th, ok := item.(thing)
+			assert.True(t, ok)
+			assert.Equal(t, tc.expected, th.name)
+		})
 	}
 }

--- a/config/track_test.go
+++ b/config/track_test.go
@@ -14,16 +14,26 @@ func TestTrackIgnoreString(t *testing.T) {
 		},
 	}
 
-	tests := map[string]bool{
+	testCases := map[string]bool{
 		"falcon.txt": false,
 		"beacon|txt": true,
 		"beacon.ext": true,
 		"proof":      false,
 	}
 
-	for name, acceptable := range tests {
-		ok, err := track.AcceptFilename(name)
-		assert.NoError(t, err, name)
-		assert.Equal(t, acceptable, ok, name)
+	for name, acceptable := range testCases {
+		testName := name + " should " + notIfNeeded(acceptable) + "be an acceptable name."
+		t.Run(testName, func(t *testing.T) {
+			ok, err := track.AcceptFilename(name)
+			assert.NoError(t, err, name)
+			assert.Equal(t, acceptable, ok, testName)
+		})
 	}
+}
+
+func notIfNeeded(b bool) string {
+	if !b {
+		return "not "
+	}
+	return ""
 }

--- a/config/user_config_test.go
+++ b/config/user_config_test.go
@@ -42,7 +42,7 @@ func TestNormalizeWorkspace(t *testing.T) {
 	assert.NoError(t, err)
 
 	cfg := &UserConfig{Home: "/home/alice"}
-	tests := []struct {
+	testCases := []struct {
 		in, out string
 	}{
 		{"", ""}, // don't make wild guesses
@@ -54,9 +54,12 @@ func TestNormalizeWorkspace(t *testing.T) {
 		{"relative///path", filepath.Join(cwd, "relative", "path")},
 	}
 
-	for _, test := range tests {
-		cfg.Workspace = test.in
-		cfg.Normalize()
-		assert.Equal(t, test.out, cfg.Workspace)
+	for _, tc := range testCases {
+		testName := "'" + tc.in + "' should be normalized as '" + tc.out + "'"
+		t.Run(testName, func(t *testing.T) {
+			cfg.Workspace = tc.in
+			cfg.Normalize()
+			assert.Equal(t, tc.out, cfg.Workspace, testName)
+		})
 	}
 }

--- a/config/user_config_windows_test.go
+++ b/config/user_config_windows_test.go
@@ -40,7 +40,7 @@ func TestNormalizeWorkspace(t *testing.T) {
 	assert.NoError(t, err)
 
 	cfg := &UserConfig{Home: "C:\\Users\\alice"}
-	tests := []struct {
+	testCases := []struct {
 		in, out string
 	}{
 		{"", ""}, // don't make wild guesses
@@ -54,9 +54,13 @@ func TestNormalizeWorkspace(t *testing.T) {
 		{"relative///path", filepath.Join(cwd, "relative", "path")},
 	}
 
-	for _, test := range tests {
-		cfg.Workspace = test.in
-		cfg.Normalize()
-		assert.Equal(t, test.out, cfg.Workspace)
+	for _, tc := range testCases {
+		testName := "'" + tc.in + "' should be normalized as '" + tc.out + "'"
+
+		t.Run(testName, func(t *testing.T) {
+			cfg.Workspace = tc.in
+			cfg.Normalize()
+			assert.Equal(t, tc.out, cfg.Workspace, testName)
+		})
 	}
 }

--- a/workspace/path_type_test.go
+++ b/workspace/path_type_test.go
@@ -8,16 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testCase struct {
+	desc string
+	path string
+	pt   PathType
+}
+
 func TestDetectPathType(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "detect-path-type")
 
-	tests := []struct {
-		desc string
-		path string
-		pt   PathType
-	}{
-		{
+	testCases := []testCase{
+		testCase{
 			desc: "absolute dir",
 			path: filepath.Join(root, "a-dir"),
 			pt:   TypeDir,
@@ -54,9 +56,16 @@ func TestDetectPathType(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		pt, err := DetectPathType(test.path)
-		assert.NoError(t, err, test.desc)
-		assert.Equal(t, test.pt, pt, test.desc)
+	for _, tc := range testCases {
+		t.Run(tc.desc, makeTest(tc))
+
+	}
+}
+
+func makeTest(tc testCase) func(*testing.T) {
+	return func(t *testing.T) {
+		pt, err := DetectPathType(tc.path)
+		assert.NoError(t, err, tc.desc)
+		assert.Equal(t, tc.pt, pt, tc.desc)
 	}
 }

--- a/workspace/solution_test.go
+++ b/workspace/solution_test.go
@@ -43,7 +43,7 @@ func TestSolution(t *testing.T) {
 }
 
 func TestSuffix(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		solution Solution
 		suffix   string
 	}{
@@ -77,13 +77,16 @@ func TestSuffix(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		assert.Equal(t, test.suffix, test.solution.Suffix())
+	for _, tc := range testCases {
+		testName := "Suffix of '" + tc.solution.Dir + "' should be " + tc.suffix
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tc.suffix, tc.solution.Suffix(), testName)
+		})
 	}
 }
 
 func TestSolutionString(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		solution Solution
 		desc     string
 	}{
@@ -136,7 +139,10 @@ func TestSolutionString(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		assert.Equal(t, test.desc, test.solution.String())
+	for _, tc := range testCases {
+		testName := "should stringify to '" + tc.desc + "'"
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tc.desc, tc.solution.String())
+		})
 	}
 }

--- a/workspace/transmission_test.go
+++ b/workspace/transmission_test.go
@@ -18,7 +18,7 @@ func TestNewTransmission(t *testing.T) {
 	fileBird := filepath.Join(dirBird, "hummingbird.txt")
 	fileSugar := filepath.Join(dirFeeder, "sugar.txt")
 
-	tests := []struct {
+	testCases := []struct {
 		desc string
 		args []string
 		ok   bool
@@ -65,18 +65,20 @@ func TestNewTransmission(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		tx, err := NewTransmission(root, test.args)
-		if test.ok {
-			assert.NoError(t, err, test.desc)
-		} else {
-			assert.Error(t, err, test.desc)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tx, err := NewTransmission(root, tc.args)
+			if tc.ok {
+				assert.NoError(t, err, tc.desc)
+			} else {
+				assert.Error(t, err, tc.desc)
+			}
 
-		if test.tx != nil {
-			assert.Equal(t, test.tx.Files, tx.Files, test.desc)
-			assert.Equal(t, test.tx.Dir, tx.Dir, test.desc)
-		}
+			if tc.tx != nil {
+				assert.Equal(t, tc.tx.Files, tx.Files)
+				assert.Equal(t, tc.tx.Dir, tx.Dir)
+			}
+		})
 	}
 }
 

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -16,7 +16,7 @@ func TestLocateErrors(t *testing.T) {
 
 	ws := New(filepath.Join(root, "workspace"))
 
-	tests := []struct {
+	testCases := []struct {
 		desc, arg string
 		errFn     func(error) bool
 	}{
@@ -47,9 +47,11 @@ func TestLocateErrors(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		_, err := ws.Locate(test.arg)
-		assert.True(t, test.errFn(err), fmt.Sprintf("test: %s (arg: %s), %#v", test.desc, test.arg, err))
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := ws.Locate(tc.arg)
+			assert.True(t, tc.errFn(err), fmt.Sprintf("test: %s (arg: %s), %#v", tc.desc, tc.arg, err))
+		})
 	}
 }
 


### PR DESCRIPTION
This allow the test tools to show individuals reports.
Other tests in the CLI uses the pattern of having a
slice of input+expectedOutput+name, they may also benefit
form this solution (I can make the change if you like this
commit)