### PR TITLE
Move API error handling into the commands

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -68,8 +69,12 @@ func TestDo(t *testing.T) {
 	req, err := client.NewRequest("GET", ts.URL, nil)
 	assert.NoError(t, err)
 
-	var body payload
-	_, err = client.Do(req, &body)
+	res, err := client.Do(req)
 	assert.NoError(t, err)
+
+	var body payload
+	err = json.NewDecoder(res.Body).Decode(&body)
+	assert.NoError(t, err)
+
 	assert.Equal(t, "world", body.Hello)
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -95,9 +95,9 @@ Download other people's solutions by providing the UUID.
 			return err
 		}
 
-		payload := &downloadPayload{}
+		var payload downloadPayload
 		defer res.Body.Close()
-		if err := json.NewDecoder(res.Body).Decode(payload); err != nil {
+		if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
 			return fmt.Errorf("unable to parse API response - %s", err)
 		}
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -90,7 +90,7 @@ Download other people's solutions by providing the UUID.
 			req.URL.RawQuery = q.Encode()
 		}
 
-		res, err := client.Do(req, nil)
+		res, err := client.Do(req)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ Download other people's solutions by providing the UUID.
 				return err
 			}
 
-			res, err := client.Do(req, nil)
+			res, err := client.Do(req)
 			if err != nil {
 				return err
 			}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -89,10 +90,20 @@ Download other people's solutions by providing the UUID.
 			req.URL.RawQuery = q.Encode()
 		}
 
-		payload := &downloadPayload{}
-		res, err := client.Do(req, payload)
+		res, err := client.Do(req, nil)
 		if err != nil {
 			return err
+		}
+
+		payload := &downloadPayload{}
+		defer res.Body.Close()
+		if err := json.NewDecoder(res.Body).Decode(payload); err != nil {
+			return fmt.Errorf("unable to parse API response - %s", err)
+		}
+
+		if res.StatusCode == http.StatusUnauthorized {
+			siteURL := config.InferSiteURL(usrCfg.APIBaseURL)
+			return fmt.Errorf("unauthorized request. Please run the configure command. You can find your API token at %s/my/settings", siteURL)
 		}
 
 		if res.StatusCode != http.StatusOK {

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -60,7 +60,7 @@ func prepareTrack(id string) error {
 		return err
 	}
 
-	res, err := client.Do(req, nil)
+	res, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -59,14 +60,20 @@ func prepareTrack(id string) error {
 		return err
 	}
 
-	payload := &prepareTrackPayload{}
-	res, err := client.Do(req, payload)
+	res, err := client.Do(req, nil)
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
+
+	payload := &prepareTrackPayload{}
+
+	if err := json.NewDecoder(res.Body).Decode(payload); err != nil {
+		return fmt.Errorf("unable to parse API response - %s", err)
+	}
 
 	if res.StatusCode != http.StatusOK {
-		return errors.New("api call failed")
+		return errors.New(payload.Error.Message)
 	}
 
 	cliCfg, err := config.NewCLIConfig()
@@ -92,6 +99,10 @@ type prepareTrackPayload struct {
 		Language    string `json:"language"`
 		TestPattern string `json:"test_pattern"`
 	} `json:"track"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
 }
 
 func initPrepareCmd() {

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -66,9 +66,9 @@ func prepareTrack(id string) error {
 	}
 	defer res.Body.Close()
 
-	payload := &prepareTrackPayload{}
+	var payload prepareTrackPayload
 
-	if err := json.NewDecoder(res.Body).Decode(payload); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
 		return fmt.Errorf("unable to parse API response - %s", err)
 	}
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -214,7 +214,7 @@ figuring things out if necessary.
 		}
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 
-		resp, err := client.Do(req, nil)
+		resp, err := client.Do(req)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I realized that we were unnecessarily complicating things by pushing some of the error handling into the global API wrapper, whereas it's in each of the commands that we'll know how to handle individual error types specific to the command that the API returns.

This is a pretty small change, but I'd appreciate your feedback on it, @nywilken, if you have time.