### PR TITLE
Fix incorrect long description of submit command

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -25,16 +25,7 @@ var submitCmd = &cobra.Command{
 	Short:   "Submit your solution to an exercise.",
 	Long: `Submit your solution to an Exercism exercise.
 
-The CLI will do its best to figure out what to submit.
-
-If you call the command without any arguments, it will
-submit the exercise contained in the current directory.
-
-If called with the path to a directory, it will submit it.
-
-If called with the name of an exercise, it will work out which
-track it is on and submit it. The command will ask for help
-figuring things out if necessary.
+	Call the command with the list of files you want to submit.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.NewConfiguration()


### PR DESCRIPTION
The documentation was still talking about all the guessing the
command used to do to figure out what to submit.

As reported by @mikewalker in https://github.com/exercism/cli/issues/620#issuecomment-404950767

FYI @nywilken 