### PR TITLE
Add more guards to the download command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,3 +14,15 @@ const msgWelcomePleaseConfigure = `
         %s configure --token=YOUR_TOKEN
 
 `
+
+// Running configure without any arguments will attempt to
+// set the default workspace. If the default workspace directory
+// risks clobbering an existing directory, it will print an
+// error message that explains how to proceed.
+const msgRerunConfigure = `
+
+    Please re-run the configure command to define where
+    to download the exercises.
+
+        %s configure
+`

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -52,6 +52,9 @@ func runDownload(cfg config.Configuration, flags *pflag.FlagSet, args []string) 
 		tokenURL := config.InferSiteURL(usrCfg.GetString("apibaseurl")) + "/my/settings"
 		return fmt.Errorf(msgWelcomePleaseConfigure, tokenURL, BinaryName)
 	}
+	if usrCfg.GetString("workspace") == "" {
+		return fmt.Errorf(msgRerunConfigure, BinaryName)
+	}
 
 	uuid, err := flags.GetString("uuid")
 	if err != nil {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -52,7 +52,7 @@ func runDownload(cfg config.Configuration, flags *pflag.FlagSet, args []string) 
 		tokenURL := config.InferSiteURL(usrCfg.GetString("apibaseurl")) + "/my/settings"
 		return fmt.Errorf(msgWelcomePleaseConfigure, tokenURL, BinaryName)
 	}
-	if usrCfg.GetString("workspace") == "" {
+	if usrCfg.GetString("workspace") == "" || usrCfg.GetString("apibaseurl") == "" {
 		return fmt.Errorf(msgRerunConfigure, BinaryName)
 	}
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -39,10 +39,25 @@ func TestDownloadWithoutWorkspace(t *testing.T) {
 	}
 }
 
+func TestDownloadWithoutBaseURL(t *testing.T) {
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", "/home/whatever")
+	cfg := config.Configuration{
+		UserViperConfig: v,
+	}
+
+	err := runDownload(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
+	if assert.Error(t, err) {
+		assert.Regexp(t, "re-run the configure", err.Error())
+	}
+}
+
 func TestDownloadWithoutFlags(t *testing.T) {
 	v := viper.New()
 	v.Set("token", "abc123")
 	v.Set("workspace", "/home/username")
+	v.Set("apibaseurl", "http://example.com")
 
 	cfg := config.Configuration{
 		UserViperConfig: v,

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -26,9 +26,23 @@ func TestDownloadWithoutToken(t *testing.T) {
 	}
 }
 
+func TestDownloadWithoutWorkspace(t *testing.T) {
+	v := viper.New()
+	v.Set("token", "abc123")
+	cfg := config.Configuration{
+		UserViperConfig: v,
+	}
+
+	err := runDownload(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
+	if assert.Error(t, err) {
+		assert.Regexp(t, "re-run the configure", err.Error())
+	}
+}
+
 func TestDownloadWithoutFlags(t *testing.T) {
 	v := viper.New()
 	v.Set("token", "abc123")
+	v.Set("workspace", "/home/username")
 
 	cfg := config.Configuration{
 		UserViperConfig: v,

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -58,18 +58,7 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	}
 
 	if usrCfg.GetString("workspace") == "" {
-		// Running configure without any arguments will attempt to
-		// set the default workspace. If the default workspace directory
-		// risks clobbering an existing directory, it will print an
-		// error message that explains how to proceed.
-		msg := `
-
-    Please re-run the configure command to define where
-    to download the exercises.
-
-        %s configure
-		`
-		return fmt.Errorf(msg, BinaryName)
+		return fmt.Errorf(msgRerunConfigure, BinaryName)
 	}
 
 	for i, arg := range args {


### PR DESCRIPTION
This will give better error messages when downloading a solution without having configured the CLI for the new site.

Merging so I can cut a release.