### PR TITLE
Introduce error stream

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -50,7 +50,7 @@ You can also override certain default settings to suit your preferences.
 
 		switch {
 		case cfg.Token == "":
-			fmt.Fprintln(Out, "There is no token configured, please set it using --token.")
+			fmt.Fprintln(Err, "There is no token configured, please set it using --token.")
 		case cmd.Flags().Lookup("token").Changed:
 			// User set new token
 			skipAuth, _ := cmd.Flags().GetBool("skip-auth")
@@ -69,7 +69,7 @@ You can also override certain default settings to suit your preferences.
 			if !skipAuth {
 				err = client.ValidateToken()
 				if err != nil {
-					fmt.Fprintln(Out, err)
+					fmt.Fprintln(Err, err)
 				}
 			}
 		}

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io/ioutil"
 	"runtime"
 	"testing"
 
@@ -16,6 +17,15 @@ type testCase struct {
 }
 
 func TestConfigure(t *testing.T) {
+	oldOut := Out
+	oldErr := Err
+	Out = ioutil.Discard
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+	}()
+
 	testCases := []testCase{
 		testCase{
 			desc: "It writes the flags when there is no config file.",

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -183,7 +183,8 @@ Download other people's solutions by providing the UUID.
 				return err
 			}
 		}
-		fmt.Fprintf(Out, "\nDownloaded to\n%s\n", solution.Dir)
+		fmt.Fprintf(Err, "\nDownloaded to\n")
+		fmt.Fprintf(Out, "%s\n", solution.Dir)
 		return nil
 	},
 }

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -45,8 +45,13 @@ const payloadTemplate = `
 
 func TestDownload(t *testing.T) {
 	oldOut := Out
+	oldErr := Err
 	Out = ioutil.Discard
-	defer func() { Out = oldOut }()
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+	}()
 
 	cmdTest := &CommandTest{
 		Cmd:    downloadCmd,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,8 +19,10 @@ var (
 	// The usage examples and help strings should reflect
 	// the actual name of the binary.
 	BinaryName string
-	// Out is used to write to the required writer.
+	// Out is used to write to information.
 	Out io.Writer
+	// Err is used to write errors.
+	Err io.Writer
 	// In is used to provide mocked test input (i.e. for prompts).
 	In io.Reader
 )
@@ -51,6 +53,7 @@ func init() {
 	BinaryName = os.Args[0]
 	config.SetDefaultDirName(BinaryName)
 	Out = os.Stdout
+	Err = os.Stderr
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -100,7 +100,7 @@ figuring things out if necessary.
 			}
 			s, ok := option.(*workspace.Solution)
 			if !ok {
-				fmt.Fprintf(Out, "something went wrong trying to pick that solution, not sure what happened")
+				fmt.Fprintf(Err, "something went wrong trying to pick that solution, not sure what happened")
 				continue
 			}
 			solution = s
@@ -162,10 +162,10 @@ figuring things out if necessary.
 				return err
 			}
 			if strings.ToLower(answer) != "y" {
-				fmt.Fprintf(Out, "Submit cancelled.\nTry submitting individually instead.")
+				fmt.Fprintf(Err, "Submit cancelled.\nTry submitting individually instead.")
 				return nil
 			}
-			fmt.Fprintf(Out, "Submitting files now...")
+			fmt.Fprintf(Err, "Submitting files now...")
 		}
 
 		for _, path := range paths {
@@ -227,13 +227,15 @@ figuring things out if necessary.
 		}
 
 		if solution.AutoApprove == true {
-			fmt.Fprintf(Out, "Your solution has been submitted "+
-				"successfully and has been auto-approved. You can complete "+
-				"the exercise and unlock the next core exercise at %s\n",
-				solution.URL)
+			msg := `Your solution has been submitted successfully and has been auto-approved.
+You can complete the exercise and unlock the next core exercise at:
+`
+			fmt.Fprintf(Err, msg)
 		} else {
-			//TODO
+			msg := "Your solution has been submitted successfully. View it at:\n"
+			fmt.Fprintf(Err, msg)
 		}
+		fmt.Fprintf(Out, "%s\n", solution.URL)
 
 		return nil
 	},

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -16,11 +16,15 @@ import (
 
 func TestSubmit(t *testing.T) {
 	oldOut := Out
+	oldErr := Err
 	oldIn := In
 	Out = ioutil.Discard
-
-	defer func() { Out = oldOut }()
-	defer func() { In = oldIn }()
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+		In = oldIn
+	}()
 
 	type file struct {
 		relativePath string


### PR DESCRIPTION
We have defined an `Out` variable in the `cmd` package which defaults to STDOUT, and all messages (both information and errors) were being written to that stream.

This introduces an `Err` variable which defaults to STDERR.

We write to `Err` instead of `Out` when we are printing an error, and also when we want to distinguish between input that is machine readable and input that is not. For example, when someone has submitted an exercise, we want to tell them what the URL of their solution is. That way they can go look at it. But all the verbiage explaining what that URL is and how you can use it is only useful if a human is looking at it. If you pipe the output into `exercism open`, then it's all irrelevant, and we only want the actual URL.

See https://www.jstorimer.com/blogs/workingwithcode/7766119-when-to-use-stderr-instead-of-stdout for some useful details about the distinction between the two streams.

FYI @nywilken -- I'm running with this for now and will merge it when it goes green. I'm totally open to tweaking this for readability, clarity, etc.