### PR TITLE
Rework submit command

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -123,15 +123,23 @@ Download other people's solutions by providing the UUID.
 			IsRequester: payload.Solution.User.IsRequester,
 		}
 
+		dir := filepath.Join(usrCfg.Workspace, solution.Track)
+		os.MkdirAll(dir, os.FileMode(0755))
+
 		var ws workspace.Workspace
 		if solution.IsRequester {
-			ws = workspace.New(filepath.Join(usrCfg.Workspace, solution.Track))
+			ws, err = workspace.New(dir)
+			if err != nil {
+				return err
+			}
 		} else {
-			ws = workspace.New(filepath.Join(usrCfg.Workspace, "users", solution.Handle, solution.Track))
+			ws, err = workspace.New(filepath.Join(usrCfg.Workspace, "users", solution.Handle, solution.Track))
+			if err != nil {
+				return err
+			}
 		}
-		os.MkdirAll(ws.Dir, os.FileMode(0755))
 
-		dir, err := ws.SolutionPath(solution.Exercise, solution.ID)
+		dir, err = ws.SolutionPath(solution.Exercise, solution.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -27,7 +27,10 @@ the solution you want to see on the website.
 		if err != nil {
 			return err
 		}
-		ws := workspace.New(cfg.Workspace)
+		ws, err := workspace.New(cfg.Workspace)
+		if err != nil {
+			return err
+		}
 
 		paths, err := ws.Locate(args[0])
 		if err != nil {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/exercism/cli/config"
 	"github.com/exercism/cli/workspace"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -38,249 +39,253 @@ figuring things out if necessary.
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Validate input before doing any other work
-		exercise, err := cmd.Flags().GetString("exercise")
+		return runSubmit(config.Configuration{}, cmd.Flags(), args)
+	},
+}
+
+func runSubmit(configuration config.Configuration, flags *pflag.FlagSet, args []string) error {
+	// Validate input before doing any other work
+	exercise, err := flags.GetString("exercise")
+	if err != nil {
+		return err
+	}
+
+	trackID, err := flags.GetString("track")
+	if err != nil {
+		return err
+	}
+
+	files, err := flags.GetStringSlice("files")
+	if err != nil {
+		return err
+	}
+
+	// Verify that both --track and --exercise are used together
+	if len(args) == 0 && len(files) == 0 && !(exercise != "" && trackID != "") {
+		// Are they both missing?
+		if exercise == "" && trackID == "" {
+			return errors.New("Please use the --exercise/--trackID flags to submit without an explicit directory or files.")
+		}
+		// Guess that --trackID is missing, unless it's not
+		present, missing := "--exercise", "--track"
+		if trackID != "" {
+			present, missing = missing, present
+		}
+		// Help user correct CLI command
+		missingFlagMessage := fmt.Sprintf("You specified %s, please also include %s.", present, missing)
+		return errors.New(missingFlagMessage)
+	}
+
+	if len(args) > 0 && (exercise != "" || trackID != "") {
+		return errors.New("You are submitting a directory. We will infer the track and exercise from that. Please re-run the submit command without the flags.")
+	}
+
+	if len(files) > 0 && len(args) > 0 {
+		return errors.New("You can submit either a list of files, or a directory, but not both.")
+	}
+
+	usrCfg, err := config.NewUserConfig()
+	if err != nil {
+		return err
+	}
+
+	cliCfg, err := config.NewCLIConfig()
+	if err != nil {
+		return err
+	}
+
+	// TODO: make sure we get the workspace configured.
+	if usrCfg.Workspace == "" {
+		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
+		usrCfg.Workspace = filepath.Dir(filepath.Dir(cwd))
+	}
 
-		trackID, err := cmd.Flags().GetString("track")
-		if err != nil {
-			return err
-		}
+	ws := workspace.New(usrCfg.Workspace)
 
-		files, err := cmd.Flags().GetStringSlice("files")
-		if err != nil {
-			return err
-		}
+	// Create directory from track and exercise slugs if needed
+	if trackID != "" && exercise != "" {
+		args = []string{filepath.Join(ws.Dir, trackID, exercise)}
+	} else if len(files) > 0 {
+		args = files
+	}
 
-		// Verify that both --track and --exercise are used together
-		if len(args) == 0 && len(files) == 0 && !(exercise != "" && trackID != "") {
-			// Are they both missing?
-			if exercise == "" && trackID == "" {
-				return errors.New("Please use the --exercise/--trackID flags to submit without an explicit directory or files.")
-			}
-			// Guess that --trackID is missing, unless it's not
-			present, missing := "--exercise", "--track"
-			if trackID != "" {
-				present, missing = missing, present
-			}
-			// Help user correct CLI command
-			missingFlagMessage := fmt.Sprintf("You specified %s, please also include %s.", present, missing)
-			return errors.New(missingFlagMessage)
-		}
+	tx, err := workspace.NewTransmission(ws.Dir, args)
+	if err != nil {
+		return err
+	}
 
-		if len(args) > 0 && (exercise != "" || trackID != "") {
-			return errors.New("You are submitting a directory. We will infer the track and exercise from that. Please re-run the submit command without the flags.")
-		}
+	dirs, err := ws.Locate(tx.Dir)
+	if err != nil {
+		return err
+	}
 
-		if len(files) > 0 && len(args) > 0 {
-			return errors.New("You can submit either a list of files, or a directory, but not both.")
-		}
+	sx, err := workspace.NewSolutions(dirs)
+	if err != nil {
+		return err
+	}
 
-		usrCfg, err := config.NewUserConfig()
-		if err != nil {
-			return err
-		}
+	var solution *workspace.Solution
 
-		cliCfg, err := config.NewCLIConfig()
-		if err != nil {
-			return err
-		}
+	selection := comms.NewSelection()
+	for _, s := range sx {
+		selection.Items = append(selection.Items, s)
+	}
 
-		// TODO: make sure we get the workspace configured.
-		if usrCfg.Workspace == "" {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			usrCfg.Workspace = filepath.Dir(filepath.Dir(cwd))
-		}
-
-		ws := workspace.New(usrCfg.Workspace)
-
-		// Create directory from track and exercise slugs if needed
-		if trackID != "" && exercise != "" {
-			args = []string{filepath.Join(ws.Dir, trackID, exercise)}
-		} else if len(files) > 0 {
-			args = files
-		}
-
-		tx, err := workspace.NewTransmission(ws.Dir, args)
-		if err != nil {
-			return err
-		}
-
-		dirs, err := ws.Locate(tx.Dir)
-		if err != nil {
-			return err
-		}
-
-		sx, err := workspace.NewSolutions(dirs)
-		if err != nil {
-			return err
-		}
-
-		var solution *workspace.Solution
-
-		selection := comms.NewSelection()
-		for _, s := range sx {
-			selection.Items = append(selection.Items, s)
-		}
-
-		for {
-			prompt := `
+	for {
+		prompt := `
 			We found more than one. Which one did you mean?
 			Type the number of the one you want to select.
 
 			%s
 			> `
-			option, err := selection.Pick(prompt)
-			if err != nil {
-				return err
-			}
-			s, ok := option.(*workspace.Solution)
-			if !ok {
-				fmt.Fprintf(Err, "something went wrong trying to pick that solution, not sure what happened")
-				continue
-			}
-			solution = s
-			break
-		}
-
-		if !solution.IsRequester {
-			return errors.New("not your solution")
-		}
-
-		track := cliCfg.Tracks[solution.Track]
-		if track == nil {
-			err := prepareTrack(solution.Track)
-			if err != nil {
-				return err
-			}
-			cliCfg.Load(viper.New())
-			track = cliCfg.Tracks[solution.Track]
-		}
-
-		paths := tx.Files
-		if len(paths) == 0 {
-			walkFn := func(path string, info os.FileInfo, err error) error {
-				if err != nil || info.IsDir() {
-					return err
-				}
-				ok, err := track.AcceptFilename(path)
-				if err != nil || !ok {
-					return err
-				}
-				paths = append(paths, path)
-				return nil
-			}
-			filepath.Walk(solution.Dir, walkFn)
-		}
-
-		body := &bytes.Buffer{}
-		writer := multipart.NewWriter(body)
-
-		if len(paths) == 0 {
-			return errors.New("no files found to submit")
-		}
-
-		// If the user submits a directory, confirm the list of files.
-		if len(tx.ArgDirs) > 0 {
-			prompt := "You specified a directory, which contains these files:\n"
-			for i, path := range paths {
-				prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
-			}
-			prompt += "\nPress ENTER to submit, or control + c to cancel: "
-
-			confirmQuestion := &comms.Question{
-				Prompt:       prompt,
-				DefaultValue: "y",
-				Reader:       In,
-				Writer:       Out,
-			}
-			answer, err := confirmQuestion.Ask()
-			if err != nil {
-				return err
-			}
-			if strings.ToLower(answer) != "y" {
-				fmt.Fprintf(Err, "Submit cancelled.\nTry submitting individually instead.")
-				return nil
-			}
-			fmt.Fprintf(Err, "Submitting files now...")
-		}
-
-		for _, path := range paths {
-			// Don't submit empty files
-			info, err := os.Stat(path)
-			if err != nil {
-				return err
-			}
-			if info.Size() == 0 {
-				fmt.Printf("Warning: file %s was empty, skipping...", path)
-				continue
-			}
-			file, err := os.Open(path)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-
-			dirname := fmt.Sprintf("%s%s%s", string(os.PathSeparator), solution.Exercise, string(os.PathSeparator))
-			pieces := strings.Split(path, dirname)
-			filename := fmt.Sprintf("%s%s", string(os.PathSeparator), pieces[len(pieces)-1])
-
-			part, err := writer.CreateFormFile("files[]", filename)
-			if err != nil {
-				return err
-			}
-			_, err = io.Copy(part, file)
-			if err != nil {
-				return err
-			}
-		}
-
-		err = writer.Close()
+		option, err := selection.Pick(prompt)
 		if err != nil {
 			return err
 		}
+		s, ok := option.(*workspace.Solution)
+		if !ok {
+			fmt.Fprintf(Err, "something went wrong trying to pick that solution, not sure what happened")
+			continue
+		}
+		solution = s
+		break
+	}
 
-		client, err := api.NewClient(usrCfg.Token, usrCfg.APIBaseURL)
+	if !solution.IsRequester {
+		return errors.New("not your solution")
+	}
+
+	track := cliCfg.Tracks[solution.Track]
+	if track == nil {
+		err := prepareTrack(solution.Track)
 		if err != nil {
 			return err
 		}
-		url := fmt.Sprintf("%s/solutions/%s", usrCfg.APIBaseURL, solution.ID)
-		req, err := client.NewRequest("PATCH", url, body)
+		cliCfg.Load(viper.New())
+		track = cliCfg.Tracks[solution.Track]
+	}
+
+	paths := tx.Files
+	if len(paths) == 0 {
+		walkFn := func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return err
+			}
+			ok, err := track.AcceptFilename(path)
+			if err != nil || !ok {
+				return err
+			}
+			paths = append(paths, path)
+			return nil
+		}
+		filepath.Walk(solution.Dir, walkFn)
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	if len(paths) == 0 {
+		return errors.New("no files found to submit")
+	}
+
+	// If the user submits a directory, confirm the list of files.
+	if len(tx.ArgDirs) > 0 {
+		prompt := "You specified a directory, which contains these files:\n"
+		for i, path := range paths {
+			prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
+		}
+		prompt += "\nPress ENTER to submit, or control + c to cancel: "
+
+		confirmQuestion := &comms.Question{
+			Prompt:       prompt,
+			DefaultValue: "y",
+			Reader:       In,
+			Writer:       Out,
+		}
+		answer, err := confirmQuestion.Ask()
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Content-Type", writer.FormDataContentType())
+		if strings.ToLower(answer) != "y" {
+			fmt.Fprintf(Err, "Submit cancelled.\nTry submitting individually instead.")
+			return nil
+		}
+		fmt.Fprintf(Err, "Submitting files now...")
+	}
 
-		resp, err := client.Do(req)
+	for _, path := range paths {
+		// Don't submit empty files
+		info, err := os.Stat(path)
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
-
-		bb := &bytes.Buffer{}
-		_, err = bb.ReadFrom(resp.Body)
+		if info.Size() == 0 {
+			fmt.Printf("Warning: file %s was empty, skipping...", path)
+			continue
+		}
+		file, err := os.Open(path)
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 
-		if solution.AutoApprove == true {
-			msg := `Your solution has been submitted successfully and has been auto-approved.
+		dirname := fmt.Sprintf("%s%s%s", string(os.PathSeparator), solution.Exercise, string(os.PathSeparator))
+		pieces := strings.Split(path, dirname)
+		filename := fmt.Sprintf("%s%s", string(os.PathSeparator), pieces[len(pieces)-1])
+
+		part, err := writer.CreateFormFile("files[]", filename)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(part, file)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClient(usrCfg.Token, usrCfg.APIBaseURL)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/solutions/%s", usrCfg.APIBaseURL, solution.ID)
+	req, err := client.NewRequest("PATCH", url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	bb := &bytes.Buffer{}
+	_, err = bb.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if solution.AutoApprove == true {
+		msg := `Your solution has been submitted successfully and has been auto-approved.
 You can complete the exercise and unlock the next core exercise at:
 `
-			fmt.Fprintf(Err, msg)
-		} else {
-			msg := "Your solution has been submitted successfully. View it at:\n"
-			fmt.Fprintf(Err, msg)
-		}
-		fmt.Fprintf(Out, "%s\n", solution.URL)
+		fmt.Fprintf(Err, msg)
+	} else {
+		msg := "Your solution has been submitted successfully. View it at:\n"
+		fmt.Fprintf(Err, msg)
+	}
+	fmt.Fprintf(Out, "%s\n", solution.URL)
 
-		return nil
-	},
+	return nil
 }
 
 func initSubmitCmd() {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -77,6 +77,15 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("TODO: run configure first")
 	}
 
