### PR TITLE
Move logic for default workspace into config package

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/exercism/cli/api"
@@ -39,16 +36,6 @@ You can also override certain default settings to suit your preferences.
 		}
 		usrCfg.Workspace = config.Resolve(usrCfg.Workspace, usrCfg.Home)
 		usrCfg.SetDefaults()
-		if usrCfg.Workspace == "" {
-			dirName := strings.Replace(path.Base(BinaryName), ".exe", "", 1)
-			defaultWorkspace := path.Join(usrCfg.Home, dirName)
-			_, err := os.Stat(defaultWorkspace)
-			// Sorry about the double negative.
-			if !os.IsNotExist(err) {
-				defaultWorkspace = fmt.Sprintf("%s-1", defaultWorkspace)
-			}
-			usrCfg.Workspace = defaultWorkspace
-		}
 
 		apiCfg := config.NewEmptyAPIConfig()
 		err = apiCfg.Load(viperAPIConfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ func Execute() {
 
 func init() {
 	BinaryName = os.Args[0]
-	config.SubdirectoryName = BinaryName
+	config.SetDefaultDirName(BinaryName)
 	Out = os.Stdout
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)

--- a/config/dir.go
+++ b/config/dir.go
@@ -2,13 +2,21 @@ package config
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 var (
-	SubdirectoryName = "exercism"
+	// DefaultDirName is the default name used for config and workspace directories.
+	DefaultDirName string
 )
+
+// SetDefaultDirName configures the default directory name based on the name of the binary.
+func SetDefaultDirName(binaryName string) {
+	DefaultDirName = strings.Replace(path.Base(binaryName), ".exe", "", 1)
+}
 
 // Dir is the configured config home directory.
 // All the cli-related config files live in this directory.
@@ -17,7 +25,7 @@ func Dir() string {
 	if runtime.GOOS == "windows" {
 		dir = os.Getenv("APPDATA")
 		if dir != "" {
-			return filepath.Join(dir, SubdirectoryName)
+			return filepath.Join(dir, DefaultDirName)
 		}
 	} else {
 		dir := os.Getenv("EXERCISM_CONFIG_HOME")
@@ -29,7 +37,7 @@ func Dir() string {
 			dir = filepath.Join(os.Getenv("HOME"), ".config")
 		}
 		if dir != "" {
-			return filepath.Join(dir, SubdirectoryName)
+			return filepath.Join(dir, DefaultDirName)
 		}
 	}
 	// If all else fails, use the current directory.

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"runtime"
 
 	"github.com/spf13/viper"
@@ -38,6 +40,9 @@ func (cfg *UserConfig) SetDefaults() {
 	if cfg.Home == "" {
 		cfg.Home = userHome()
 	}
+	if cfg.Workspace == "" {
+		cfg.Workspace = defaultWorkspace(cfg.Home)
+	}
 }
 
 // Write stores the config to disk.
@@ -71,5 +76,15 @@ func userHome() string {
 	}
 	// If all else fails, use the current directory.
 	dir, _ = os.Getwd()
+	return dir
+}
+
+func defaultWorkspace(home string) string {
+	dir := path.Join(home, DefaultDirName)
+	_, err := os.Stat(dir)
+	// Sorry about the double negative.
+	if !os.IsNotExist(err) {
+		dir = fmt.Sprintf("%s-1", dir)
+	}
 	return dir
 }


### PR DESCRIPTION
We have a method called `SetDefaults()` on the user config type... and we call it in the `configure` command. And then on the following 10 lines we do messy logic for setting even more defaults.

I moved this into the config package and set the default as part of `SetDefaults()`.

FYI @nywilken I'm going to merge this when it goes green.