### PR TITLE
Use filepath rather than path for manipulating paths

### DIFF
--- a/config/dir.go
+++ b/config/dir.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -15,7 +14,7 @@ var (
 
 // SetDefaultDirName configures the default directory name based on the name of the binary.
 func SetDefaultDirName(binaryName string) {
-	DefaultDirName = strings.Replace(path.Base(binaryName), ".exe", "", 1)
+	DefaultDirName = strings.Replace(filepath.Base(binaryName), ".exe", "", 1)
 }
 
 // Dir is the configured config home directory.

--- a/config/user_config.go
+++ b/config/user_config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/spf13/viper"
@@ -88,7 +88,7 @@ func userHome() string {
 }
 
 func defaultWorkspace(home string) string {
-	dir := path.Join(home, DefaultDirName)
+	dir := filepath.Join(home, DefaultDirName)
 	_, err := os.Stat(dir)
 	// Sorry about the double negative.
 	if !os.IsNotExist(err) {


### PR DESCRIPTION
The documentation for the path package says:

> The path package should only be used for paths separated by forward
> slashes, such as the paths in URLs. This package does not deal with
> Windows paths with drive letters or backslashes; to manipulate operating
> system paths, use the path/filepath package.

Closes #570