### PR TITLE
Fix issue with upgrading on Windows

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -164,6 +164,10 @@ func extractBinary(source *bytes.Reader, os string) (binary io.ReadCloser, err e
 		}
 
 		for _, f := range zr.File {
+			info := f.FileInfo()
+			if info.IsDir() || !strings.HasSuffix(f.Name, ".exe") {
+				continue
+			}
 			return f.Open()
 		}
 	} else {


### PR DESCRIPTION
This changes ensures that the upgrade process does not try to replace
the exercism binary with a non executable file. There is probably a more
extensive check we can do to ensure we have the correct file. I did not
choose to use the full name as Configlet is also using the cli pkg for
upgrading its binary.

closes #645