### PR TITLE
Rework the configure command to be more robust and testable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,13 +22,28 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "392dba7d905ed5d04a5794ba89f558b27e2ba1ca"
 
 [[projects]]
   branch = "master"
   name = "github.com/inconshreveable/go-update"
-  packages = [".","internal/binarydist","internal/osext"]
+  packages = [
+    ".",
+    "internal/binarydist",
+    "internal/osext"
+  ]
   revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
 
 [[projects]]
@@ -70,7 +85,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
@@ -101,7 +119,7 @@
   branch = "master"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  revision = "15738813a09db5c8e5b60a19d67d3f9bd38da3a4"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -112,7 +130,11 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["html","html/atom","html/charset"]
+  packages = [
+    "html",
+    "html/atom",
+    "html/charset"
+  ]
   revision = "f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f"
 
 [[projects]]
@@ -124,7 +146,28 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/triegen","internal/ucd","internal/utf8internal","language","runes","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "internal/utf8internal",
+    "language",
+    "runes",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "3bd178b88a8180be2df394a1fbb81313916f0e7b"
 
 [[projects]]

--- a/api/client.go
+++ b/api/client.go
@@ -85,3 +85,17 @@ func (c *Client) TokenIsValid() (bool, error) {
 	}
 	return resp.StatusCode == http.StatusOK, nil
 }
+
+// IsPingable calls the API /ping to determine whether the API can be reached.
+func (c *Client) IsPingable() (bool, error) {
+	url := fmt.Sprintf("%s/ping", c.APIBaseURL)
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return false, err
+	}
+	return resp.StatusCode == http.StatusOK, nil
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -76,6 +76,7 @@ func (test *CommandTest) Setup(t *testing.T) {
 
 	test.App = &cobra.Command{}
 	test.App.AddCommand(test.Cmd)
+	test.App.SetOutput(Err)
 }
 
 // Teardown puts the environment back the way it was before the test.

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -49,10 +49,18 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 	if err != nil {
 		return err
 	}
-
 	if show {
 		printCurrentConfig(configuration)
 		return nil
+	}
+
+	if flags.NFlag() == 0 && cfg.GetString("token") == "" {
+		baseURL := cfg.GetString("apibaseurl")
+		if baseURL != "" {
+			tokenURL := config.InferSiteURL(baseURL) + "/my/settings"
+			return fmt.Errorf("There is no token configured. Find your token on %s, and call this command again with --token=<your-token>.", tokenURL)
+		}
+		return fmt.Errorf("There is no token configured. Find your token in your settings on the website, and call this command again with --token=<your-token>.")
 	}
 
 	baseURL, err := flags.GetString("api")

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -66,12 +66,12 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 		return fmt.Errorf("There is no token configured. Find your token on %s, and call this command again with --token=<your-token>.", tokenURL)
 	}
 
-	skipAuth, err := flags.GetBool("skip-auth")
+	skipVerification, err := flags.GetBool("no-verify")
 	if err != nil {
 		return err
 	}
 
