### PR TITLE
Fix multi-file submission bug

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -36,7 +36,6 @@ If called with the name of an exercise, it will work out which
 track it is on and submit it. The command will ask for help
 figuring things out if necessary.
 `,
-	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.NewConfiguration()
 


### PR DESCRIPTION
When I rewrote the tests to go through the runSubmit function so I can
inject stuff, I forgot to actually consider what the command setup was
configuring.

In this case we had left a strict requirement that the submit command
only accept one single argument.

I've deleted the restriction, and tested manually.

I'll add a proper test when things slow down a bit.