### PR TITLE
Add a newline to the printed error before exiting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ Download exercises and submit your solutions.`,
 // Execute adds all child commands to the root command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(Err, err.Error())
+		fmt.Fprintf(Err, "%s\n", err.Error())
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
I missed this the first time through. Should have waited for code review :-)

/cc @nywilken 