### PR TITLE
moving debug response parser to use the body reader copy

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -31,6 +31,7 @@ func Printf(format string, args ...interface{}) {
 	}
 }
 
+// DumpRequest dumps out the provided http.Request
 func DumpRequest(req *http.Request) {
 	if !Verbose {
 		return
@@ -53,6 +54,7 @@ func DumpRequest(req *http.Request) {
 	req.Body = ioutil.NopCloser(&bodyCopy)
 }
 
+// DumpResponse dumps out the provided http.Response
 func DumpResponse(res *http.Response) {
 	if !Verbose {
 		return
@@ -72,5 +74,5 @@ func DumpResponse(res *http.Response) {
 	Println("========================= END DumpResponse =========================")
 	Println("")
 
-	res.Body = ioutil.NopCloser(&bodyCopy)
+	res.Body = ioutil.NopCloser(body)
 }


### PR DESCRIPTION
Fixes https://github.com/exercism/v2-feedback/issues/169

The debug mode is trying to process an empty `resp.Body` from the `http.Response` dump function, which only happens when you provide the `--verbose` flag. To fix, reassign the `res.Body` inside `debug` pkg to the original body reader.

```
[sborza@icebox]:~/src/github.com/exercism/cli (fix_verbose *%):$ ./testercism download hello-world --track=go -v

========================= BEGIN DumpRequest =========================
GET /api/v1/solutions/latest?exercise_id=hello-world&track_id=go HTTP/1.1
Host: mentors-beta.exercism.io
Authorization: Bearer d8cfc839-10fb-4486-a2c7-9f1e738d1a3d
Content-Type: application/json
User-Agent: github.com/exercism/cli v3.0.0-alpha.9.mentors (linux/amd64)


========================= END DumpRequest =========================


========================= BEGIN DumpResponse =========================
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Sun, 24 Jun 2018 20:31:09 GMT
Etag: W/"49f6dfe92fabcf92827c8513ffb03ee0"
Server: nginx/1.10.3 (Ubuntu)
Set-Cookie: _exercism_session=T1FUOEtGZmlmbG1lTXJnMnIybW5VYzlkMlp4MEtpc0RkMVgreTZlK0UxMnJaVG5PbkYwQWFBVFNzMnhPNitYN2RGa3UzOXBmeEF6UFZYS2ZOZ1ZURHFmWUJEbHdSTzY2SkQ3ZGVjQjRqTmRuSTY4a3h0dlhoK2RkVlVjbVFyaGs2dmN2NlEwVkVoYlV5MWF3bW1XMU80eXhPQUFwc0pwSFBpT0VJNHJ1cGVJQUpXa2J2a1crZnZnTmZ2YkNrNStZLS1mSzNSSzZpZkZocTFBbFNxRU9iSnl3PT0%3D--fa5dd7a9066f03b11e76eea707eec73ed1647642; domain=.exercism.io; path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: adaa8479-e00c-4c55-8e5a-6586baa3db6c
X-Runtime: 1.439385
X-Xss-Protection: 1; mode=block


========================= END DumpResponse =========================


========================= BEGIN DumpRequest =========================
GET /api/v1/solutions/3d333d2618f64a1a9e6d70f67d475338/files/README.md HTTP/1.1
Host: mentors-beta.exercism.io
Authorization: Bearer d8cfc839-10fb-4486-a2c7-9f1e738d1a3d
Content-Type: application/json
User-Agent: github.com/exercism/cli v3.0.0-alpha.9.mentors (linux/amd64)


========================= END DumpRequest =========================


========================= BEGIN DumpResponse =========================
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Type: text/plain; charset=utf-8
Date: Sun, 24 Jun 2018 20:31:10 GMT
Etag: W/"3ec0992bc039f8710d8900833266b43b"
Server: nginx/1.10.3 (Ubuntu)
Set-Cookie: _exercism_session=ZXQ4L0hWOWcvZ1l1cTRTYW01c0EvejFMdGNLbHllRjVyNVppT1hsSk9QMldvN0N0aEhPMXUwbU1vQ0RCM0ZZVlZUVVN0ZXU3WFBPM0NaakUwS2VPdTZaTmEwK0NYVzJZNmhQU0NzT29rMXkwNzBtYURKVHRod0pJaVV3RWt1and2bnBBNFVLeTFZVlBJU2RBVjZaeEFqRVRYb2dQdW5lcWROUnNTWlhnRk50WGdHU3J4bFlwSUhvai9OOVR1M3MxLS1SbmNTeFlWaUkyekpHcVNjcmxJeVVBPT0%3D--c609c706c15b5f8d11f5bbcc66c95d6315cbb696; domain=.exercism.io; path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: a1a078d4-d8c5-408c-a10a-78a9ffd17bbf
X-Runtime: 0.027326
X-Xss-Protection: 1; mode=block


========================= END DumpResponse =========================


========================= BEGIN DumpRequest =========================
GET /api/v1/solutions/3d333d2618f64a1a9e6d70f67d475338/files/hello_test.go HTTP/1.1
Host: mentors-beta.exercism.io
Authorization: Bearer d8cfc839-10fb-4486-a2c7-9f1e738d1a3d
Content-Type: application/json
User-Agent: github.com/exercism/cli v3.0.0-alpha.9.mentors (linux/amd64)


========================= END DumpRequest =========================


========================= BEGIN DumpResponse =========================
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Type: text/plain; charset=utf-8
Date: Sun, 24 Jun 2018 20:31:11 GMT
Etag: W/"7f3d6b1c5549f26ca3176245b3fc1af5"
Server: nginx/1.10.3 (Ubuntu)
Set-Cookie: _exercism_session=S2R0b0ttTVI0TWdJYVA2ZFliM2dQZllaalphWmtRQ1hvenEwNC9BVTF2WFM3SWxpcHNOdVhQVVltV200TlFXa25tN0ZqcWw4KzRCOEhkUjVZNEV2d0RteE1oZHltZ0l1RHBCZWpJVU9DUXRWQnRKMVduYkY5NVZjZWk5SW9wTWRUOGZHZVRSZTdKbVpLNmQ1TXJGMFJheFUyNm9Wb1Q4UXc5bTRXRlJLNG9rWFN6VStBSm5ZQ0lzeG5Gc0JXRTR5LS12NnpOUVp2ODMzQUN4QjlORFVQU2RRPT0%3D--37b89ee390cbb503f98191c18afa2c8758c30476; domain=.exercism.io; path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: dc208fab-94ed-4629-8a7c-c7a865be9f66
X-Runtime: 0.024654
X-Xss-Protection: 1; mode=block


========================= END DumpResponse =========================


========================= BEGIN DumpRequest =========================
GET /api/v1/solutions/3d333d2618f64a1a9e6d70f67d475338/files/hello_world.go HTTP/1.1
Host: mentors-beta.exercism.io
Authorization: Bearer d8cfc839-10fb-4486-a2c7-9f1e738d1a3d
Content-Type: application/json
User-Agent: github.com/exercism/cli v3.0.0-alpha.9.mentors (linux/amd64)


========================= END DumpRequest =========================


========================= BEGIN DumpResponse =========================
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Type: text/plain; charset=utf-8
Date: Sun, 24 Jun 2018 20:31:11 GMT
Etag: W/"978a6c3cb23cbdd03fece068ffcddbe8"
Server: nginx/1.10.3 (Ubuntu)
Set-Cookie: _exercism_session=b1pmQnZGMkc5Z0ZzbHdibExXS1ZZMjJYb2ZjYkVJRWNDYndQTzNvUVdSd3RwL2N6T0tsUXBDNzlFVFZVT0hhaVYvZDJhbGNYOHExenUxTVp6UjlUMXlZYWgzQ09TdCttRUxISEluREVEeU1heUdxYWtuaE13NFZwdkdMSDAxb0VUbW1xb0dKWXRhaDdOVEZ5T1laQ21TVzR2cHd3OHBTZTZZVjNUZ3pnNmZYWmwrQ1NpNTJYalJKMVFrSHNDT0ZiLS1mem5sRnlvZ3dKMTVoeEtIcU9uN01RPT0%3D--a92c4132e1e145cc5030f527688b8eeb5f47f09f; domain=.exercism.io; path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: 58fe3f3b-c49c-4d95-ae5f-2c86c1ee83e4
X-Runtime: 0.025519
X-Xss-Protection: 1; mode=block


========================= END DumpResponse =========================


Downloaded to
/home/sborza/src/github.com/challenges/mentorcism/go/hello-world
[sborza@icebox]:~/src/github.com/exercism/cli (fix_verbose *%):$ ./testercism download hello-world --track=go

Downloaded to
/home/sborza/src/github.com/challenges/mentorcism/go/hello-world
```