### PR TITLE
[WIP] Implement viper persister

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,13 +22,28 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "392dba7d905ed5d04a5794ba89f558b27e2ba1ca"
 
 [[projects]]
   branch = "master"
   name = "github.com/inconshreveable/go-update"
-  packages = [".","internal/binarydist","internal/osext"]
+  packages = [
+    ".",
+    "internal/binarydist",
+    "internal/osext"
+  ]
   revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
 
 [[projects]]
@@ -70,7 +85,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
@@ -101,7 +119,7 @@
   branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  revision = "15738813a09db5c8e5b60a19d67d3f9bd38da3a4"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -112,7 +130,11 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["html","html/atom","html/charset"]
+  packages = [
+    "html",
+    "html/atom",
+    "html/charset"
+  ]
   revision = "f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f"
 
 [[projects]]
@@ -124,7 +146,28 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/triegen","internal/ucd","internal/utf8internal","language","runes","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "internal/utf8internal",
+    "language",
+    "runes",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "3bd178b88a8180be2df394a1fbb81313916f0e7b"
 
 [[projects]]

--- a/config/persister.go
+++ b/config/persister.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+// ConfigType is one of the available exercism config types.
+type ConfigType int
+
+const (
+	// TypeUser is configuration relevant to the individual's local setup.
+	TypeUser ConfigType = iota
+	// TypeAPI is configuration relevant to the API.
+	TypeAPI
+)
+
+// Persister saves viper configurations.
+type Persister interface {
+	Load(ConfigType) (*viper.Viper, error)
+	Save(*viper.Viper, ConfigType) error
+}
+
+// FilePersister handles viper configs on the file system.
+type FilePersister struct {
+	Dir string
+}
+
+// NewFilePersister returns a persister configured with the default config directory.
+func NewFilePersister() FilePersister {
+	return FilePersister{
+		Dir: Dir(),
+	}
+}
+
+// Save stores the viper config to the configured location on the filesystem.
+func (fp FilePersister) Save(v *viper.Viper, ct ConfigType) error {
+	v.SetConfigType("json")
+	v.AddConfigPath(fp.Dir)
+	v.SetConfigName(basename(ct))
+
+	if _, err := os.Stat(fp.Dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(fp.Dir, os.FileMode(0755)); err != nil {
+			return err
+		}
+	}
+	// WriteConfig is broken.
+	// Someone proposed a fix in https://github.com/spf13/viper/pull/503,
+	// but it doesn't work yet.
+	// When it's fixed and merge we can get rid of `fp.path()`
+	// and use v.WriteConfig() directly.
+	return v.WriteConfigAs(fp.path(ct))
+}
+
+// Load reads a config file on the filesystem into a new Viper value.
+func (fp FilePersister) Load(ct ConfigType) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigType("json")
+	v.AddConfigPath(fp.Dir)
+	v.SetConfigName(basename(ct))
+	err := v.ReadInConfig()
+	return v, err
+}
+
+// InMemoryPersister stores viper configs in memory (for testing).
+type InMemoryPersister struct {
+	store map[string]*viper.Viper
+}
+
+// NewInMemoryPersister creates a new in memory store.
+func NewInMemoryPersister() *InMemoryPersister {
+	return &InMemoryPersister{
+		store: map[string]*viper.Viper{},
+	}
+}
+
+// Save stores the viper config to memory.
+func (imp *InMemoryPersister) Save(v *viper.Viper, ct ConfigType) error {
+	imp.store[basename(ct)] = v
+	return nil
+}
+
+// Load returns a viper config stored in memory.
+func (imp *InMemoryPersister) Load(ct ConfigType) (*viper.Viper, error) {
+	return imp.store[basename(ct)], nil
+}
+
+func basename(ct ConfigType) string {
+	switch ct {
+	case TypeUser:
+		return "user"
+	case TypeAPI:
+		return "api"
+	}
+	return "unknown"
+}
+
+func (fp FilePersister) path(ct ConfigType) string {
+	return filepath.Join(fp.Dir, fmt.Sprintf("%s.json", basename(ct)))
+}

--- a/config/persister_test.go
+++ b/config/persister_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilePersisterSave(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fake-config")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	fp := FilePersister{
+		// Make sure we don't bomb if the dir doesn't exist.
+		Dir: filepath.Join(tmpDir, "subdir"),
+	}
+
+	v := viper.New()
+	v.Set("hello", "world")
+
+	if err = fp.Save(v, TypeAPI); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(fp.Dir, "api.json")
+	b, err := ioutil.ReadFile(path)
+	assert.NoError(t, err)
+
+	type apiConfig struct {
+		Hello string `json:"hello"`
+	}
+	var cfg apiConfig
+	err = json.Unmarshal(b, &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "world", cfg.Hello)
+}
+
+func TestFilePersisterLoad(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fake-config")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Write a JSON config.
+	body := `{"hello": "world"}`
+	if err := ioutil.WriteFile(filepath.Join(tmpDir, "api.json"), []byte(body), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load it into a viper config.
+	fp := FilePersister{
+		Dir: tmpDir,
+	}
+	v, err := fp.Load(TypeAPI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, v.GetString("hello"), "world")
+}
+
+func TestInMemoryPersister(t *testing.T) {
+	v1 := viper.New()
+	v1.Set("hello", "world")
+
+	imp := NewInMemoryPersister()
+
+	if err := imp.Save(v1, TypeAPI); err != nil {
+		t.Fatal(err)
+	}
+
+	v2, err := imp.Load(TypeAPI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "world", v2.GetString("hello"))
+}


### PR DESCRIPTION
🚧 🚧 🚧 work in progress 🚧 🚧 🚧 

Here's the direction I'm thinking of going in, based on some comments from @FabienTregan a few days ago.

The idea is to get rid of the various Config types in the `config` package, operating with a viper persister interface that writes to files when in production mode, and stores in memory when in test mode.

The cleanest way that I can see to move forward here is to set the persister we need as a package variable on `config`. That means that we would get in trouble if the config package is called from more than one package, because... well... race conditions. But I think we'll be fine as long as it's only used from the config package. Maybe. Unless I've forgotten how the parallelization of tests works in Go, which is likely. If we can't do a package variable the only other thing I can think of is to have the `RunE` function load the viper config and then immediately pass that on to another function, which would be the one we test. I don't much like it though.

As you can tell, I'm not yet sure what the shape of everything needs to be, that will be easier to experiment with once we've merged the open refactoring PRs which reduce some of the unnecessary indirection and abstractions.