+	for _, arg := range args {
+		if _, err := os.Stat(arg); err != nil {
+			if os.IsNotExist(err) {
+				return errors.New("TODO: explain that there is no such file")
+			}
+			return err
+		}
+	}
+
 	ws := workspace.New(usrCfg.GetString("workspace"))
 
 	tx, err := workspace.NewTransmission(ws.Dir, args)

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -66,13 +66,17 @@ figuring things out if necessary.
 }
 
 func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) error {
+	usrCfg := cfg.UserViperConfig
+	cliCfg := cfg.CLIConfig
+
+	if usrCfg.GetString("token") == "" {
+		return errors.New("TODO: Welcome to Exercism this is how you use this")
+	}
+
 	files, err := flags.GetStringSlice("files")
 	if err != nil {
 		return err
 	}
-
-	usrCfg := cfg.UserViperConfig
-	cliCfg := cfg.CLIConfig
 
 	ws := workspace.New(usrCfg.GetString("workspace"))
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -78,11 +78,15 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	}
 
 	for _, arg := range args {
-		if _, err := os.Stat(arg); err != nil {
+		info, err := os.Lstat(arg)
+		if err != nil {
 			if os.IsNotExist(err) {
 				return errors.New("TODO: explain that there is no such file")
 			}
 			return err
+		}
+		if info.IsDir() {
+			return errors.New("TODO: it is a directory and we cannot handle that")
 		}
 	}
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -120,7 +120,6 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("can't find a solution metadata file. (todo: explain how to fix it)")
 	}
 	if len(sx) > 1 {
-		// TODO: add test
 		return errors.New("files from multiple solutions. Can only submit one solution at a time. (todo: fix error message)")
 	}
 	solution := sx[0]

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -77,14 +77,9 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("TODO: run configure first")
 	}
 
