### PR TITLE
Don't accept token flag on download command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,16 @@
+package cmd
+
+const msgWelcomePleaseConfigure = `
+
+    Welcome to Exercism!
+
+    To get started, you need to configure the the tool with your API token.
+    Find your token at
+
+        %s
+
+    Then run the configure command:
+
+        %s configure --token=YOUR_TOKEN
+
+`

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -36,22 +36,7 @@ Download other people's solutions by providing the UUID.
 		}
 		if usrCfg.Token == "" {
 			tokenURL := config.InferSiteURL(usrCfg.APIBaseURL) + "/my/settings"
-			msg := `
-
-    Welcome to Exercism!
-
-    To get started, you need to configure the the tool with your API token.
-    Find your token at
-
-        %s
-
-    Then run the configure command:
-
-
-        %s configure --token=YOUR_TOKEN
-
-    `
-			return fmt.Errorf(msg, tokenURL, BinaryName)
+			return fmt.Errorf(msgWelcomePleaseConfigure, tokenURL, BinaryName)
 		}
 
 		uuid, err := cmd.Flags().GetString("uuid")

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -30,6 +30,30 @@ latest solution.
 Download other people's solutions by providing the UUID.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		usrCfg, err := config.NewUserConfig()
+		if err != nil {
+			return err
+		}
+		if usrCfg.Token == "" {
+			tokenURL := config.InferSiteURL(usrCfg.APIBaseURL) + "/my/settings"
+			msg := `
+
+    Welcome to Exercism!
+
+    To get started, you need to configure the the tool with your API token.
+    Find your token at
+
+        %s
+
+    Then run the configure command:
+
+
+        %s configure --token=YOUR_TOKEN
+
+    `
+			return fmt.Errorf(msg, tokenURL, BinaryName)
+		}
+
 		uuid, err := cmd.Flags().GetString("uuid")
 		if err != nil {
 			return err
@@ -40,10 +64,6 @@ Download other people's solutions by providing the UUID.
 		}
 		if uuid == "" && exercise == "" {
 			return errors.New("need an --exercise name or a solution --uuid")
-		}
-		usrCfg, err := config.NewUserConfig()
-		if err != nil {
-			return err
 		}
 
 		var slug string

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -30,16 +30,6 @@ latest solution.
 Download other people's solutions by providing the UUID.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		token, err := cmd.Flags().GetString("token")
-		if err != nil {
-			return err
-		}
-		if token != "" {
-			RootCmd.SetArgs([]string{"configure", "--token", token})
-			if err := RootCmd.Execute(); err != nil {
-				return err
-			}
-		}
 		uuid, err := cmd.Flags().GetString("uuid")
 		if err != nil {
 			return err
@@ -229,7 +219,6 @@ func initDownloadCmd() {
 	downloadCmd.Flags().StringP("uuid", "u", "", "the solution UUID")
 	downloadCmd.Flags().StringP("track", "t", "", "the track ID")
 	downloadCmd.Flags().StringP("exercise", "e", "", "the exercise slug")
-	downloadCmd.Flags().StringP("token", "k", "", "authentication token used to connect to the site")
 }
 
 func init() {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -31,10 +31,10 @@ func TestDownload(t *testing.T) {
 	cmdTest.Setup(t)
 	defer cmdTest.Teardown(t)
 
-	mockServer := makeMockServer()
-	defer mockServer.Close()
+	ts := fakeDownloadServer()
+	defer ts.Close()
 
-	err := writeFakeUserConfigSettings(cmdTest.TmpDir, mockServer.URL)
+	err := writeFakeUserConfigSettings(cmdTest.TmpDir, ts.URL)
 	assert.NoError(t, err)
 
 	testCases := []struct {
@@ -111,7 +111,7 @@ func writeFakeUserConfigSettings(tmpDirPath, serverURL string) error {
 	return userCfg.Write()
 }
 
-func makeMockServer() *httptest.Server {
+func fakeDownloadServer() *httptest.Server {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -108,6 +108,7 @@ func writeFakeUserConfigSettings(tmpDirPath, serverURL string) error {
 	userCfg := config.NewEmptyUserConfig()
 	userCfg.Workspace = tmpDirPath
 	userCfg.APIBaseURL = serverURL
+	userCfg.Token = "abc123"
 	return userCfg.Write()
 }
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -63,22 +63,7 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 
 	if usrCfg.GetString("token") == "" {
 		tokenURL := config.InferSiteURL(usrCfg.GetString("apibaseurl")) + "/my/settings"
-		msg := `
-
-    Welcome to Exercism!
-
-    To get started, you need to configure the the tool with your API token.
-    Find your token at
-
-        %s
-
-    Then run the configure command:
-
-
-        %s configure --token=YOUR_TOKEN
-
-    `
-		return fmt.Errorf(msg, tokenURL, BinaryName)
+		return fmt.Errorf(msgWelcomePleaseConfigure, tokenURL, BinaryName)
 	}
 
 	if usrCfg.GetString("workspace") == "" {


### PR DESCRIPTION
We need to know who you are in order to download the correct exercise with all the requisite
metadata.

Originally the download command allowed you to pass a token on the fly, during download.
That added a lot of complexity. This changes it so that we instead bail with a helpful error message
that explains how to configure the client.

The error message is the same as the one we are using for the submit command. I moved the error message to a constant. I'm not convinced this is the right choice, but it is one which will be cheap to back out of if we decide to.

My goal for today is to do the same sort of simplification/cleanup in download as I recently did in submit. I'm going to merge this to provide a basis for the next changes, but as with all of the changes in the last couple of weeks, feedback, thoughts, and ideas are very welcome.

Closes #544