### PR TITLE
Fix problem with downloading another person's solution using the --uuid flag

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -132,20 +132,16 @@ func runDownload(cfg config.Configuration, flags *pflag.FlagSet, args []string) 
 		IsRequester: payload.Solution.User.IsRequester,
 	}
 
-	dir := filepath.Join(usrCfg.GetString("workspace"), solution.Track)
-	os.MkdirAll(dir, os.FileMode(0755))
+	dir := usrCfg.GetString("workspace")
+	if !solution.IsRequester {
+		dir = filepath.Join(dir, "users", solution.Handle)
+	}
+	dir = filepath.Join(dir, solution.Track)
 
-	var ws workspace.Workspace
-	if solution.IsRequester {
-		ws, err = workspace.New(dir)
-		if err != nil {
-			return err
-		}
-	} else {
-		ws, err = workspace.New(filepath.Join(usrCfg.GetString("workspace"), "users", solution.Handle, solution.Track))
-		if err != nil {
-			return err
-		}
+	os.MkdirAll(dir, os.FileMode(0755))
+	ws, err := workspace.New(dir)
+	if err != nil {
+		return err
 	}
 
 	dir, err = ws.SolutionPath(solution.Exercise, solution.ID)

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -43,7 +43,7 @@ func TestDownloadWithoutFlags(t *testing.T) {
 	}
 }
 
-func TestDownload(t *testing.T) {
+func TestDownloadTHISONE(t *testing.T) {
 	oldOut := Out
 	oldErr := Err
 	Out = ioutil.Discard
@@ -60,6 +60,7 @@ func TestDownload(t *testing.T) {
 	}{
 		{requestorSelf, "", "exercise", "bogus-exercise"},
 		{requestorSelf, "", "uuid", "bogus-id"},
+		{requestorOther, filepath.Join("users", "alice"), "uuid", "bogus-id"},
 	}
 
 	for _, tc := range testCases {
@@ -84,7 +85,7 @@ func TestDownload(t *testing.T) {
 		err = runDownload(cfg, flags, []string{})
 		assert.NoError(t, err)
 
-		assertDownloadedCorrectFiles(t, filepath.Join(tmpDir, tc.expectedDir))
+		assertDownloadedCorrectFiles(t, filepath.Join(tmpDir, tc.expectedDir), tc.requestor)
 	}
 }
 
@@ -118,7 +119,8 @@ func fakeDownloadServer(requestor string) *httptest.Server {
 	return server
 }
 
-func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
+func assertDownloadedCorrectFiles(t *testing.T, targetDir, requestor string) {
+	metadata := `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":%s,"auto_approve":false}`
 	expectedFiles := []struct {
 		desc     string
 		path     string
@@ -137,7 +139,7 @@ func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 		{
 			desc:     "the solution metadata file",
 			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", ".solution.json"),
-			contents: `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":true,"auto_approve":false}`,
+			contents: fmt.Sprintf(metadata, requestor),
 		},
 	}
 


### PR DESCRIPTION
We were failing to do a `mkdir -p` before trying to write files when downloading someone else's solution.

Closes #621 