### PR TITLE
Do not double-print the command errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,6 @@ Download exercises and submit your solutions.`,
 // Execute adds all child commands to the root command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(Err, "%s\n", err.Error())
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
I somehow was getting no errors, then when I printed them I got double errors,
then going back to how it was before, I'm getting exactly one error printed
... which is what I wanted in the first place.

I have no idea what I was doing.