### PR TITLE
Add proper error message when solution metadata is not found

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,3 +26,10 @@ const msgRerunConfigure = `
 
         %s configure
 `
+
+const msgMissingMetadata = `
+
+    The exercise you are submitting doesn't have the necessary metadata.
+    Please see https://exercism.io/cli-v1-to-v2 for instructions on how to fix it.
+
+`

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -109,6 +109,9 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	for _, arg := range args {
 		dir, err := ws.SolutionDir(arg)
 		if err != nil {
+			if workspace.IsMissingMetadata(err) {
+				return errors.New(msgMissingMetadata)
+			}
 			return err
 		}
 		if exerciseDir != "" && dir != exerciseDir {
@@ -131,16 +134,6 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	sx, err := workspace.NewSolutions(dirs)
 	if err != nil {
 		return err
-	}
-	if len(sx) == 0 {
-		// TODO: add test
-		msg := `
-
-    The exercise you are submitting doesn't have the necessary metadata.
-    Please see https://exercism.io/cli-v1-to-v2 for instructions on how to fix it.
-
-		`
-		return errors.New(msg)
 	}
 	if len(sx) > 1 {
 		msg := `

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -68,6 +68,32 @@ func TestSubmitNonExistentFile(t *testing.T) {
 	assert.Regexp(t, "cannot be found", err.Error())
 }
 
+func TestSubmitExerciseWithoutSolutionMetadataFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "no-metadata-file")
+	assert.NoError(t, err)
+
+	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
+	os.MkdirAll(dir, os.FileMode(0755))
+
+	file := filepath.Join(dir, "file.txt")
+	err = ioutil.WriteFile(file, []byte("This is a file."), os.FileMode(0755))
+	assert.NoError(t, err)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+
+	cfg := config.Configuration{
+		Persister:       config.InMemoryPersister{},
+		Dir:             tmpDir,
+		UserViperConfig: v,
+	}
+
+	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
+	assert.Error(t, err)
+	assert.Regexp(t, "doesn't have the necessary metadata", err.Error())
+}
+
 func TestSubmitFilesAndDir(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
 	assert.NoError(t, err)

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+var errMissingMetadata = errors.New("no solution metadata file found")
+
+// IsMissingMetadata verifies the type of error.
+func IsMissingMetadata(err error) bool {
+	return err == errMissingMetadata
+}
+
 var rgxSerialSuffix = regexp.MustCompile(`-\d*$`)
 
 // Workspace represents a user's Exercism workspace.
@@ -186,7 +193,7 @@ func (ws Workspace) SolutionDir(s string) (string, error) {
 	path := s
 	for {
 		if path == ws.Dir {
-			return "", errors.New("couldn't find it")
+			return "", errMissingMetadata
 		}
 		if _, err := os.Lstat(path); os.IsNotExist(err) {
 			return "", err


### PR DESCRIPTION
This provides a better error message than `couldn't find it` when trying to submit a solution that doesn't have the requisite v2 metadata.

```
Error: 

    The exercise you are submitting doesn't have the necessary metadata.
    Please see https://exercism.io/cli-v1-to-v2 for instructions on how to fix it.

```


Closes #634

FYI: I'm going to merge this and cut a release... and then take the rest of the day off.