### PR TITLE
Improve setup instructions for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,19 @@ The TL;DR is: **don't clone your fork**, and it matters where on your filesystem
 
 If you don't care how and why and just want something that works, follow these steps:
 
-1. [fork this repo][fork]
+1. [fork this repo on the Github webpage][fork]
 1. `go get github.com/exercism/cli/exercism`
 1. `cd $GOPATH/src/github.com/exercism/cli` (or `cd %GOPATH%/src/github.com/exercism/cli` on Windows)
-1. `git remote set-url origin https://github.com/<your-github-username>/cli`
+1. `git remote add upstream https://github.com/exercism/cli.git`
+1. `git remote add origin git@github.com:<your-github-username>/cli.git`
+1. `git checkout -b development`
+1. `git push -u origin development`
+1. `
 1. `go get -u github.com/golang/dep/cmd/dep`
    * depending on your setup, you may need to install `dep` by following the instructions in the [`dep` repo](https://github.com/golang/dep)
 1. `dep ensure`
+1. `git update-index --assume-unchanged Gopkg.lock`
+1. `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o exercism main.go && mv exercism ~/bin`
 
 Then make the change as usual, and submit a pull request. Please provide tests for the changes where possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,18 +20,16 @@ If you don't care how and why and just want something that works, follow these s
 1. [fork this repo on the Github webpage][fork]
 1. `go get github.com/exercism/cli/exercism`
 1. `cd $GOPATH/src/github.com/exercism/cli` (or `cd %GOPATH%/src/github.com/exercism/cli` on Windows)
-1. `git remote add upstream https://github.com/exercism/cli.git`
+1. `git remote rename origin upstream`
 1. `git remote add origin git@github.com:<your-github-username>/cli.git`
 1. `git checkout -b development`
-1. `git push -u origin development`
-1. `
+1. `git push -u origin development` (setup where you push to, check it works)
 1. `go get -u github.com/golang/dep/cmd/dep`
    * depending on your setup, you may need to install `dep` by following the instructions in the [`dep` repo](https://github.com/golang/dep)
 1. `dep ensure`
-1. `git update-index --assume-unchanged Gopkg.lock`
-1. `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o exercism main.go && mv exercism ~/bin`
+1. `git update-index --assume-unchanged Gopkg.lock` (prevent your dep changes being committed)
 
-Then make the change as usual, and submit a pull request. Please provide tests for the changes where possible.
+Then make changes as usual and submit a pull request. Please provide tests for the changes where possible.
 
 If you care about the details, check out the blog post [Contributing to Open Source Repositories in Go][contrib-blog] on the Splice blog.
 
@@ -53,24 +51,15 @@ As of Go 1.9 this is simplified to `go test ./...`.
 
 ## Manual Testing against Exercism
 
-You can build whatever is in your local, working copy of the CLI without overwriting your existing Exercism
-CLI installation by using the `go build` command:
+If you want to test your changes while doing your everyday exorcism work you could do:
 
-```
-go build -o testercism exercism/main.go
-```
+On Unices:
 
-This assumes that you are standing at the root of the exercism/cli repository checked out locally, and it will put a binary named `testercism` in your current working directory.
+- `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o exercism main.go && mv exercism ~/bin`
 
-You can call it whatever you like, but `exercism` would conflict with the directory that is already there.
+On Windows:
 
-Then you call it with `./testercism`.
-
-You can always put this in your path if you want to run it from elsewhere on your system.
-
-We highly recommend spinning up a local copy of Exercism to test against so that you can mess with the database (and so you don't accidentally break stuff for yourself in production).
-
-[TODO: link to the nextercism repo installation instructions, and explain how to reconfigure the CLI]
+- ?? TODO
 
 ### Building for All Platforms
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,14 @@ damaging your real Exercism submissions, or test different tokens, etc.
 
 On Unices:
 
-- `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o testercism main.go && mv testercism ~/bin`
+- `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o testercism main.go`
+- `./testercism -h`
 
 On Windows:
 
 - `cd /d %GOPATH%\src\github.com\exercism\cli`
 - `go build -o testercism.exe exercism\main.go`
-- TODO where would a Windows developer put the binary?
+- `testercism.exe —help`
 
 ### Building for All Platforms
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The TL;DR is: **don't clone your fork**, and it matters where on your filesystem
 
 If you don't care how and why and just want something that works, follow these steps:
 
-1. [fork this repo on the Github webpage][fork]
+1. [fork this repo on the GitHub webpage][fork]
 1. `go get github.com/exercism/cli/exercism`
 1. `cd $GOPATH/src/github.com/exercism/cli` (or `cd %GOPATH%/src/github.com/exercism/cli` on Windows)
 1. `git remote rename origin upstream`
@@ -51,15 +51,21 @@ As of Go 1.9 this is simplified to `go test ./...`.
 
 ## Manual Testing against Exercism
 
-If you want to test your changes while doing your everyday exorcism work you could do:
+To test your changes while doing everyday Exercism work you
+can build using the following instructions. Any name may be used for the
+binary (e.g. `testercism`) - by using a name other than `exercism` you
+can have different profiles under `~/.config` and avoid possibly
+damaging your real Exercism submissions, or test different tokens, etc.
 
 On Unices:
 
-- `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o exercism main.go && mv exercism ~/bin`
+- `cd $GOPATH/src/github.com/exercism/cli/exercism && go build -o testercism main.go && mv testercism ~/bin`
 
 On Windows:
 
-- ?? TODO
+- `cd /d %GOPATH%\src\github.com\exercism\cli`
+- `go build -o testercism.exe exercism\main.go`
+- TODO where would a Windows developer put the binary?
 
 ### Building for All Platforms
 


### PR DESCRIPTION
The current instructions don't demonstrate how a contributor would track
the main repo while submitting pull requests.

These updated instructions allow contributors to pull from upstream
but not push, whilst being able to push to their repo and submit
PR's. There may be a better way of doing this, if so please comment!

See:

* https://help.github.com/articles/configuring-a-remote-for-a-fork/
* https://www.atlassian.com/git/tutorials/syncing

Also `git update-index --assume-unchanged Gopkg.lock` prevents
accidental commits by contributors.