### PR TITLE
Make the successfully configured message friendlier

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -197,6 +197,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 	if err := configuration.Save("user"); err != nil {
 		return err
 	}
+	fmt.Fprintln(Err, "\nYou have configured the Exercism command-line client:")
 	printCurrentConfig(configuration)
 	return nil
 }
@@ -208,10 +209,10 @@ func printCurrentConfig(configuration config.Configuration) {
 	v := configuration.UserViperConfig
 
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, fmt.Sprintf("Config dir:\t%s", configuration.Dir))
-	fmt.Fprintln(w, fmt.Sprintf("-t, --token\t%s", v.GetString("token")))
-	fmt.Fprintln(w, fmt.Sprintf("-w, --workspace\t%s", v.GetString("workspace")))
-	fmt.Fprintln(w, fmt.Sprintf("-a, --api\t%s", v.GetString("apibaseurl")))
+	fmt.Fprintln(w, fmt.Sprintf("Config dir:\t\t%s", configuration.Dir))
+	fmt.Fprintln(w, fmt.Sprintf("Token:\t(-t, --token)\t%s", v.GetString("token")))
+	fmt.Fprintln(w, fmt.Sprintf("Workspace:\t(-w, --workspace)\t%s", v.GetString("workspace")))
+	fmt.Fprintln(w, fmt.Sprintf("API Base URL:\t(-a, --api)\t%s", v.GetString("apibaseurl")))
 	fmt.Fprintln(w, "")
 }
 


### PR DESCRIPTION
The configure output looked like it could be an error message.
This adds a bit of context to say that the configuration was saved, and
clarifies the output to make it easier to understand that it's showing you
what the configuration settings that were saved are.

**Old output:**

```
$ exercism configure --token=abc123

Config dir:      /Users/kytrinyx/.config/exercism
-t, --token      abc123
-w, --workspace  /Users/kytrinyx/Exercism
-a, --api        https://api.exercism.io/v1
```
**New output:**

```
$ ./testercism configure --token=abc123

You have configured the Exercism command-line client:

Config dir:                       /Users/kytrinyx/.config/exercism
Token:         (-t, --token)      abc123
Workspace:     (-w, --workspace)  /Users/kytrinyx/Exercism
API Base URL:  (-a, --api)        https://api.exercism.io/v1
```