### PR TITLE
Standardize submit command (#550, #551, #547, #549)

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -38,7 +38,7 @@ figuring things out if necessary.
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// check input before doing any other work
+		// Validate input before doing any other work
 		exercise, err := cmd.Flags().GetString("exercise")
 		if err != nil {
 			return err
@@ -88,7 +88,7 @@ figuring things out if necessary.
 
 		ws := workspace.New(usrCfg.Workspace)
 
-		// create directory from track and exercise slugs if needed
+		// Create directory from track and exercise slugs if needed
 		if trackId != "" && exercise != "" {
 			args = []string{filepath.Join(ws.Dir, trackId, exercise)}
 		} else if len(files) > 0 {
@@ -99,10 +99,12 @@ figuring things out if necessary.
 		if err != nil {
 			return err
 		}
+
 		dirs, err := ws.Locate(tx.Dir)
 		if err != nil {
 			return err
 		}
+
 		sx, err := workspace.NewSolutions(dirs)
 		if err != nil {
 			return err

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -44,7 +44,7 @@ func TestSubmit(t *testing.T) {
 		relativePath: "README.md",
 		contents:     "The readme.",
 	}
-	// make a list of tests
+	// Make a list of test commands
 	cmdTestFlags := &CommandTest{
 		Cmd:                     submitCmd,
 		InitFn:                  initSubmitCmd,
@@ -72,9 +72,8 @@ func TestSubmit(t *testing.T) {
 		cmdTest.Setup(t)
 		defer cmdTest.Teardown(t)
 
-		// handle case when directory to submit needs the tmp dir prefix
+		// Prefix submitted filenames with correct temporary directory
 		if cmdTest.Args[2] == "--files" {
-			// prefix each file
 			filenames := make([]string, 2)
 			for i, file := range []file{file1, file2} {
 				filenames[i] = filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", file.relativePath)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -48,7 +48,7 @@ func TestSubmit(t *testing.T) {
 		Cmd:                     submitCmd,
 		InitFn:                  initSubmitCmd,
 		MockInteractiveResponse: "\n",
-		Args: []string{"fakeapp", "submit", "bogus-exercise"},
+		Args: []string{"fakeapp", "submit", "-e", "bogus-exercise", "-t", "bogus-track"},
 	}
 	cmdTest.Setup(t)
 	defer cmdTest.Teardown(t)


### PR DESCRIPTION
This PR should address  #550, #551, #547 and #549 by conforming the `submit` command to the following behaviors:
 - submit using a directory
 - submit using a combination of exercise/track flags
 - submit a list of files.
 - adds new tests for all 3 behaviors.

(It does not handle the --team feature requested in a separate ticket.)

The new functionality was also smoke tested against mentorcism-beta by reconfiguring the client to point to that, and submitting Hello World for a new language.

Thank you for the opportunity to contribute! 

ETA: Just noticed this comment on #547, which is not addressed here:
> (... should print out) the command to use (copy/paste) to submit individual files in case they don't want to submit everything

Happy to add it in afterwards, or in another PR.