### PR TITLE
Update minimum supported Go version to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.8
-  - 1.9
+  - "1.9"
+  - "1.10.x"
   - tip
 
 install:
@@ -12,4 +12,4 @@ install:
   - dep ensure
 
 script:
-  - go test $(go list ./... | grep -v /vendor/)
+  - go test -cover ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Exercism would be impossible without people like you being willing to spend time
 
 ## Dependencies
 
-You'll need Go version 1.8 or higher. Follow the directions on http://golang.org/doc/install
+You'll need Go version 1.9 or higher. Follow the directions on http://golang.org/doc/install
 
 You will also need `dep`, the Go dependency management tool. Follow the directions on https://golang.github.io/dep/docs/installation.html
 
@@ -19,7 +19,7 @@ If you don't care how and why and just want something that works, follow these s
 
 1. [fork this repo on the GitHub webpage][fork]
 1. `go get github.com/exercism/cli/exercism`
-1. `cd $GOPATH/src/github.com/exercism/cli` (or `cd %GOPATH%/src/github.com/exercism/cli` on Windows)
+1. `cd $GOPATH/src/github.com/exercism/cli` (or `cd %GOPATH%\src\github.com\exercism\cli` on Windows)
 1. `git remote rename origin upstream`
 1. `git remote add origin git@github.com:<your-github-username>/cli.git`
 1. `git checkout -b development`
@@ -35,19 +35,11 @@ If you care about the details, check out the blog post [Contributing to Open Sou
 
 ## Running the Tests
 
-To run the tests locally on Linux or MacOS, use
+To run the tests locally
 
 ```
-go test $(go list ./... | grep -v vendor)
+go test ./...
 ```
-
-On Windows, the command is more painful (sorry!):
-
-```
-for /f "" %G in ('go list ./... ^| find /i /v "/vendor/"') do @go test %G
-```
-
-As of Go 1.9 this is simplified to `go test ./...`.
 
 ## Manual Testing against Exercism
 
@@ -66,7 +58,7 @@ On Windows:
 
 - `cd /d %GOPATH%\src\github.com\exercism\cli`
 - `go build -o testercism.exe exercism\main.go`
-- `testercism.exe —help`
+- `testercism.exe —h`
 
 ### Building for All Platforms
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ install:
   - c:\gopath\bin\dep.exe ensure
 
 build_script:
-  - for /f "" %%G in ('go list github.com/exercism/cli/... ^| find /i /v "/vendor/"') do ( go test %%G & IF ERRORLEVEL == 1 EXIT 1)
+  - go test -cover ./...


### PR DESCRIPTION
This change drops support for Go1.8 and sets the minimum to Go1.9.
By making this change we are able to use the same testing steps on *nix and Windows. 

Travis and Appveyor build scripts have been updated to reflect the said testing step. I also included the `-cover` flag to `go test` so that we have a better idea which features need some testing :heart: 