-	files, err := flags.GetStringSlice("files")
-	if err != nil {
-		return err
-	}
-
 	ws := workspace.New(usrCfg.GetString("workspace"))
 
-	tx, err := workspace.NewTransmission(ws.Dir, files)
+	tx, err := workspace.NewTransmission(ws.Dir, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -39,11 +39,25 @@ figuring things out if necessary.
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runSubmit(config.Configuration{}, cmd.Flags(), args)
+		usrCfg, err := config.NewUserConfig()
+		if err != nil {
+			return err
+		}
+
+		cliCfg, err := config.NewCLIConfig()
+		if err != nil {
+			return err
+		}
+
+		cfg := config.NewConfiguration()
+		cfg.UserConfig = usrCfg
+		cfg.CLIConfig = cliCfg
+
+		return runSubmit(cfg, cmd.Flags(), args)
 	},
 }
 
-func runSubmit(configuration config.Configuration, flags *pflag.FlagSet, args []string) error {
+func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) error {
 	// Validate input before doing any other work
 	exercise, err := flags.GetString("exercise")
 	if err != nil {
@@ -84,15 +98,8 @@ func runSubmit(configuration config.Configuration, flags *pflag.FlagSet, args []
 		return errors.New("You can submit either a list of files, or a directory, but not both.")
 	}
 
-	usrCfg, err := config.NewUserConfig()
-	if err != nil {
-		return err
-	}
-
-	cliCfg, err := config.NewCLIConfig()
-	if err != nil {
-		return err
-	}
+	usrCfg := cfg.UserConfig
+	cliCfg := cfg.CLIConfig
 
 	// TODO: make sure we get the workspace configured.
 	if usrCfg.Workspace == "" {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -305,9 +305,13 @@ You can complete the exercise and unlock the next core exercise at:
 }
 
 func initSubmitCmd() {
-	submitCmd.Flags().StringP("track", "t", "", "the track ID")
-	submitCmd.Flags().StringP("exercise", "e", "", "the exercise ID")
-	submitCmd.Flags().StringSliceP("files", "f", make([]string, 0), "files to submit")
+	setupSubmitFlags(submitCmd.Flags())
+}
+
+func setupSubmitFlags(flags *pflag.FlagSet) {
+	flags.StringP("track", "t", "", "the track ID")
+	flags.StringP("exercise", "e", "", "the exercise ID")
+	flags.StringSliceP("files", "f", make([]string, 0), "files to submit")
 }
 
 func init() {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -49,11 +49,18 @@ figuring things out if necessary.
 		_ = usrCfg.ReadInConfig()
 		cfg.UserViperConfig = usrCfg
 
-		cliCfg, err := config.NewCLIConfig()
-		if err != nil {
+		v := viper.New()
+		v.AddConfigPath(cfg.Dir)
+		v.SetConfigName("cli")
+		v.SetConfigType("json")
+		// Ignore error. If the file doesn't exist, that is fine.
+		_ = v.ReadInConfig()
+
+		cliCfg := config.CLIConfig{Tracks: config.Tracks{}}
+		if err := v.Unmarshal(&cliCfg); err != nil {
 			return err
 		}
-		cfg.CLIConfig = cliCfg
+		cfg.CLIConfig = &cliCfg
 
 		return runSubmit(cfg, cmd.Flags(), args)
 	},

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -207,31 +207,6 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("no files found to submit")
 	}
 
-	// If the user submits a directory, confirm the list of files.
-	if len(tx.ArgDirs) > 0 {
-		prompt := "You specified a directory, which contains these files:\n"
-		for i, path := range paths {
-			prompt += fmt.Sprintf(" [%d]  %s\n", i+1, path)
-		}
-		prompt += "\nPress ENTER to submit, or control + c to cancel: "
-
-		confirmQuestion := &comms.Question{
-			Prompt:       prompt,
-			DefaultValue: "y",
-			Reader:       In,
-			Writer:       Out,
-		}
-		answer, err := confirmQuestion.Ask()
-		if err != nil {
-			return err
-		}
-		if strings.ToLower(answer) != "y" {
-			fmt.Fprintf(Err, "Submit cancelled.\nTry submitting individually instead.")
-			return nil
-		}
-		fmt.Fprintf(Err, "Submitting files now...")
-	}
-
 	for _, path := range paths {
 		// Don't submit empty files
 		info, err := os.Stat(path)

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -55,19 +55,12 @@ figuring things out if necessary.
 		// Ignore error. If the file doesn't exist, that is fine.
 		_ = v.ReadInConfig()
 
-		cliCfg := config.CLIConfig{Tracks: config.Tracks{}}
-		if err := v.Unmarshal(&cliCfg); err != nil {
-			return err
-		}
-		cfg.CLIConfig = &cliCfg
-
 		return runSubmit(cfg, cmd.Flags(), args)
 	},
 }
 
 func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) error {
 	usrCfg := cfg.UserViperConfig
-	cliCfg := cfg.CLIConfig
 
 	if usrCfg.GetString("token") == "" {
 		return errors.New("TODO: Welcome to Exercism this is how you use this")
@@ -127,12 +120,6 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	if !solution.IsRequester {
 		// TODO: add test
 		return errors.New("not your solution. todo: fix error message")
-	}
-
-	track := cliCfg.Tracks[solution.Track]
-	if track == nil {
-		track = config.NewTrack(solution.Track)
-		track.SetDefaults()
 	}
 
 	paths := make([]string, 0, len(tx.Files))

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -73,6 +73,10 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("TODO: Welcome to Exercism this is how you use this")
 	}
 
+	if usrCfg.GetString("workspace") == "" {
+		return errors.New("TODO: run configure first")
+	}
+
 	files, err := flags.GetStringSlice("files")
 	if err != nil {
 		return err

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -77,7 +77,7 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		return errors.New("TODO: run configure first")
 	}
 
-	for _, arg := range args {
+	for i, arg := range args {
 		info, err := os.Lstat(arg)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -88,9 +88,18 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 		if info.IsDir() {
 			return errors.New("TODO: it is a directory and we cannot handle that")
 		}
+
+		src, err := filepath.EvalSymlinks(arg)
+		if err != nil {
+			return err
+		}
+		args[i] = src
 	}
 
-	ws := workspace.New(usrCfg.GetString("workspace"))
+	ws, err := workspace.New(usrCfg.GetString("workspace"))
+	if err != nil {
+		return err
+	}
 
 	tx, err := workspace.NewTransmission(ws.Dir, args)
 	if err != nil {

--- a/cmd/submit_relative_path_test.go
+++ b/cmd/submit_relative_path_test.go
@@ -1,0 +1,68 @@
+// +build !windows
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exercism/cli/config"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitRelativePath(t *testing.T) {
+	oldOut := Out
+	oldErr := Err
+	Out = ioutil.Discard
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+	}()
+	// The fake endpoint will populate this when it receives the call from the command.
+	submittedFiles := map[string]string{}
+	ts := fakeSubmitServer(t, submittedFiles)
+	defer ts.Close()
+
+	tmpDir, err := ioutil.TempDir("", "relative-path")
+	assert.NoError(t, err)
+
+	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
+	os.MkdirAll(dir, os.FileMode(0755))
+
+	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+	v.Set("apibaseurl", ts.URL)
+
+	cliCfg := &config.CLIConfig{
+		Config: config.New(tmpDir, "cli"),
+		Tracks: config.Tracks{},
+	}
+	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
+	err = cliCfg.Write()
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		CLIConfig:       cliCfg,
+	}
+
+	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))
+
+	err = os.Chdir(dir)
+	assert.NoError(t, err)
+
+	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{"file.txt"})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(submittedFiles))
+	assert.Equal(t, "This is a file.", submittedFiles["/file.txt"])
+}

