### PR TITLE
Pass only needed primitives to api.Client

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/exercism/cli/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,8 +32,8 @@ func TestNewRequestSetsDefaultHeaders(t *testing.T) {
 		{
 			desc: "Override defaults",
 			client: &Client{
-				UserConfig:  &config.UserConfig{Token: "abc123"},
 				ContentType: "bogus",
+				Token:       "abc123",
 			},
 			auth:        "Bearer abc123",
 			contentType: "bogus",

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -64,7 +64,7 @@ You can also override certain default settings to suit your preferences.
 		if show {
 			defer printCurrentConfig()
 		}
-		client, err := api.NewClient()
+		client, err := api.NewClient(usrCfg.Token, apiCfg.BaseURL)
 		if err != nil {
 			return err
 		}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -48,6 +48,11 @@ Download other people's solutions by providing the UUID.
 			// TODO: usage
 			return errors.New("need an exercise name or a solution --uuid")
 		}
+		usrCfg, err := config.NewUserConfig()
+		if err != nil {
+			return err
+		}
+
 		apiCfg, err := config.NewAPIConfig()
 		if err != nil {
 			return err
@@ -61,7 +66,7 @@ Download other people's solutions by providing the UUID.
 		}
 		url := fmt.Sprintf("%s/solutions/%s", apiCfg.BaseURL, slug)
 
-		client, err := api.NewClient()
+		client, err := api.NewClient(usrCfg.Token, apiCfg.BaseURL)
 		if err != nil {
 			return err
 		}
@@ -116,9 +121,9 @@ Download other people's solutions by providing the UUID.
 
 		var ws workspace.Workspace
 		if solution.IsRequester {
-			ws = workspace.New(filepath.Join(client.UserConfig.Workspace, solution.Track))
+			ws = workspace.New(filepath.Join(usrCfg.Workspace, solution.Track))
 		} else {
-			ws = workspace.New(filepath.Join(client.UserConfig.Workspace, "users", solution.Handle, solution.Track))
+			ws = workspace.New(filepath.Join(usrCfg.Workspace, "users", solution.Handle, solution.Track))
 		}
 		os.MkdirAll(ws.Dir, os.FileMode(0755))
 

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -43,12 +43,16 @@ To customize the CLI to suit your own preferences, use the configure command.
 }
 
 func prepareTrack(id string) error {
+	usrCfg, err := config.NewUserConfig()
+	if err != nil {
+		return err
+	}
 	apiCfg, err := config.NewAPIConfig()
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClient()
+	client, err := api.NewClient(usrCfg.Token, apiCfg.BaseURL)
 	if err != nil {
 		return err
 	}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -208,7 +208,7 @@ figuring things out if necessary.
 			return err
 		}
 
-		client, err := api.NewClient()
+		client, err := api.NewClient(usrCfg.Token, apiCfg.BaseURL)
 		if err != nil {
 			return err
 		}
@@ -232,8 +232,8 @@ figuring things out if necessary.
 		}
 
 		if solution.AutoApprove == true {
-			fmt.Fprintf(Out, "Your solution has been submitted " +
-				"successfully and has been auto-approved. You can complete " +
+			fmt.Fprintf(Out, "Your solution has been submitted "+
+				"successfully and has been auto-approved. You can complete "+
 				"the exercise and unlock the next core exercise at %s\n",
 				solution.URL)
 		} else {


### PR DESCRIPTION
The client doesn't need the entire config objects, it just needs a couple of strings.

Between this PR and #581 the api package doesn't need to know about the config package anymore!

FYI @nywilken I'm going to merge this one when it goes green and then rebase #581 onto nextercism again.