### PR TITLE
Tweak config track test for readability

### DIFF
--- a/config/track_test.go
+++ b/config/track_test.go
@@ -23,11 +23,10 @@ func TestTrackIgnoreString(t *testing.T) {
 	}
 
 	for name, ok := range testCases {
-		testName := fmt.Sprintf("%s is %s", name, acceptability(ok))
-		t.Run(testName, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			acceptable, err := track.AcceptFilename(name)
 			assert.NoError(t, err, name)
-			assert.Equal(t, ok, acceptable, testName)
+			assert.Equal(t, ok, acceptable, fmt.Sprintf("%s is %s", name, acceptability(ok)))
 		})
 	}
 }

--- a/config/track_test.go
+++ b/config/track_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,19 +22,19 @@ func TestTrackIgnoreString(t *testing.T) {
 		"proof":      false,
 	}
 
-	for name, acceptable := range testCases {
-		testName := name + " should " + notIfNeeded(acceptable) + "be an acceptable name."
+	for name, ok := range testCases {
+		testName := fmt.Sprintf("%s is %s", name, acceptability(ok))
 		t.Run(testName, func(t *testing.T) {
-			ok, err := track.AcceptFilename(name)
+			acceptable, err := track.AcceptFilename(name)
 			assert.NoError(t, err, name)
-			assert.Equal(t, acceptable, ok, testName)
+			assert.Equal(t, ok, acceptable, testName)
 		})
 	}
 }
 
-func notIfNeeded(b bool) string {
-	if !b {
-		return "not "
+func acceptability(ok bool) string {
+	if ok {
+		return "fine"
 	}
-	return ""
+	return "not acceptable"
 }


### PR DESCRIPTION
When naming a method that contains a small conditional, I find it easier
to name if the method contains both the exception and the rule.

The notIfNeeded method is naming only the case where it's not needed.
This changes the logic so that it contains two variations on the same
concept ("how acceptable is this").

In the second commit I differentiate between the test name and the failure message, as we don't need the same message in both places.