--- a/cmd/submit_relative_path_test.go
+++ b/cmd/submit_relative_path_test.go
@@ -41,18 +41,9 @@ func TestSubmitRelativePath(t *testing.T) {
 	v.Set("workspace", tmpDir)
 	v.Set("apibaseurl", ts.URL)
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-	err = cliCfg.Write()
-	assert.NoError(t, err)
-
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))

--- a/cmd/submit_relative_path_windows_test.go
+++ b/cmd/submit_relative_path_windows_test.go
@@ -41,18 +41,9 @@ func TestSubmitRelativePath(t *testing.T) {
 	v.Set("workspace", tmpDir)
 	v.Set("apibaseurl", ts.URL)
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-	err = cliCfg.Write()
-	assert.NoError(t, err)
-
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))

--- a/cmd/submit_relative_path_windows_test.go
+++ b/cmd/submit_relative_path_windows_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exercism/cli/config"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitRelativePath(t *testing.T) {
+	t.Skip("The Windows build is failing and needs to be debugged.\nSee https://ci.appveyor.com/project/kytrinyx/cli/build/110")
+
+	oldOut := Out
+	oldErr := Err
+	Out = ioutil.Discard
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+	}()
+	// The fake endpoint will populate this when it receives the call from the command.
+	submittedFiles := map[string]string{}
+	ts := fakeSubmitServer(t, submittedFiles)
+	defer ts.Close()
+
+	tmpDir, err := ioutil.TempDir("", "relative-path")
+	assert.NoError(t, err)
+
+	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
+	os.MkdirAll(dir, os.FileMode(0755))
+
+	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+	v.Set("apibaseurl", ts.URL)
+
+	cliCfg := &config.CLIConfig{
+		Config: config.New(tmpDir, "cli"),
+		Tracks: config.Tracks{},
+	}
+	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
+	err = cliCfg.Write()
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		CLIConfig:       cliCfg,
+	}
+
+	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))
+
+	err = os.Chdir(dir)
+	assert.NoError(t, err)
+
+	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{"file.txt"})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(submittedFiles))
+	assert.Equal(t, "This is a file.", submittedFiles["/file.txt"])
+}

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -42,12 +42,6 @@ func TestSubmitFilesInSymlinkedPath(t *testing.T) {
 	dir := filepath.Join(dstDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-
 	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
 
 	v := viper.New()
@@ -58,7 +52,6 @@ func TestSubmitFilesInSymlinkedPath(t *testing.T) {
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	file := filepath.Join(dir, "file.txt")

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -1,0 +1,73 @@
+// +build !windows
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exercism/cli/config"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitFilesInSymlinkedPath(t *testing.T) {
+	oldOut := Out
+	oldErr := Err
+	Out = ioutil.Discard
+	Err = ioutil.Discard
+	defer func() {
+		Out = oldOut
+		Err = oldErr
+	}()
+
+	// The fake endpoint will populate this when it receives the call from the command.
+	submittedFiles := map[string]string{}
+	ts := fakeSubmitServer(t, submittedFiles)
+	defer ts.Close()
+
+	tmpDir, err := ioutil.TempDir("", "symlink-destination")
+	assert.NoError(t, err)
+	dstDir := filepath.Join(tmpDir, "workspace")
+
+	srcDir, err := ioutil.TempDir("", "symlink-source")
+	assert.NoError(t, err)
+
+	err = os.Symlink(srcDir, dstDir)
+	assert.NoError(t, err)
+
+	dir := filepath.Join(dstDir, "bogus-track", "bogus-exercise")
+	os.MkdirAll(dir, os.FileMode(0755))
+
+	cliCfg := &config.CLIConfig{
+		Config: config.New(tmpDir, "cli"),
+		Tracks: config.Tracks{},
+	}
+	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
+
+	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", dstDir)
+	v.Set("apibaseurl", ts.URL)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		CLIConfig:       cliCfg,
+	}
+
+	file := filepath.Join(dir, "file.txt")
+	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))
+	assert.NoError(t, err)
+
+	err = runSubmit(cfg, pflag.NewFlagSet("symlinks", pflag.PanicOnError), []string{file})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(submittedFiles))
+	assert.Equal(t, "This is a file.", submittedFiles["/file.txt"])
+}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -142,14 +142,7 @@ func TestSubmitFiles(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	solution := &workspace.Solution{
-		ID:          "bogus-solution-uuid",
-		Track:       "bogus-track",
-		Exercise:    "bogus-exercise",
-		IsRequester: true,
-	}
-	err = solution.Write(dir)
-	assert.NoError(t, err)
+	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 	setupSubmitFlags(flags)
@@ -210,4 +203,15 @@ func fakeSubmitServer(t *testing.T, submittedFiles map[string]string) *httptest.
 		}
 	})
 	return httptest.NewServer(handler)
