### PR TITLE
Fix token validation logic

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -72,14 +72,16 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
-// ValidateToken calls the API to determine whether the token is valid.
-func (c *Client) ValidateToken() error {
+// TokenIsValid calls the API to determine whether the token is valid.
+func (c *Client) TokenIsValid() (bool, error) {
 	url := fmt.Sprintf("%s/validate_token", c.APIBaseURL)
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
-	_, err = c.Do(req)
-
-	return err
+	resp, err := c.Do(req)
+	if err != nil {
+		return false, err
+	}
+	return resp.StatusCode == http.StatusOK, nil
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -55,22 +55,27 @@ You can also override certain default settings to suit your preferences.
 			// User set new token
 			skipAuth, _ := cmd.Flags().GetBool("skip-auth")
 			if !skipAuth {
-				err = client.ValidateToken()
+				ok, err := client.TokenIsValid()
 				if err != nil {
 					return err
+				}
+				if !ok {
+					fmt.Fprintln(Err, "The token is invalid.")
 				}
 			}
 		default:
 			// Validate existing token
-			if !show {
-				defer printCurrentConfig()
-			}
 			skipAuth, _ := cmd.Flags().GetBool("skip-auth")
 			if !skipAuth {
-				err = client.ValidateToken()
+				ok, err := client.TokenIsValid()
 				if err != nil {
-					fmt.Fprintln(Err, err)
+					return err
 				}
+				if !ok {
+					fmt.Fprintln(Err, "The token is invalid.")
+				}
+
+				defer printCurrentConfig()
 			}
 		}
 


### PR DESCRIPTION
The configure command was calling the token validation endpoint, but
was not actually bailing or providing an error in the case of an invalid
token.

We will need to improve the error message to include the link to the
url where the token can be found. Also, we should probably not print
the current configuration after printing the error message.

I am working on improvements to the configure command in a separate branch, and will make those changes there.

I have tested this by building the client and configuring with both an invalid and a valid token. In the new configure branch I am adding tests for the token validation.

FYI @nywilken I will merge this in order to unblock the configuration improvements. I don't think it's worth looking at this PR too closely; I mainly wanted to fix the api/client.go separately from the improvements to configure.