-	if !skipAuth {
+	if !skipVerification {
 		client, err := api.NewClient(cfg.GetString("token"), cfg.GetString("apibaseurl"))
 		if err != nil {
 			return err
@@ -127,7 +127,7 @@ func setupConfigureFlags(flags *pflag.FlagSet, v *viper.Viper) {
 	flags.StringP("workspace", "w", "", "directory for exercism exercises")
 	flags.StringP("api", "a", "", "API base url")
 	flags.BoolP("show", "s", false, "show the current configuration")
-	flags.BoolP("skip-auth", "", false, "skip online token authorization check")
+	flags.BoolP("no-verify", "", false, "skip online token authorization check")
 
 	v.BindPFlag("workspace", flags.Lookup("workspace"))
 	v.BindPFlag("apibaseurl", flags.Lookup("api"))

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -154,7 +154,11 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 	cfg.Set("workspace", workspace)
 
 	// Persist the new configuration.
-	return configuration.Save("user")
+	if err := configuration.Save("user"); err != nil {
+		return err
+	}
+	printCurrentConfig(configuration)
+	return nil
 }
 
 func printCurrentConfig(configuration config.Configuration) {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -113,16 +113,20 @@ func printCurrentConfig(configuration config.Configuration) {
 }
 
 func initConfigureCmd() {
-	configureCmd.Flags().StringP("token", "t", "", "authentication token used to connect to the site")
-	configureCmd.Flags().StringP("workspace", "w", "", "directory for exercism exercises")
-	configureCmd.Flags().StringP("api", "a", "", "API base url")
-	configureCmd.Flags().BoolP("show", "s", false, "show the current configuration")
-	configureCmd.Flags().BoolP("skip-auth", "", false, "skip online token authorization check")
-
 	viperConfig = viper.New()
-	viperConfig.BindPFlag("token", configureCmd.Flags().Lookup("token"))
-	viperConfig.BindPFlag("workspace", configureCmd.Flags().Lookup("workspace"))
-	viperConfig.BindPFlag("apibaseurl", configureCmd.Flags().Lookup("api"))
+	setupConfigureFlags(configureCmd.Flags(), viperConfig)
+}
+
+func setupConfigureFlags(flags *pflag.FlagSet, v *viper.Viper) {
+	flags.StringP("token", "t", "", "authentication token used to connect to the site")
+	flags.StringP("workspace", "w", "", "directory for exercism exercises")
+	flags.StringP("api", "a", "", "API base url")
+	flags.BoolP("show", "s", false, "show the current configuration")
+	flags.BoolP("skip-auth", "", false, "skip online token authorization check")
+
+	v.BindPFlag("token", configureCmd.Flags().Lookup("token"))
+	v.BindPFlag("workspace", configureCmd.Flags().Lookup("workspace"))
+	v.BindPFlag("apibaseurl", configureCmd.Flags().Lookup("api"))
 }
 
 func init() {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"text/tabwriter"
 
@@ -68,7 +69,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 
 	switch {
 	case cfg.GetString("token") == "":
-		fmt.Fprintln(Err, "There is no token configured, please set it using --token.")
+		return errors.New("There is no token configured, please set it using --token.")
 	case flags.Lookup("token").Changed:
 		// User set new token
 		skipAuth, _ := flags.GetBool("skip-auth")
@@ -78,7 +79,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 				return err
 			}
 			if !ok {
-				fmt.Fprintln(Err, "The token is invalid.")
+				return errors.New("The token is invalid.")
 			}
 		}
 	default:
@@ -90,7 +91,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 				return err
 			}
 			if !ok {
-				fmt.Fprintln(Err, "The token is invalid.")
+				return errors.New("The token is invalid.")
 			}
 			defer printCurrentConfig(configuration)
 		}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -45,6 +45,16 @@ You can also override certain default settings to suit your preferences.
 func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) error {
 	cfg := configuration.UserViperConfig
 
+	show, err := flags.GetBool("show")
+	if err != nil {
+		return err
+	}
+
+	if show {
+		printCurrentConfig(configuration)
+		return nil
+	}
+
 	baseURL, err := flags.GetString("api")
 	if err != nil {
 		return err
@@ -108,18 +118,11 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 		cfg.Set("workspace", config.DefaultWorkspaceDir(configuration))
 	}
 
-	show, err := flags.GetBool("show")
-	if err != nil {
-		return err
-	}
-	if show {
-		defer printCurrentConfig(configuration)
-	}
 	return configuration.Save("user")
 }
 
 func printCurrentConfig(configuration config.Configuration) {
-	w := tabwriter.NewWriter(Out, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(Err, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 
 	v := configuration.UserViperConfig

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -120,11 +120,18 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 	}
 	cfg.Set("token", token)
 
-	cfg.Set("workspace", config.Resolve(viperConfig.GetString("workspace"), configuration.Home))
-
-	if cfg.GetString("workspace") == "" {
-		cfg.Set("workspace", config.DefaultWorkspaceDir(configuration))
+	workspace, err := flags.GetString("workspace")
+	if err != nil {
+		return err
 	}
+	if workspace == "" {
+		workspace = cfg.GetString("workspace")
+	}
+	workspace = config.Resolve(workspace, configuration.Home)
+	if workspace == "" {
+		workspace = config.DefaultWorkspaceDir(configuration)
+	}
+	cfg.Set("workspace", workspace)
 
 	return configuration.Save("user")
 }
@@ -145,17 +152,15 @@ func printCurrentConfig(configuration config.Configuration) {
 
 func initConfigureCmd() {
 	viperConfig = viper.New()
-	setupConfigureFlags(configureCmd.Flags(), viperConfig)
+	setupConfigureFlags(configureCmd.Flags())
 }
 
-func setupConfigureFlags(flags *pflag.FlagSet, v *viper.Viper) {
+func setupConfigureFlags(flags *pflag.FlagSet) {
 	flags.StringP("token", "t", "", "authentication token used to connect to the site")
 	flags.StringP("workspace", "w", "", "directory for exercism exercises")
 	flags.StringP("api", "a", "", "API base url")
 	flags.BoolP("show", "s", false, "show the current configuration")
 	flags.BoolP("no-verify", "", false, "skip online token authorization check")
-
-	v.BindPFlag("workspace", flags.Lookup("workspace"))
 }
 
 func init() {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/exercism/cli/api"
@@ -53,7 +51,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 		cfg.Set("apibaseurl", configuration.DefaultBaseURL)
 	}
 	if cfg.GetString("workspace") == "" {
-		cfg.Set("workspace", configuration.DefaultWorkspaceDir)
+		cfg.Set("workspace", config.DefaultWorkspaceDir(configuration))
 	}
 
 	show, err := flags.GetBool("show")
@@ -97,23 +95,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 			defer printCurrentConfig(configuration)
 		}
 	}
-
-	viperConfig.SetConfigType("json")
-	viperConfig.AddConfigPath(configuration.Dir)
-	viperConfig.SetConfigName("user")
-
-	if _, err := os.Stat(configuration.Dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(configuration.Dir, os.FileMode(0755)); err != nil {
-			return err
-		}
-	}
-	// WriteConfig is broken.
-	// Someone proposed a fix in https://github.com/spf13/viper/pull/503,
-	// but the fix doesn't work yet.
-	// When it's fixed and merged we can get rid of `path`
-	// and use viperConfig.WriteConfig() directly.
-	path := filepath.Join(configuration.Dir, "user.json")
-	return viperConfig.WriteConfigAs(path)
+	return configuration.Save("user")
 }
 
 func printCurrentConfig(configuration config.Configuration) {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"text/tabwriter"
 
@@ -46,12 +45,34 @@ You can also override certain default settings to suit your preferences.
 func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) error {
 	cfg := configuration.UserViperConfig
 
-	if cfg.GetString("apibaseurl") == "" {
-		cfg.Set("apibaseurl", configuration.DefaultBaseURL)
+	baseURL, err := flags.GetString("api")
+	if err != nil {
+		return err
 	}
-	if cfg.GetString("workspace") == "" {
-		cfg.Set("workspace", config.DefaultWorkspaceDir(configuration))
+	if baseURL == "" {
+		baseURL = cfg.GetString("apibaseurl")
 	}
+	if baseURL == "" {
+		baseURL = configuration.DefaultBaseURL
+	}
+
+	skipVerification, err := flags.GetBool("no-verify")
+	if err != nil {
+		return err
+	}
+
+	if !skipVerification {
+		client, err := api.NewClient("", baseURL)
+		if err != nil {
+			return err
+		}
+
+		ok, err := client.IsPingable()
+		if !ok || err != nil {
+			return fmt.Errorf("The base API URL '%s' cannot be reached.\n\n%s", baseURL, err)
+		}
+	}
+	cfg.Set("apibaseurl", baseURL)
 
 	token, err := flags.GetString("token")
 	if err != nil {
@@ -66,13 +87,8 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 		return fmt.Errorf("There is no token configured. Find your token on %s, and call this command again with --token=<your-token>.", tokenURL)
 	}
 
-	skipVerification, err := flags.GetBool("no-verify")
-	if err != nil {
-		return err
-	}
-
 	if !skipVerification {
-		client, err := api.NewClient(cfg.GetString("token"), cfg.GetString("apibaseurl"))
+		client, err := api.NewClient(token, baseURL)
 		if err != nil {
 			return err
 		}
@@ -81,8 +97,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 			return err
 		}
 		if !ok {
-			msg := fmt.Sprintf("The token '%s' is invalid. Find your token on %s.", token, tokenURL)
-			return errors.New(msg)
+			return fmt.Errorf("The token '%s' is invalid. Find your token on %s.", token, tokenURL)
 		}
 	}
 	cfg.Set("token", token)
@@ -130,7 +145,6 @@ func setupConfigureFlags(flags *pflag.FlagSet, v *viper.Viper) {
 	flags.BoolP("no-verify", "", false, "skip online token authorization check")
 
 	v.BindPFlag("workspace", flags.Lookup("workspace"))
-	v.BindPFlag("apibaseurl", flags.Lookup("api"))
 }
 
 func init() {

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -271,6 +271,12 @@ func TestConfigureAPIBaseURL(t *testing.T) {
 }
 
 func TestConfigureWorkspace(t *testing.T) {
+	oldErr := Err
+	Err = ioutil.Discard
+	defer func() {
+		Err = oldErr
+	}()
+
 	testCases := []struct {
 		desc       string
 		configured string

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -28,31 +28,31 @@ func TestConfigureToken(t *testing.T) {
 		{
 			desc:       "It doesn't lose a configured value",
 			configured: "existing-token",
-			args:       []string{"--skip-auth"},
+			args:       []string{"--no-verify"},
 			expected:   "existing-token",
 		},
 		{
 			desc:       "It writes a token when passed as a flag",
 			configured: "",
-			args:       []string{"--skip-auth", "--token", "a-token"},
+			args:       []string{"--no-verify", "--token", "a-token"},
 			expected:   "a-token",
 		},
 		{
 			desc:       "It overwrites the token",
 			configured: "old-token",
-			args:       []string{"--skip-auth", "--token", "replacement-token"},
+			args:       []string{"--no-verify", "--token", "replacement-token"},
 			expected:   "replacement-token",
 		},
 		{
 			desc:       "It complains when token is neither configured nor passed",
 			configured: "",
-			args:       []string{"--skip-auth"},
+			args:       []string{"--no-verify"},
 			expected:   "",
 			err:        true,
 			message:    "no token configured",
 		},
 		{
-			desc:       "It validates the existing token if we're not skipping auth",
+			desc:       "It validates the existing token if we're not skipping validations",
 			configured: "configured-token",
 			args:       []string{},
 			expected:   "configured-token",
@@ -60,7 +60,7 @@ func TestConfigureToken(t *testing.T) {
 			message:    "token.*invalid",
 		},
 		{
-			desc:       "It validates the replacement token if we're not skipping auth",
+			desc:       "It validates the replacement token if we're not skipping validations",
 			configured: "",
 			args:       []string{"--token", "invalid-token"},
 			expected:   "",
@@ -132,7 +132,7 @@ func TestConfigure(t *testing.T) {
 		testCase{
 			desc: "It writes the flags when there is no config file.",
 			args: []string{
-				"fakeapp", "configure", "--skip-auth",
+				"fakeapp", "configure", "--no-verify",
 				"--token", "abc123",
 				"--workspace", "/workspace",
 				"--api", "http://api.example.com",
@@ -143,7 +143,7 @@ func TestConfigure(t *testing.T) {
 		testCase{
 			desc: "It overwrites the flags in the config file.",
 			args: []string{
-				"fakeapp", "configure", "--skip-auth",
+				"fakeapp", "configure", "--no-verify",
 				"--token", "new-token",
 				"--workspace", "/new-workspace",
 				"--api", "http://new.example.com",
@@ -154,7 +154,7 @@ func TestConfigure(t *testing.T) {
 		testCase{
 			desc: "It overwrites the flags that are passed, without losing the ones that are not.",
 			args: []string{
-				"fakeapp", "configure", "--skip-auth",
+				"fakeapp", "configure", "--no-verify",
 				"--token", "replacement-token",
 			},
 			existingUsrCfg: &config.UserConfig{Token: "original-token", Workspace: "/unmodified", APIBaseURL: "http://unmodified.example.com"},
@@ -162,7 +162,7 @@ func TestConfigure(t *testing.T) {
 		},
 		testCase{
 			desc:           "It gets the default API base url.",
-			args:           []string{"fakeapp", "configure", "--skip-auth"},
+			args:           []string{"fakeapp", "configure", "--no-verify"},
 			existingUsrCfg: &config.UserConfig{Workspace: "/configured-workspace"},
 			expectedUsrCfg: &config.UserConfig{Workspace: "/configured-workspace", APIBaseURL: "https://v2.exercism.io/api/v1"},
 		},

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"testing"
 
 	"github.com/exercism/cli/config"
@@ -348,98 +347,5 @@ func TestConfigureWorkspace(t *testing.T) {
 		err = runConfigure(cfg, flags)
 		assert.NoError(t, err, tc.desc)
 		assert.Equal(t, tc.expected, cfg.UserViperConfig.GetString("workspace"), tc.desc)
-	}
-}
-
-func TestConfigure(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
-
-	type testCase struct {
-		desc           string
-		args           []string
-		existingUsrCfg *config.UserConfig
-		expectedUsrCfg *config.UserConfig
-	}
-
-	testCases := []testCase{
-		testCase{
-			desc: "It writes the flags when there is no config file.",
-			args: []string{
-				"fakeapp", "configure", "--no-verify",
-				"--token", "abc123",
-				"--workspace", "/workspace",
-				"--api", "http://api.example.com",
-			},
-			existingUsrCfg: nil,
-			expectedUsrCfg: &config.UserConfig{Token: "abc123", Workspace: "/workspace", APIBaseURL: "http://api.example.com"},
-		},
-		testCase{
-			desc: "It overwrites the flags in the config file.",
-			args: []string{
-				"fakeapp", "configure", "--no-verify",
-				"--token", "new-token",
-				"--workspace", "/new-workspace",
-				"--api", "http://new.example.com",
-			},
-			existingUsrCfg: &config.UserConfig{Token: "old-token", Workspace: "/old-workspace", APIBaseURL: "http://old.example.com"},
-			expectedUsrCfg: &config.UserConfig{Token: "new-token", Workspace: "/new-workspace", APIBaseURL: "http://new.example.com"},
-		},
-		testCase{
-			desc: "It overwrites the flags that are passed, without losing the ones that are not.",
-			args: []string{
-				"fakeapp", "configure", "--no-verify",
-				"--token", "replacement-token",
-			},
-			existingUsrCfg: &config.UserConfig{Token: "original-token", Workspace: "/unmodified", APIBaseURL: "http://unmodified.example.com"},
-			expectedUsrCfg: &config.UserConfig{Token: "replacement-token", Workspace: "/unmodified", APIBaseURL: "http://unmodified.example.com"},
-		},
-		testCase{
-			desc:           "It gets the default API base url.",
-			args:           []string{"fakeapp", "configure", "--no-verify"},
-			existingUsrCfg: &config.UserConfig{Workspace: "/configured-workspace"},
-			expectedUsrCfg: &config.UserConfig{Workspace: "/configured-workspace", APIBaseURL: "https://v2.exercism.io/api/v1"},
-		},
-	}
-
-	for _, tc := range testCases {
-		cmdTest := &CommandTest{
-			Cmd:    configureCmd,
-			InitFn: initConfigureCmd,
-			Args:   tc.args,
-		}
-		cmdTest.Setup(t)
-		defer cmdTest.Teardown(t)
-
-		if tc.existingUsrCfg != nil {
-			// Write a fake config.
-			cfg := config.NewEmptyUserConfig()
-			cfg.Token = tc.existingUsrCfg.Token
-			cfg.Workspace = tc.existingUsrCfg.Workspace
-			cfg.APIBaseURL = tc.existingUsrCfg.APIBaseURL
-			err := cfg.Write()
-			assert.NoError(t, err, tc.desc)
-		}
-
-		cmdTest.App.Execute()
-
-		if tc.expectedUsrCfg != nil {
-			if runtime.GOOS == "windows" {
-				tc.expectedUsrCfg.SetDefaults()
-			}
-
-			cfg, err := config.NewUserConfig()
-
-			assert.NoError(t, err, tc.desc)
-			assert.Equal(t, tc.expectedUsrCfg.Token, cfg.Token, tc.desc)
-			assert.Equal(t, tc.expectedUsrCfg.Workspace, cfg.Workspace, tc.desc)
-			assert.Equal(t, tc.expectedUsrCfg.APIBaseURL, cfg.APIBaseURL, tc.desc)
-		}
 	}
 }

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -16,6 +16,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConfigureShow(t *testing.T) {
+	oldErr := Err
+	defer func() {
+		Err = oldErr
+	}()
+
+	var buf bytes.Buffer
+	Err = &buf
+
+	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+	v := viper.New()
+	v.Set("token", "configured-token")
+	v.Set("workspace", "configured-workspace")
+	v.Set("apibaseurl", "http://configured.example.com")
+
+	setupConfigureFlags(flags, v)
+
+	// it will ignore any flags
+	args := []string{
+		"--show",
+		"--api", "http://override.example.com",
+		"--token", "token-override",
+		"--workspace", "workspace-override",
+	}
+	err := flags.Parse(args)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+	}
+
+	err = runConfigure(cfg, flags)
+	assert.NoError(t, err)
+
+	assert.Regexp(t, "configured.example", Err)
+	assert.NotRegexp(t, "override.example", Err)
+
+	assert.Regexp(t, "configured-token", Err)
+	assert.NotRegexp(t, "token-overrid", Err)
+
+	assert.Regexp(t, "configured-workspace", Err)
+	assert.NotRegexp(t, "workspace-override", Err)
+}
+
 func TestConfigureToken(t *testing.T) {
 	testCases := []struct {
 		desc       string

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -11,13 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testCase struct {
-	desc           string
-	args           []string
-	existingUsrCfg *config.UserConfig
-	expectedUsrCfg *config.UserConfig
-}
-
 func TestConfigure(t *testing.T) {
 	oldOut := Out
 	oldErr := Err
@@ -27,6 +20,13 @@ func TestConfigure(t *testing.T) {
 		Out = oldOut
 		Err = oldErr
 	}()
+
+	type testCase struct {
+		desc           string
+		args           []string
+		existingUsrCfg *config.UserConfig
+		expectedUsrCfg *config.UserConfig
+	}
 
 	testCases := []testCase{
 		testCase{
@@ -69,13 +69,6 @@ func TestConfigure(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.desc, makeTest(tc))
-	}
-}
-
-func makeTest(tc testCase) func(*testing.T) {
-
-	return func(t *testing.T) {
 		cmdTest := &CommandTest{
 			Cmd:    configureCmd,
 			InitFn: initConfigureCmd,

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -28,11 +28,13 @@ type Configuration struct {
 	UserViperConfig *viper.Viper
 	UserConfig      *UserConfig
 	CLI             *CLIConfig
+	Persister       Persister
 }
 
 // NewConfiguration provides a configuration with default values.
 func NewConfiguration() Configuration {
 	home := userHome()
+	dir := Dir()
 
 	return Configuration{
 		OS:             runtime.GOOS,
@@ -40,6 +42,7 @@ func NewConfiguration() Configuration {
 		Home:           home,
 		DefaultBaseURL: defaultBaseURL,
 		DefaultDirName: DefaultDirName,
+		Persister:      FilePersister{Dir: dir},
 	}
 }
 
@@ -103,4 +106,8 @@ func DefaultWorkspaceDir(cfg Configuration) string {
 		dir = strings.Title(dir)
 	}
 	return filepath.Join(cfg.Home, dir)
+}
+
+func (c Configuration) Save(basename string) error {
+	return c.Persister.Save(c.UserViperConfig, basename)
 }

--- a/config/persister.go
+++ b/config/persister.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+// Persister saves viper configs.
+type Persister interface {
+	Save(*viper.Viper, string) error
+}
+
+// FilePersister saves viper configs to the file system.
+type FilePersister struct {
+	Dir string
+}
+
+// Save writes the viper config to the target location on the filesystem.
+func (p FilePersister) Save(v *viper.Viper, basename string) error {
+	v.SetConfigType("json")
+	v.AddConfigPath(p.Dir)
+	v.SetConfigName(basename)
+
+	if _, err := os.Stat(p.Dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(p.Dir, os.FileMode(0755)); err != nil {
+			return err
+		}
+	}
+
+	// WriteConfig is broken.
+	// Someone proposed a fix in https://github.com/spf13/viper/pull/503,
+	// but the fix doesn't work yet.
+	// When it's fixed and merged we can get rid of `path`
+	// and use viperConfig.WriteConfig() directly.
+	path := filepath.Join(p.Dir, fmt.Sprintf("%s.json", basename))
+	return v.WriteConfigAs(path)
+}
+
+// InMemoryPersister is a noop persister for use in unit tests.
+type InMemoryPersister struct{}
+
+// Save does nothing.
+func (p InMemoryPersister) Save(*viper.Viper, string) error {
+	return nil
+}


### PR DESCRIPTION
The configure command was a bit gnarly, and the test we had was testing everything at once, which made it fairly difficult to reason about.

This makes several related but fairly extensive changes:

- It adds a level of indirection by introducing a `runConfigure` function which takes a configuration object and the flags, but does not in any way deal with the Cobra command itself. The configuration object is new. By default, it will set a bunch of defaults, but since we're passing it to `runConfigure`, the tests can hard-code any of the defaults and things that we usually determine via the environment and OS.
- It uses the Out and Err streams more deliberately, and ensures that the tests do not print to them.
- It adds separate tests for each configuration option, so that all the logic related to each flag can be reasoned about separately.
- It removes all mention of the `config.UserConfig` type, which I am going to be working towards getting rid of. Instead, it uses the viper config directly, and adds a thin persistence wrapper to it, allowing us to avoid the filesystem for most of the tests.
- It fleshes out the verification logic for the `--no-verify` flag to verify both the base API URL (API is reachable) and the token (can successfully authenticate)

Additionally, this ensures that if we set a default workspace, that we do not set it to an existing directory. If there is something at the default workspace location, then we will print an error explaining that if they mean it, they can pass `--workspace` explicitly. We print the current command with the additional workspace in that case.

**Note: the new tests are quite repetitive. I did not want to introduce an abstraction here yet, as I'm afraid it will obscure more than it helps. I'm open to experimenting a bit with DRYing it up a bit, but I do not want to do it this week, as it's not crucial to moving the project forward.**

This pull request clarifies the behavior of the command in a number of ways:

If you just run `exercism configure` with no flags, then it will tell you how to configure the token if you haven't yet.

```
$ ./testercism configure
Error: There is no token configured. Find your token in your settings on the website, and call this command again with --token=<your-token>.
```

If you explicitly pass `--show` we will ignore any other flags, and just show you what is _currently_ configured.

```
$ ./testercism configure --show

Config dir:      /Users/kytrinyx/.config/testercism
-t, --token      11111111-2222-3333-4444-555555555555
-w, --workspace  /Users/kytrinyx/testercism
-a, --api        https://v2a.exercism.io/api/v1
```  

If you get an error, we will not print out the existing config:
```
$ ./testercism configure --token=abc123
Error: The token 'abc123' is invalid. Find your token on https://v2.exercism.io/my/settings.
```

If you successfully configure something, it will print the configuration (even if you don't pass --show).


```
$ ./testercism configure --token=11111111-2222-3333-4444-555555555555

Config dir:      /Users/kytrinyx/.config/testercism
-t, --token      11111111-2222-3333-4444-555555555555
-w, --workspace  /Users/kytrinyx/testercism
-a, --api        https://v2.exercism.io/api/v1
```    

Closes #567
Closes #542