### PR TITLE
Fix panic in Workspace.Locate when encountering filesystem errors

### DIFF
--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -61,6 +61,10 @@ func (ws Workspace) Locate(exercise string) ([]string, error) {
 	var paths []string
 	// Look through the entire workspace tree to find any matches.
 	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		// If it's a symlink, follow it, then get the file info of the target.
 		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 			src, err := filepath.EvalSymlinks(path)


### PR DESCRIPTION
I encountered this while playing around after cloning the repo, when trying to download the a `hello-world` exercise. I suspect this is because my built binaries are named the same as the intended download folder? 🤷‍♂️ 

Regardless, the problem is:

[filepath.Walk](https://golang.org/pkg/path/filepath/#Walk) passes any errors it encounters straight to our `walkFn`, without a `os.FileInfo` object (in case we want to do any filtering on the errors).

https://github.com/golang/go/blob/master/src/path/filepath/path.go#L401

Our code then tries to call `info.Mode()` when `info == nil`, hence the panic.

This PR fixes that by checking for any errors passed into `walkFn`, and passing them straight back.

**Before**

```
➜  cli git:(fix-download-panic) ✗ ./testercism download hello-world
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x13b6734]

goroutine 1 [running]:
github.com/exercism/cli/workspace.Workspace.Locate.func1(0xc420086040, 0x3c, 0x0, 0x0, 0x171acc0, 0xc42048c690, 0x0, 0x0)
	/Users/rjackson/go/src/github.com/exercism/cli/workspace/workspace.go:65 +0x44
path/filepath.Walk(0xc420086040, 0x3c, 0xc4202321e0, 0x0, 0x171acc0)
	/usr/local/Cellar/go/1.9.2/libexec/src/path/filepath/path.go:401 +0x76
github.com/exercism/cli/workspace.Workspace.Locate(0xc420086040, 0x3c, 0xc420238240, 0xb, 0x109a0aa, 0xc420086040, 0x39, 0x1ed, 0x171acc0)
	/Users/rjackson/go/src/github.com/exercism/cli/workspace/workspace.go:100 +0x188
github.com/exercism/cli/workspace.Workspace.SolutionPath(0xc420086040, 0x3c, 0xc420238240, 0xb, 0xc4202b2100, 0x20, 0x0, 0x1, 0x0, 0x0)
	/Users/rjackson/go/src/github.com/exercism/cli/workspace/workspace.go:113 +0x59
github.com/exercism/cli/cmd.glob..func2(0x17dd2c0, 0xc42007f370, 0x1, 0x1, 0x0, 0x0)
	/Users/rjackson/go/src/github.com/exercism/cli/cmd/download.go:125 +0x814
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).execute(0x17dd2c0, 0xc42007f350, 0x1, 0x1, 0x17dd2c0, 0xc42007f350)
	/Users/rjackson/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:649 +0x456
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x17dd080, 0xc42007c058, 0x0, 0x1)
	/Users/rjackson/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:728 +0x2fe
github.com/exercism/cli/vendor/github.com/spf13/cobra.(*Command).Execute(0x17dd080, 0x0, 0x0)
	/Users/rjackson/go/src/github.com/exercism/cli/vendor/github.com/spf13/cobra/command.go:687 +0x2b
github.com/exercism/cli/cmd.Execute()
	/Users/rjackson/go/src/github.com/exercism/cli/cmd/root.go:45 +0x2d
main.main()
	/Users/rjackson/go/src/github.com/exercism/cli/exercism/main.go:6 +0x20
```

**After**

```
➜  cli git:(fix-download-panic) ✗ ./testercism-fix-download-panic download hello-world
Error: open /Users/rjackson/go/src/github.com/exercism/cli/testercism-fix-download-panic/go/hello-world/.solution.json: not a directory
```