### PR TITLE
Rework download command to take exercise flag

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -29,7 +29,7 @@ latest solution.
 
 Download other people's solutions by providing the UUID.
 `,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token, err := cmd.Flags().GetString("token")
 		if err != nil {
@@ -45,9 +45,12 @@ Download other people's solutions by providing the UUID.
 		if err != nil {
 			return err
 		}
-		if uuid == "" && len(args) == 0 {
-			// TODO: usage
-			return errors.New("need an exercise name or a solution --uuid")
+		exercise, err := cmd.Flags().GetString("exercise")
+		if err != nil {
+			return err
+		}
+		if uuid == "" && exercise == "" {
+			return errors.New("need an --exercise name or a solution --uuid")
 		}
 		usrCfg, err := config.NewUserConfig()
 		if err != nil {
@@ -75,10 +78,6 @@ Download other people's solutions by providing the UUID.
 		track, err := cmd.Flags().GetString("track")
 		if err != nil {
 			return err
-		}
-		var exercise string
-		if len(args) > 0 {
-			exercise = args[0]
 		}
 
 		if uuid == "" {
@@ -222,6 +221,7 @@ type downloadPayload struct {
 func initDownloadCmd() {
 	downloadCmd.Flags().StringP("uuid", "u", "", "the solution UUID")
 	downloadCmd.Flags().StringP("track", "t", "", "the track ID")
+	downloadCmd.Flags().StringP("exercise", "e", "", "the exercise ID")
 	downloadCmd.Flags().StringP("token", "k", "", "authentication token used to connect to the site")
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -29,7 +29,6 @@ latest solution.
 
 Download other people's solutions by providing the UUID.
 `,
-	Args: cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token, err := cmd.Flags().GetString("token")
 		if err != nil {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -221,7 +221,7 @@ type downloadPayload struct {
 func initDownloadCmd() {
 	downloadCmd.Flags().StringP("uuid", "u", "", "the solution UUID")
 	downloadCmd.Flags().StringP("track", "t", "", "the track ID")
-	downloadCmd.Flags().StringP("exercise", "e", "", "the exercise ID")
+	downloadCmd.Flags().StringP("exercise", "e", "", "the exercise slug")
 	downloadCmd.Flags().StringP("token", "k", "", "authentication token used to connect to the site")
 }
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -56,7 +56,7 @@ func TestDownload(t *testing.T) {
 	cmdTest := &CommandTest{
 		Cmd:    downloadCmd,
 		InitFn: initDownloadCmd,
-		Args:   []string{"fakeapp", "download", "bogus-exercise"},
+		Args:   []string{"fakeapp", "download", "--exercise=bogus-exercise"},
 	}
 	cmdTest.Setup(t)
 	defer cmdTest.Teardown(t)

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -138,3 +138,32 @@ func makeMockServer() *httptest.Server {
 	return server
 
 }
+
+func TestDownloadArgs(t *testing.T) {
+	tests := []struct {
+		args          []string
+		expectedError string
+	}{
+		{
+			args:          []string{"bogus"}, // providing just an exercise slug without the flag
+			expectedError: "need an --exercise name or a solution --uuid",
+		},
+		{
+			args:          []string{""}, // providing no args
+			expectedError: "need an --exercise name or a solution --uuid",
+		},
+	}
+
+	for _, test := range tests {
+		cmdTest := &CommandTest{
+			Cmd:    downloadCmd,
+			InitFn: initDownloadCmd,
+			Args:   append([]string{"fakeapp", "download"}, test.args...),
+		}
+		cmdTest.Setup(t)
+		defer cmdTest.Teardown(t)
+		err := cmdTest.App.Execute()
+
+		assert.EqualError(t, err, test.expectedError)
+	}
+}


### PR DESCRIPTION
Hi! This very minimally solves https://github.com/exercism/cli/issues/545

This is my first contribution (and actually the first time I've ever touched go code) - so I hope it's alright.

### The fix:

* Changed the command to take ONLY flags
* Check for the exercise flag instead of relying on the arg
* Lifted the check for exercise name to the beginning of the function so it can thow an error early if there is no exercise name OR uuid

### About me:

I've played very in a very minor way with exercism a while back and thought it was awesome (but not immediately useful to me).

A good friend of mine recently started programming and I showed her exercism. She immediately connected with it and is having an awesome experience which reinvigorated my excitement and I thought I would help where I can! (though I have no go experience)

❤️ Hope this helps and thanks for the amazing community you've created! ❤️

