### PR TITLE
Add quiet flag

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -172,6 +172,7 @@ Download other people's solutions by providing the UUID.
 				return err
 			}
 		}
+
 		fmt.Fprintf(Out, "\nDownloaded to\n%s\n", solution.Dir)
 		return nil
 	},

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -30,6 +30,8 @@ Download other people's solutions by providing the UUID.
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+
 		token, err := cmd.Flags().GetString("token")
 		if err != nil {
 			return err
@@ -171,6 +173,11 @@ Download other people's solutions by providing the UUID.
 			if err != nil {
 				return err
 			}
+		}
+
+		if quiet {
+			fmt.Fprintln(Out, solution.Dir)
+			return nil
 		}
 
 		fmt.Fprintf(Out, "\nDownloaded to\n%s\n", solution.Dir)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,5 +53,6 @@ func init() {
 	Out = os.Stdout
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
+	RootCmd.PersistentFlags().BoolP("quiet", "q", false, "quiet mode")
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -37,6 +37,8 @@ track it is on and submit it. The command will ask for help
 figuring things out if necessary.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+
 		usrCfg, err := config.NewUserConfig()
 		if err != nil {
 			return err
@@ -100,7 +102,9 @@ figuring things out if necessary.
 			}
 			s, ok := option.(*workspace.Solution)
 			if !ok {
-				fmt.Fprintf(Out, "something went wrong trying to pick that solution, not sure what happened")
+				if !quiet {
+					fmt.Fprintf(Out, "something went wrong trying to pick that solution, not sure what happened")
+				}
 				continue
 			}
 			solution = s
@@ -162,10 +166,14 @@ figuring things out if necessary.
 				return err
 			}
 			if strings.ToLower(answer) != "y" {
-				fmt.Fprintf(Out, "Submit cancelled.\nTry submitting individually instead.")
+				if !quiet {
+					fmt.Fprintf(Out, "Submit cancelled.\nTry submitting individually instead.")
+				}
 				return nil
 			}
-			fmt.Fprintf(Out, "Submitting files now...")
+			if !quiet {
+				fmt.Fprintf(Out, "Submitting files now...")
+			}
 		}
 
 		for _, path := range paths {
@@ -231,10 +239,12 @@ figuring things out if necessary.
 		}
 
 		if solution.AutoApprove == true {
-			fmt.Fprintf(Out, "Your solution has been submitted " +
-				"successfully and has been auto-approved. You can complete " +
-				"the exercise and unlock the next core exercise at %s\n",
-				solution.URL)
+			if !quiet {
+				fmt.Fprintf(Out, "Your solution has been submitted "+
+					"successfully and has been auto-approved. You can complete "+
+					"the exercise and unlock the next core exercise at %s\n",
+					solution.URL)
+			}
 		} else {
 			//TODO
 		}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,20 +22,24 @@ The next time you upgrade, the hidden file will be overwritten.
 You can always delete this file.
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+
 		c := cli.New(Version)
-		return updateCLI(c)
+		return updateCLI(c, quiet)
 	},
 }
 
 // updateCLI updates CLI to the latest available version, if it is out of date.
-func updateCLI(c cli.Updater) error {
+func updateCLI(c cli.Updater, quiet bool) error {
 	ok, err := c.IsUpToDate()
 	if err != nil {
 		return err
 	}
 
 	if ok {
-		fmt.Fprintln(Out, "Your CLI version is up to date.")
+		if !quiet {
+			fmt.Fprintln(Out, "Your CLI version is up to date.")
+		}
 		return nil
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,6 +26,12 @@ To check for the latest available version, call the command with the
 	`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		if quiet {
+			fmt.Fprintln(Out, Version)
+			return nil
+		}
+
 		fmt.Println(currentVersion())
 
 		if checkLatest {


### PR DESCRIPTION
Adding a quiet flag to hide human-friendly output, which will make it a little easier to script with the Exercism CLI.

The idea comes from #576, with the example of automatically changing directory to a just-downloaded exercise:

```
cd $(mentorcism download hello-world --track=erlang -q)
```

Commands to review:

- [x] configure (no change)
- [x] download
- [x] help (no change)
- [x] open (no change)
- [x] prepare (no change)
- [x] submit
- [x] troubleshoot (no change)
- [x] upgrade
- [x] version
- [x] workspace (no change)
- [ ] Errors? Some errors are currently logged to `stdout`. Might be worth reviewing and updating those lines to use `fmt.Errorf()` / `errors.New`. Separate issue?

**Proof of functionality**

Download:

```
➜  hello-world testercism download hello-world

Downloaded to
/Users/rjackson/testercism/go/hello-world
➜  hello-world testercism download hello-world -q
/Users/rjackson/testercism/go/hello-world
```

Submit:

```
➜  hello-world testercism submit hello_world.go
Your solution has been submitted successfully and has been auto-approved. You can complete the exercise and unlock the next core exercise at https://v2.exercism.io/my/solutions/7535a49fd9284b778848a009c9db2633
➜  hello-world testercism submit hello_world.go -q
➜  hello-world echo $?
0
```


Upgrade:

```
➜  hello-world testercism upgrade
Your CLI version is up to date.
➜  hello-world testercism upgrade -q
➜  hello-world echo $?
0
```

Version:

```
➜  hello-world testercism version
exercism version 3.0.0-alpha.4
➜  hello-world testercism version -q
3.0.0-alpha.4
```