### PR TITLE
Remove indirection for API URLs

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -104,7 +104,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 
 // ValidateToken calls the API to determine whether the token is valid.
 func (c *Client) ValidateToken() error {
-	url := c.APIConfig.URL("validate")
+	url := fmt.Sprintf("%s/validate_token", c.APIConfig.BaseURL)
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/cli/status.go
+++ b/cli/status.go
@@ -104,7 +104,7 @@ func newAPIReachabilityStatus() (apiReachabilityStatus, error) {
 	ar := apiReachabilityStatus{
 		Services: []*apiPing{
 			{Service: "GitHub", URL: "https://api.github.com"},
-			{Service: "Exercism", URL: apiCfg.URL("ping")},
+			{Service: "Exercism", URL: fmt.Sprintf("%s/ping", apiCfg.BaseURL)},
 		},
 	}
 	var wg sync.WaitGroup

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -59,7 +59,7 @@ Download other people's solutions by providing the UUID.
 		} else {
 			slug = uuid
 		}
-		url := apiCfg.URL("download", slug)
+		url := fmt.Sprintf("%s/solutions/%s", apiCfg.BaseURL, slug)
 
 		client, err := api.NewClient()
 		if err != nil {

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -52,7 +52,7 @@ func prepareTrack(id string) error {
 	if err != nil {
 		return err
 	}
-	url := apiCfg.URL("prepare-track", id)
+	url := fmt.Sprintf("%s/tracks/%s", apiCfg.BaseURL, id)
 
 	req, err := client.NewRequest("GET", url, nil)
 	if err != nil {

--- a/cmd/prepare_test.go
+++ b/cmd/prepare_test.go
@@ -37,7 +37,6 @@ func TestPrepareTrack(t *testing.T) {
 
 	apiCfg := config.NewEmptyAPIConfig()
 	apiCfg.BaseURL = ts.URL
-	apiCfg.Endpoints = map[string]string{"prepare-track": "?%s"}
 	err := apiCfg.Write()
 	assert.NoError(t, err)
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -212,7 +212,8 @@ figuring things out if necessary.
 		if err != nil {
 			return err
 		}
-		req, err := client.NewRequest("PATCH", apiCfg.URL("submit", solution.ID), body)
+		url := fmt.Sprintf("%s/solutions/%s", apiCfg.BaseURL, solution.ID)
+		req, err := client.NewRequest("PATCH", url, body)
 		if err != nil {
 			return err
 		}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -112,7 +112,6 @@ func TestSubmit(t *testing.T) {
 	apiCfg, err := config.NewAPIConfig()
 	assert.NoError(t, err)
 	apiCfg.BaseURL = ts.URL
-	apiCfg.Endpoints["submit"] = "?%s"
 	err = apiCfg.Write()
 	assert.NoError(t, err)
 

--- a/config/api_config.go
+++ b/config/api_config.go
@@ -1,28 +1,19 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/viper"
 )
 
 var (
-	defaultBaseURL   = "https://v2.exercism.io/api/v1"
-	defaultEndpoints = map[string]string{
-		"download":      "/solutions/%s",
-		"submit":        "/solutions/%s",
-		"prepare-track": "/tracks/%s",
-		"ping":          "/ping",
-		"validate":      "/validate_token",
-	}
+	defaultBaseURL = "https://v2.exercism.io/api/v1"
 )
 
 // APIConfig provides API-specific configuration values.
 type APIConfig struct {
 	*Config
-	BaseURL   string
-	Endpoints map[string]string
+	BaseURL string
 }
 
 // NewAPIConfig loads the config file in the config directory.
@@ -43,25 +34,6 @@ func (cfg *APIConfig) SetDefaults() {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = defaultBaseURL
 	}
-	if cfg.Endpoints == nil {
-		cfg.Endpoints = defaultEndpoints
-		return
-	}
-
-	for key, endpoint := range defaultEndpoints {
-		if cfg.Endpoints[key] == "" {
-			cfg.Endpoints[key] = endpoint
-		}
-	}
-}
-
-// URL provides the API URL for a given endpoint key.
-func (cfg *APIConfig) URL(key string, args ...interface{}) string {
-	pattern := fmt.Sprintf("%s%s", cfg.BaseURL, cfg.Endpoints[key])
-	if args == nil {
-		return pattern
-	}
-	return fmt.Sprintf(pattern, args...)
 }
 
 // NewEmptyAPIConfig doesn't load the config from file or set default values.

--- a/config/api_config_test.go
+++ b/config/api_config_test.go
@@ -17,10 +17,6 @@ func TestAPIConfig(t *testing.T) {
 	cfg := &APIConfig{
 		Config:  New(dir, "api"),
 		BaseURL: "http://example.com/v1",
-		Endpoints: map[string]string{
-			"a": "/a",
-			"b": "/b",
-		},
 	}
 
 	// write it
@@ -34,8 +30,6 @@ func TestAPIConfig(t *testing.T) {
 	err = cfg.Load(viper.New())
 	assert.NoError(t, err)
 	assert.Equal(t, "http://example.com/v1", cfg.BaseURL)
-	assert.Equal(t, "/a", cfg.Endpoints["a"])
-	assert.Equal(t, "/b", cfg.Endpoints["b"])
 }
 
 func TestAPIConfigSetDefaults(t *testing.T) {
@@ -43,8 +37,6 @@ func TestAPIConfigSetDefaults(t *testing.T) {
 	cfg := &APIConfig{}
 	cfg.SetDefaults()
 	assert.Equal(t, "https://v2.exercism.io/api/v1", cfg.BaseURL)
-	assert.Equal(t, "/solutions/%s", cfg.Endpoints["download"])
-	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
 
 	// Override just the base url.
 	cfg = &APIConfig{
@@ -52,30 +44,4 @@ func TestAPIConfigSetDefaults(t *testing.T) {
 	}
 	cfg.SetDefaults()
 	assert.Equal(t, "http://example.com/v1", cfg.BaseURL)
-	assert.Equal(t, "/solutions/%s", cfg.Endpoints["download"])
-	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
-
-	// Override just one of the endpoints.
-	cfg = &APIConfig{
-		Endpoints: map[string]string{
-			"download": "/download/%d",
-		},
-	}
-	cfg.SetDefaults()
-	assert.Equal(t, "https://v2.exercism.io/api/v1", cfg.BaseURL)
-	assert.Equal(t, "/download/%d", cfg.Endpoints["download"])
-	assert.Equal(t, "/solutions/%s", cfg.Endpoints["submit"])
-}
-
-func TestAPIConfigURL(t *testing.T) {
-	cfg := &APIConfig{
-		Endpoints: map[string]string{
-			"a": "a/%s/a",
-			"b": "b/%s/%d",
-			"c": "c/%s/%s/%s",
-		},
-	}
-	assert.Equal(t, "a/apple/a", cfg.URL("a", "apple"))
-	assert.Equal(t, "b/banana/2", cfg.URL("b", "banana", 2))
-	assert.Equal(t, "c/cherry/coca/cola", cfg.URL("c", "cherry", "coca", "cola"))
 }


### PR DESCRIPTION
This gets rid of more of the needlessly complicated indirection that I somehow dreamed up.
I think I had some very grandiose plans about flexibly handling multiple concurrent APIs but honestly we may never need that.

FYI @nywilken I'm merging this when it goes green.