### PR TITLE
Clean up default workspace directory

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -35,6 +35,7 @@ You can also override certain default settings to suit your preferences.
 		if err != nil {
 			return err
 		}
+		usrCfg.Normalize()
 		if usrCfg.Workspace == "" {
 			dirName := path.Base(BinaryName)
 			defaultWorkspace := path.Join(usrCfg.Home, dirName)

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/exercism/cli/config"
@@ -37,7 +38,7 @@ You can also override certain default settings to suit your preferences.
 		}
 		usrCfg.Normalize()
 		if usrCfg.Workspace == "" {
-			dirName := path.Base(BinaryName)
+			dirName := strings.Replace(path.Base(BinaryName), ".exe", "", 1)
 			defaultWorkspace := path.Join(usrCfg.Home, dirName)
 			_, err := os.Stat(defaultWorkspace)
 			// Sorry about the double negative.

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"text/tabwriter"
 
@@ -35,7 +36,14 @@ You can also override certain default settings to suit your preferences.
 			return err
 		}
 		if usrCfg.Workspace == "" {
-			usrCfg.Workspace = path.Join(usrCfg.Home, path.Base(BinaryName))
+			dirName := path.Base(BinaryName)
+			defaultWorkspace := path.Join(usrCfg.Home, dirName)
+			_, err := os.Stat(defaultWorkspace)
+			// Sorry about the double negative.
+			if !os.IsNotExist(err) {
+				defaultWorkspace = fmt.Sprintf("%s-1", defaultWorkspace)
+			}
+			usrCfg.Workspace = defaultWorkspace
 		}
 
 		apiCfg := config.NewEmptyAPIConfig()


### PR DESCRIPTION
While testing the alpha-9 build we came across three issues with the default workspace directory:

- the download would blow up if you happened to configure the workspace to the same location as the binary
- on windows using the binary name for the workspace directory turned out weird because of the `.exe` suffix
- while I thought we were creating the workspace directory in the home directory, it turns out we were creating it in the current directory, because `cfg.Home` was empty

This is still a hacky solution just to unlock some beta testing, I will do proper testing and cleanup when solving the workspace issues properly as described in #542 

Merging as soon as the tests go green.

/cc @nywilken 