### PR TITLE
Use the binary name to determine the default workspace

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -33,6 +33,9 @@ You can also override certain default settings to suit your preferences.
 		if err != nil {
 			return err
 		}
+		if usrCfg.Workspace == "" {
+			fmt.Println(usrCfg.Home + BinaryName)
+		}
 
 		apiCfg := config.NewEmptyAPIConfig()
 		err = apiCfg.Load(viperAPIConfig)


### PR DESCRIPTION
This is temporary, to unblock beta testing.
To be fixed properly by https://github.com/exercism/cli/issues/541

FYI @nywilken I'm going to merge this when it goes green, to unblock some beta testing.