+}
+
+func writeFakeSolution(t *testing.T, dir, trackID, exerciseSlug string) {
+	solution := &workspace.Solution{
+		ID:          "bogus-solution-uuid",
+		Track:       trackID,
+		Exercise:    exerciseSlug,
+		IsRequester: true,
+	}
+	err := solution.Write(dir)
+	assert.NoError(t, err)
 }

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/exercism/cli/config"
@@ -125,12 +124,6 @@ func TestSubmitFiles(t *testing.T) {
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 	setupSubmitFlags(flags)
-	flagArgs := []string{
-		"--files",
-		strings.Join(filenames, ","),
-	}
-	err = flags.Parse(flagArgs)
-	assert.NoError(t, err)
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -152,7 +145,7 @@ func TestSubmitFiles(t *testing.T) {
 		CLIConfig:       cliCfg,
 	}
 
-	err = runSubmit(cfg, flags, []string{})
+	err = runSubmit(cfg, flags, filenames)
 	assert.NoError(t, err)
 
 	// We currently have a bug, and we're not filtering anything.

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -29,6 +29,22 @@ func TestSubmitWithoutToken(t *testing.T) {
 	assert.Regexp(t, "Welcome to Exercism", err.Error())
 }
 
+func TestSubmitWithoutWorkspace(t *testing.T) {
+	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		DefaultBaseURL:  "http://example.com",
+	}
+
+	err := runSubmit(cfg, flags, []string{})
+	assert.Regexp(t, "run configure", err.Error())
+}
+
 func TestSubmitFiles(t *testing.T) {
 	oldOut := Out
 	oldErr := Err

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -37,7 +37,7 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 	}
 
 	err := runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
