### PR TITLE
Use the binary name as the config subdirectory name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/config"
 	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
 )
@@ -48,6 +49,7 @@ func Execute() {
 
 func init() {
 	BinaryName = os.Args[0]
+	config.SubdirectoryName = BinaryName
 	Out = os.Stdout
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)

--- a/config/dir.go
+++ b/config/dir.go
@@ -6,6 +6,10 @@ import (
 	"runtime"
 )
 
+var (
+	SubdirectoryName = "exercism"
+)
+
 // Dir is the configured config home directory.
 // All the cli-related config files live in this directory.
 func Dir() string {
@@ -13,7 +17,7 @@ func Dir() string {
 	if runtime.GOOS == "windows" {
 		dir = os.Getenv("APPDATA")
 		if dir != "" {
-			return filepath.Join(dir, "exercism")
+			return filepath.Join(dir, SubdirectoryName)
 		}
 	} else {
 		dir := os.Getenv("EXERCISM_CONFIG_HOME")
@@ -25,7 +29,7 @@ func Dir() string {
 			dir = filepath.Join(os.Getenv("HOME"), ".config")
 		}
 		if dir != "" {
-			return filepath.Join(dir, "exercism")
+			return filepath.Join(dir, SubdirectoryName)
 		}
 	}
 	// If all else fails, use the current directory.


### PR DESCRIPTION
We need to be able to have multiple clients all working against different environments at the same time. If they all use a directory named 'exercism' for the config files, then running the configure command on any client will clobber the values of the other client.

I chose to use a package variable, since this is not something that different packages would want to set--it's only going to be set once for the entire CLI when booting up the process.

@nywilken I'm going to merge this as soon as it passes the tests, as I need to unblock some of our beta testers, but if you see any improvements you want, please do add a review and I'll make a new PR to clean up.