### PR TITLE
Fix the encode problem

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	netURL "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,7 +172,15 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 
 	for _, file := range payload.Solution.Files {
-		url := fmt.Sprintf("%s%s", payload.Solution.FileDownloadBaseURL, file)
+		unparsedUrl := fmt.Sprintf("%s%s", payload.Solution.FileDownloadBaseURL, file)
+		parsedUrl, err := netURL.ParseRequestURI(unparsedUrl)
+
+		if err != nil {
+			return err
+		}
+
+		url := parsedUrl.String()
+
 		req, err := client.NewRequest("GET", url, nil)
 		if err != nil {
 			return err

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -162,8 +162,12 @@ func fakeDownloadServer(requestor, teamSlug string) *httptest.Server {
 		fmt.Fprint(w, "this is file 1")
 	})
 
-	mux.HandleFunc("/subdir/file-2#.txt", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/subdir/file-2.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "this is file 2")
+	})
+
+	mux.HandleFunc("/special-char-filename#.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "this is a special file")
 	})
 
 	mux.HandleFunc("/file-3.txt", func(w http.ResponseWriter, r *http.Request) {
@@ -199,8 +203,13 @@ func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 		},
 		{
 			desc:     "a file in a subdirectory",
-			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "subdir", "file-2#.txt"),
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "subdir", "file-2.txt"),
 			contents: "this is file 2",
+		},
+		{
+			desc:     "a file that requires URL encoding",
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "special-char-filename#.txt"),
+			contents: "this is a special file",
 		},
 	}
 
@@ -238,7 +247,8 @@ const payloadTemplate = `
 		"file_download_base_url": "%s",
 		"files": [
 			"/file-1.txt",
-			"/subdir/file-2#.txt",
+			"/subdir/file-2.txt",
+			"/special-char-filename#.txt",
 			"/file-3.txt"
 		],
 		"iteration": {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -162,7 +162,7 @@ func fakeDownloadServer(requestor, teamSlug string) *httptest.Server {
 		fmt.Fprint(w, "this is file 1")
 	})
 
-	mux.HandleFunc("/subdir/file-2.txt", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/subdir/file-2#.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "this is file 2")
 	})
 
@@ -199,7 +199,7 @@ func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 		},
 		{
 			desc:     "a file in a subdirectory",
-			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "subdir", "file-2.txt"),
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "subdir", "file-2#.txt"),
 			contents: "this is file 2",
 		},
 	}

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -238,7 +238,7 @@ const payloadTemplate = `
 		"file_download_base_url": "%s",
 		"files": [
 			"/file-1.txt",
-			"/subdir/file-2.txt",
+			"/subdir/file-2#.txt",
 			"/file-3.txt"
 		],
 		"iteration": {


### PR DESCRIPTION
Now that the file are download by a get request, if some character do not be encoded will try to get the wrong one. 
Follow the evidence

**https://api.exercism.io/v1/solutions/latest?exercise_id=hello-world&track_id=plsql**
_Response:_
```
{
    "solution": {
        "id": "7f887ffb489c40c8ae1c1481eb2e1165",
        "url": "https://exercism.io/my/solutions/7f887ffb489c40c8ae1c1481eb2e1165",
        "team": null,
        "user": {
            "handle": "williandrade",
            "is_requester": true
        },
        "exercise": {
            "id": "hello-world",
            "instructions_url": "https://exercism.io/my/solutions/7f887ffb489c40c8ae1c1481eb2e1165",
            "auto_approve": true,
            "track": {
                "id": "plsql",
                "language": "PL/SQL"
            }
        },
        "file_download_base_url": "https://api.exercism.io/v1/solutions/7f887ffb489c40c8ae1c1481eb2e1165/files/",
        "files": [
            "README.md",
            "hello_world#.plsql",
            "ut_hello_world#.plsql"
        ],
        "iteration": null
    }
}
```

_Response when do the GET request_
```
========================= BEGIN DumpResponse =========================
HTTP/1.1 404 Not Found
Transfer-Encoding: chunked
Cache-Control: no-cache
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Tue, 17 Jul 2018 14:58:29 GMT
Referrer-Policy: strict-origin-when-cross-origin
Server: nginx/1.10.3 (Ubuntu)
Set-Cookie: site_context=normal; domain=.exercism.io; path=/
Set-Cookie: _exercism_session=MTjAmlcMmkeVLWfioqW5PvGvqFSypvhLk3Kb1zPESLkCbpep5XOD68gVDnUS1wX9DwcSe7nSi%2ByBqhsJBYOGccYUl4LC%2BpCLcDCFHRb%2BGeO22NleSGhHSk9avFom%2BJIGOBtyXv0o9FGmT5fKRtNdV61LDoT65jI0jz%2BqmqmPFhSHusAhy1XPYlxYZliLi6kKhjdPf3wVKkleBHfyI6A5sT7jBQf68BIOzqgeDRxcRjIEYba3CWurtxiTUwpIyV%2FNfw9kS63qvvTo--x0xwl%2BdZYyy1tYlD--KCuaNutWr0d%2Fl%2F9bSp5%2FVQ%3D%3D; domain=.exercism.io; path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Request-Id: 4783f37e-c921-4203-a92f-e56b2df8fba1
X-Runtime: 0.088371
X-Xss-Protection: 1; mode=block


========================= END DumpResponse =========================
```
