### PR TITLE
Tweak path resolving logic

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -37,6 +37,7 @@ You can also override certain default settings to suit your preferences.
 		if err != nil {
 			return err
 		}
+		usrCfg.Workspace = config.Resolve(usrCfg.Workspace, usrCfg.Home)
 		usrCfg.SetDefaults()
 		if usrCfg.Workspace == "" {
 			dirName := strings.Replace(path.Base(BinaryName), ".exe", "", 1)

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -70,4 +71,26 @@ func InferSiteURL(apiURL string) string {
 	}
 	re := regexp.MustCompile("^(https?://[^/]*).*")
 	return re.ReplaceAllString(apiURL, "$1")
+}
+
+func Resolve(path, home string) string {
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "~/") {
+		path = strings.Replace(path, "~/", "", 1)
+		return filepath.Join(home, path)
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	// if using "/dir" on Windows
+	if strings.HasPrefix(path, "/") {
+		return filepath.Join(home, filepath.Clean(path))
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(cwd, path)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,3 +111,27 @@ func TestInferSiteURL(t *testing.T) {
 		assert.Equal(t, InferSiteURL(tc.api), tc.url)
 	}
 }
+
+func TestResolve(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		in, out string
+	}{
+		{"", ""}, // don't make wild guesses
+		{"/home/alice///foobar", "/home/alice/foobar"},
+		{"~/foobar", "/home/alice/foobar"},
+		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
+		{"/no/modification", "/no/modification"},
+		{"relative", filepath.Join(cwd, "relative")},
+		{"relative///path", filepath.Join(cwd, "relative", "path")},
+	}
+
+	for _, tc := range testCases {
+		testName := "'" + tc.in + "' should be normalized as '" + tc.out + "'"
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tc.out, Resolve(tc.in, "/home/alice"), testName)
+		})
+	}
+}

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -2,9 +2,7 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -40,7 +38,7 @@ func (cfg *UserConfig) SetDefaults() {
 	if cfg.Home == "" {
 		cfg.Home = userHome()
 	}
-	cfg.Workspace = cfg.resolve(cfg.Workspace)
+	cfg.Workspace = Resolve(cfg.Workspace, cfg.Home)
 }
 
 // Write stores the config to disk.
@@ -75,26 +73,4 @@ func userHome() string {
 	// If all else fails, use the current directory.
 	dir, _ = os.Getwd()
 	return dir
-}
-
-func (cfg *UserConfig) resolve(path string) string {
-	if path == "" {
-		return ""
-	}
-	if strings.HasPrefix(path, "~/") {
-		path = strings.Replace(path, "~/", "", 1)
-		return filepath.Join(cfg.Home, path)
-	}
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-	// if using "/dir" on Windows
-	if strings.HasPrefix(path, "/") {
-		return filepath.Join(cfg.Home, filepath.Clean(path))
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return path
-	}
-	return filepath.Join(cwd, path)
 }

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -38,7 +38,6 @@ func (cfg *UserConfig) SetDefaults() {
 	if cfg.Home == "" {
 		cfg.Home = userHome()
 	}
-	cfg.Workspace = Resolve(cfg.Workspace, cfg.Home)
 }
 
 // Write stores the config to disk.

--- a/config/user_config_test.go
+++ b/config/user_config_test.go
@@ -5,7 +5,6 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -35,31 +34,4 @@ func TestUserConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "a", cfg.Token)
 	assert.Equal(t, "/a", cfg.Workspace)
-}
-
-func TestSetDefaultWorkspace(t *testing.T) {
-	cwd, err := os.Getwd()
-	assert.NoError(t, err)
-
-	cfg := &UserConfig{Home: "/home/alice"}
-	testCases := []struct {
-		in, out string
-	}{
-		{"", ""}, // don't make wild guesses
-		{"/home/alice///foobar", "/home/alice/foobar"},
-		{"~/foobar", "/home/alice/foobar"},
-		{"/foobar/~/noexpand", "/foobar/~/noexpand"},
-		{"/no/modification", "/no/modification"},
-		{"relative", filepath.Join(cwd, "relative")},
-		{"relative///path", filepath.Join(cwd, "relative", "path")},
-	}
-
-	for _, tc := range testCases {
-		testName := "'" + tc.in + "' should be normalized as '" + tc.out + "'"
-		t.Run(testName, func(t *testing.T) {
-			cfg.Workspace = tc.in
-			cfg.SetDefaults()
-			assert.Equal(t, tc.out, cfg.Workspace, testName)
-		})
-	}
 }


### PR DESCRIPTION
This makes resolve a function on the config package instead of a method on the UserConfig type, and then changes the configure command so that we are only resolving user-provided values.

FYI @nywilken I'm going to merge this when it goes green.