### PR TITLE
Print errors before exiting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ Download exercises and submit your solutions.`,
 // Execute adds all child commands to the root command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
+		fmt.Fprintf(Err, err.Error())
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
We are detecting errors when executing commands, but we are exiting
with an error code directly, without printing the error.

This prints the error to the Err stream.

FYI @nywilken, I'm merging this when it goes green.