-	assert.Regexp(t, "run configure", err.Error())
+	assert.Regexp(t, "re-run the configure", err.Error())
 }
 
 func TestSubmitNonExistentFile(t *testing.T) {
@@ -65,7 +65,7 @@ func TestSubmitNonExistentFile(t *testing.T) {
 		filepath.Join(tmpDir, "file-2.txt"),
 	}
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), files)
-	assert.Regexp(t, "no such file", err.Error())
+	assert.Regexp(t, "cannot be found", err.Error())
 }
 
 func TestSubmitFilesAndDir(t *testing.T) {
@@ -93,7 +93,7 @@ func TestSubmitFilesAndDir(t *testing.T) {
 		filepath.Join(tmpDir, "file-2.txt"),
 	}
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), files)
-	assert.Regexp(t, "is a directory", err.Error())
+	assert.Regexp(t, "submitting a directory", err.Error())
 }
 
 func TestSubmitFiles(t *testing.T) {
@@ -231,7 +231,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
 	assert.Error(t, err)
-	assert.Regexp(t, "no files", err.Error())
+	assert.Regexp(t, "No files found", err.Error())
 }
 
 func TestSubmitFilesFromDifferentSolutions(t *testing.T) {

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSubmitWithoutToken(t *testing.T) {
+	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: viper.New(),
+		DefaultBaseURL:  "http://example.com",
+	}
+
+	err := runSubmit(cfg, flags, []string{})
+	assert.Regexp(t, "Welcome to Exercism", err.Error())
+}
+
 func TestSubmitFiles(t *testing.T) {
 	oldOut := Out
 	oldErr := Err

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -70,6 +70,32 @@ func TestSubmitNonExistentFile(t *testing.T) {
 	assert.Regexp(t, "no such file", err.Error())
 }
 
+func TestSubmitFilesAndDir(t *testing.T) {
+	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+
+	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
+	assert.NoError(t, err)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		DefaultBaseURL:  "http://example.com",
+	}
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-2.txt"), []byte("This is file 2"), os.FileMode(0755))
+	assert.NoError(t, err)
+
+	err = runSubmit(cfg, flags, []string{filepath.Join(tmpDir, "file-1.txt"), tmpDir, filepath.Join(tmpDir, "file-2.txt")})
+	assert.Regexp(t, "is a directory", err.Error())
+}
+
 func TestSubmitFiles(t *testing.T) {
 	oldOut := Out
 	oldErr := Err

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -210,6 +210,7 @@ func writeFakeSolution(t *testing.T, dir, trackID, exerciseSlug string) {
 		ID:          "bogus-solution-uuid",
 		Track:       trackID,
 		Exercise:    exerciseSlug,
+		URL:         "http://example.com/bogus-url",
 		IsRequester: true,
 	}
 	err := solution.Write(dir)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -44,110 +44,92 @@ func TestSubmit(t *testing.T) {
 		relativePath: "README.md",
 		contents:     "The readme.",
 	}
-	// Make a list of test commands
-	cmdTestFlags := &CommandTest{
-		Cmd:    submitCmd,
-		InitFn: initSubmitCmd,
-		Args:   []string{"fakeapp", "submit", "-e", "bogus-exercise", "-t", "bogus-track"},
-	}
-	cmdTestRelativeDir := &CommandTest{
-		Cmd:    submitCmd,
-		InitFn: initSubmitCmd,
-		Args:   []string{"fakeapp", "submit", filepath.Join("bogus-track", "bogus-exercise")},
-	}
-	cmdTestFilesFlag := &CommandTest{
+	cmdTest := &CommandTest{
 		Cmd:    submitCmd,
 		InitFn: initSubmitCmd,
 		Args:   []string{"fakeapp", "submit", "--files"},
 	}
-	tests := []*CommandTest{
-		cmdTestFlags,
-		cmdTestRelativeDir,
-		cmdTestFilesFlag,
+	cmdTest.Setup(t)
+	defer cmdTest.Teardown(t)
+
+	// Prefix submitted filenames with correct temporary directory
+	if cmdTest.Args[2] == "--files" {
+		filenames := make([]string, 2)
+		for i, file := range []file{file1, file2} {
+			filenames[i] = filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", file.relativePath)
+		}
+		filenameString := strings.Join(filenames, ",")
+		cmdTest.Args[2] = fmt.Sprintf("-f=%s", filenameString)
+	} else if len(cmdTest.Args) == 3 {
+		cmdTest.Args[2] = filepath.Join(cmdTest.TmpDir, cmdTest.Args[2])
 	}
-	for _, cmdTest := range tests {
-		cmdTest.Setup(t)
-		defer cmdTest.Teardown(t)
+	// Create a temp dir for the config and the exercise files.
+	dir := filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise")
+	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 
-		// Prefix submitted filenames with correct temporary directory
-		if cmdTest.Args[2] == "--files" {
-			filenames := make([]string, 2)
-			for i, file := range []file{file1, file2} {
-				filenames[i] = filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise", file.relativePath)
-			}
-			filenameString := strings.Join(filenames, ",")
-			cmdTest.Args[2] = fmt.Sprintf("-f=%s", filenameString)
-		} else if len(cmdTest.Args) == 3 {
-			cmdTest.Args[2] = filepath.Join(cmdTest.TmpDir, cmdTest.Args[2])
-		}
-		// Create a temp dir for the config and the exercise files.
-		dir := filepath.Join(cmdTest.TmpDir, "bogus-track", "bogus-exercise")
-		os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
+	solution := &workspace.Solution{
+		ID:          "bogus-solution-uuid",
+		Track:       "bogus-track",
+		Exercise:    "bogus-exercise",
+		IsRequester: true,
+	}
+	err := solution.Write(dir)
+	assert.NoError(t, err)
 
-		solution := &workspace.Solution{
-			ID:          "bogus-solution-uuid",
-			Track:       "bogus-track",
-			Exercise:    "bogus-exercise",
-			IsRequester: true,
-		}
-		err := solution.Write(dir)
+	for _, file := range []file{file1, file2, file3} {
+		err := ioutil.WriteFile(filepath.Join(dir, file.relativePath), []byte(file.contents), os.FileMode(0755))
 		assert.NoError(t, err)
+	}
 
-		for _, file := range []file{file1, file2, file3} {
-			err := ioutil.WriteFile(filepath.Join(dir, file.relativePath), []byte(file.contents), os.FileMode(0755))
-			assert.NoError(t, err)
+	// The fake endpoint will populate this when it receives the call from the command.
+	submittedFiles := map[string]string{}
+
+	// Set up the test server.
+	fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseMultipartForm(2 << 10)
+		if err != nil {
+			t.Fatal(err)
 		}
+		mf := r.MultipartForm
 
-		// The fake endpoint will populate this when it receives the call from the command.
-		submittedFiles := map[string]string{}
-
-		// Set up the test server.
-		fakeEndpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			err := r.ParseMultipartForm(2 << 10)
+		files := mf.File["files[]"]
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
 			if err != nil {
 				t.Fatal(err)
 			}
-			mf := r.MultipartForm
-
-			files := mf.File["files[]"]
-			for _, fileHeader := range files {
-				file, err := fileHeader.Open()
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer file.Close()
-				body, err := ioutil.ReadAll(file)
-				if err != nil {
-					t.Fatal(err)
-				}
-				submittedFiles[fileHeader.Filename] = string(body)
+			defer file.Close()
+			body, err := ioutil.ReadAll(file)
+			if err != nil {
+				t.Fatal(err)
 			}
-		})
-		ts := httptest.NewServer(fakeEndpoint)
-		defer ts.Close()
-
-		// Create a fake user config.
-		usrCfg := config.NewEmptyUserConfig()
-		usrCfg.Workspace = cmdTest.TmpDir
-		usrCfg.APIBaseURL = ts.URL
-		err = usrCfg.Write()
-		assert.NoError(t, err)
-
-		// Create a fake CLI config.
-		cliCfg, err := config.NewCLIConfig()
-		assert.NoError(t, err)
-		cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-		err = cliCfg.Write()
-		assert.NoError(t, err)
-
-		// Execute the command!
-		cmdTest.App.Execute()
-
-		// We got only the file we expected.
-		assert.Equal(t, 2, len(submittedFiles))
-		for _, file := range []file{file1, file2} {
-			path := string(os.PathSeparator) + file.relativePath
-			assert.Equal(t, file.contents, submittedFiles[path])
+			submittedFiles[fileHeader.Filename] = string(body)
 		}
+	})
+	ts := httptest.NewServer(fakeEndpoint)
+	defer ts.Close()
+
+	// Create a fake user config.
+	usrCfg := config.NewEmptyUserConfig()
+	usrCfg.Workspace = cmdTest.TmpDir
+	usrCfg.APIBaseURL = ts.URL
+	err = usrCfg.Write()
+	assert.NoError(t, err)
+
+	// Create a fake CLI config.
+	cliCfg, err := config.NewCLIConfig()
+	assert.NoError(t, err)
+	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
+	err = cliCfg.Write()
+	assert.NoError(t, err)
+
+	// Execute the command!
+	cmdTest.App.Execute()
+
+	// We got only the file we expected.
+	assert.Equal(t, 2, len(submittedFiles))
+	for _, file := range []file{file1, file2} {
+		path := string(os.PathSeparator) + file.relativePath
+		assert.Equal(t, file.contents, submittedFiles[path])
 	}
 }

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -46,22 +46,19 @@ func TestSubmit(t *testing.T) {
 	}
 	// Make a list of test commands
 	cmdTestFlags := &CommandTest{
-		Cmd:                     submitCmd,
-		InitFn:                  initSubmitCmd,
-		MockInteractiveResponse: "\n",
-		Args: []string{"fakeapp", "submit", "-e", "bogus-exercise", "-t", "bogus-track"},
+		Cmd:    submitCmd,
+		InitFn: initSubmitCmd,
+		Args:   []string{"fakeapp", "submit", "-e", "bogus-exercise", "-t", "bogus-track"},
 	}
 	cmdTestRelativeDir := &CommandTest{
-		Cmd:                     submitCmd,
-		InitFn:                  initSubmitCmd,
-		MockInteractiveResponse: "\n",
-		Args: []string{"fakeapp", "submit", filepath.Join("bogus-track", "bogus-exercise")},
+		Cmd:    submitCmd,
+		InitFn: initSubmitCmd,
+		Args:   []string{"fakeapp", "submit", filepath.Join("bogus-track", "bogus-exercise")},
 	}
 	cmdTestFilesFlag := &CommandTest{
-		Cmd:                     submitCmd,
-		InitFn:                  initSubmitCmd,
-		MockInteractiveResponse: "\n",
-		Args: []string{"fakeapp", "submit", "--files"},
+		Cmd:    submitCmd,
+		InitFn: initSubmitCmd,
+		Args:   []string{"fakeapp", "submit", "--files"},
 	}
 	tests := []*CommandTest{
 		cmdTestFlags,
@@ -142,9 +139,6 @@ func TestSubmit(t *testing.T) {
 		cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
 		err = cliCfg.Write()
 		assert.NoError(t, err)
-
-		// Write mock interactive input to In for the CLI command.
-		In = strings.NewReader(cmdTest.MockInteractiveResponse)
 
 		// Execute the command!
 		cmdTest.App.Execute()

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -129,6 +129,7 @@ func TestSubmitFiles(t *testing.T) {
 		relativePath: filepath.Join("subdir", "file-2.txt"),
 		contents:     "This is file 2.",
 	}
+	// We don't filter *.md files if you explicitly pass the file path.
 	file3 := file{
 		relativePath: "README.md",
 		contents:     "The readme.",
@@ -170,8 +171,6 @@ func TestSubmitFiles(t *testing.T) {
 	err = runSubmit(cfg, flags, filenames)
 	assert.NoError(t, err)
 
-	// We currently have a bug, and we're not filtering anything.
-	// Fix that in a separate commit.
 	assert.Equal(t, 3, len(submittedFiles))
 
 	for _, file := range []file{file1, file2, file3} {

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -135,19 +135,10 @@ func TestSubmitFiles(t *testing.T) {
 	v.Set("workspace", tmpDir)
 	v.Set("apibaseurl", ts.URL)
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-	err = cliCfg.Write()
-	assert.NoError(t, err)
-
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		Dir:             tmpDir,
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	files := []string{
@@ -184,12 +175,6 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-
 	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
 
 	v := viper.New()
@@ -200,7 +185,6 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	file1 := filepath.Join(dir, "file-1.txt")
@@ -231,12 +215,6 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-
 	writeFakeSolution(t, dir, "bogus-track", "bogus-exercise")
 
 	v := viper.New()
@@ -246,7 +224,6 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	file := filepath.Join(dir, "file.txt")
@@ -281,19 +258,10 @@ func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
 	v.Set("token", "abc123")
 	v.Set("workspace", tmpDir)
 
-	cliCfg := &config.CLIConfig{
-		Config: config.New(tmpDir, "cli"),
-		Tracks: config.Tracks{},
-	}
-	cliCfg.Tracks["bogus-track"] = config.NewTrack("bogus-track")
-	err = cliCfg.Write()
-	assert.NoError(t, err)
-
 	cfg := config.Configuration{
 		Persister:       config.InMemoryPersister{},
 		Dir:             tmpDir,
 		UserViperConfig: v,
-		CLIConfig:       cliCfg,
 	}
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file1, file2})

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -27,7 +27,7 @@ type Configuration struct {
 	DefaultDirName  string
 	UserViperConfig *viper.Viper
 	UserConfig      *UserConfig
-	CLI             *CLIConfig
+	CLIConfig       *CLIConfig
 	Persister       Persister
 }
 

--- a/workspace/transmission.go
+++ b/workspace/transmission.go
@@ -38,7 +38,10 @@ func NewTransmission(root string, args []string) (*Transmission, error) {
 		return nil, errors.New("mixing files and dirs")
 	}
 	if len(tx.Files) > 0 {
-		ws := New(root)
+		ws, err := New(root)
+		if err != nil {
+			return nil, err
+		}
 		parents := map[string]bool{}
 		for _, file := range tx.Files {
 			dir, err := ws.SolutionDir(file)

--- a/workspace/transmission_windows_test.go
+++ b/workspace/transmission_windows_test.go
@@ -1,10 +1,6 @@
-// +build !windows
-
 package workspace
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -13,6 +9,8 @@ import (
 )
 
 func TestNewTransmission(t *testing.T) {
+	t.Skip("This panics on Windows. Once debugged, this can likely be inlined back into the main transmission test.")
+
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "transmission")
 	dirBird := filepath.Join(root, "creatures", "hummingbird")
@@ -81,20 +79,5 @@ func TestNewTransmission(t *testing.T) {
 				assert.Equal(t, tc.tx.Dir, tx.Dir)
 			}
 		})
-	}
-}
-
-func TestTransmissionWithRelativePath(t *testing.T) {
-	// This is really dirty, but I need to make sure that we turn relative paths into absolute paths.
-	err := ioutil.WriteFile(".solution.json", []byte("{}"), os.FileMode(0755))
-	assert.NoError(t, err)
-	defer os.Remove(".solution.json")
-
-	_, cwd, _, _ := runtime.Caller(0)
-	dir := filepath.Dir(filepath.Dir(cwd))
-	file := filepath.Base(cwd)
-	tx, err := NewTransmission(dir, []string{file})
-	if assert.NoError(t, err) {
-		assert.Equal(t, filepath.Clean(cwd), tx.Files[0])
 	}
 }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -19,8 +19,16 @@ type Workspace struct {
 }
 
 // New returns a configured workspace.
-func New(dir string) Workspace {
-	return Workspace{Dir: dir}
+func New(dir string) (Workspace, error) {
+	_, err := os.Lstat(dir)
+	if err != nil {
+		return Workspace{}, err
+	}
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		return Workspace{}, err
+	}
+	return Workspace{Dir: dir}, nil
 }
 
 // Locate the matching directories within the workspace.

--- a/workspace/workspace_locate_test.go
+++ b/workspace/workspace_locate_test.go
@@ -16,7 +16,8 @@ func TestLocateErrors(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "locate-exercise")
 
-	ws := New(filepath.Join(root, "workspace"))
+	ws, err := New(filepath.Join(root, "workspace"))
+	assert.NoError(t, err)
 
 	testCases := []struct {
 		desc, arg string
@@ -68,7 +69,8 @@ func TestLocate(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "locate-exercise")
 
-	wsPrimary := New(filepath.Join(root, "workspace"))
+	wsPrimary, err := New(filepath.Join(root, "workspace"))
+	assert.NoError(t, err)
 
 	testCases := []locateTestCase{
 		{

--- a/workspace/workspace_symlinks_test.go
+++ b/workspace/workspace_symlinks_test.go
@@ -6,14 +6,18 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLocateSymlinks(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "locate-exercise")
 
-	wsSymbolic := New(filepath.Join(root, "symlinked-workspace"))
-	wsPrimary := New(filepath.Join(root, "workspace"))
+	wsSymbolic, err := New(filepath.Join(root, "symlinked-workspace"))
+	assert.NoError(t, err)
+	wsPrimary, err := New(filepath.Join(root, "workspace"))
+	assert.NoError(t, err)
 
 	testCases := []locateTestCase{
 		{

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"io/ioutil"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -10,7 +11,8 @@ import (
 
 func TestSolutionPath(t *testing.T) {
 	root := filepath.Join("..", "fixtures", "solution-path", "creatures")
-	ws := New(root)
+	ws, err := New(root)
+	assert.NoError(t, err)
 
 	// An existing exercise.
 	path, err := ws.SolutionPath("gazelle", "ccc")
@@ -48,7 +50,9 @@ func TestIsSolutionPath(t *testing.T) {
 }
 
 func TestResolveSolutionPath(t *testing.T) {
-	ws := New("tmp")
+	tmpDir, err := ioutil.TempDir("", "resolve-solution-path")
+	ws, err := New(tmpDir)
+	assert.NoError(t, err)
 
 	existsFn := func(solutionID, path string) (bool, error) {
 		pathToSolutionID := map[string]string{
@@ -138,7 +142,8 @@ func TestSolutionDir(t *testing.T) {
 	_, cwd, _, _ := runtime.Caller(0)
 	root := filepath.Join(cwd, "..", "..", "fixtures", "solution-dir")
 
-	ws := New(filepath.Join(root, "workspace"))
+	ws, err := New(filepath.Join(root, "workspace"))
+	assert.NoError(t, err)
 
 	tests := []struct {
 		path string


### PR DESCRIPTION
The conclusion from the v2 beta is that the submit command is too hard to use.

In order to bring this back to something manageable I'm dramatically reducing the number of ways that you can interact with the submit command to exactly one: submitting a list of files as arguments:

    exercism submit path/to/file1 [path/to/file2...]

Once we get this worked out, and have added some features and tooling that will help us filter files more sensibly, we can judiciously add back a way to submit an entire directory (see https://github.com/exercism/meta/issues/107).

I've added extensive tests for the submit command, and I've made them very straight forward, which for now means quite a lot of duplication. I'd rather have duplication than conditionals within loops to do setup that isn't clear.

Closes https://github.com/exercism/cli/issues/608