### PR TITLE
Add --team flag to download command

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -114,7 +114,7 @@ func TestDownload(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 		assert.NoError(t, err)
 
-		ts := fakeDownloadServer(strconv.FormatBool(tc.requester))
+		ts := fakeDownloadServer(strconv.FormatBool(tc.requester), tc.flags["team"])
 		defer ts.Close()
 
 		v := viper.New()
@@ -149,7 +149,7 @@ func TestDownload(t *testing.T) {
 	}
 }
 
-func fakeDownloadServer(requestor string) *httptest.Server {
+func fakeDownloadServer(requestor, teamSlug string) *httptest.Server {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 
@@ -165,11 +165,16 @@ func fakeDownloadServer(requestor string) *httptest.Server {
 		fmt.Fprint(w, "")
 	})
 
-	payloadBody := fmt.Sprintf(payloadTemplate, requestor, server.URL+"/")
 	mux.HandleFunc("/solutions/latest", func(w http.ResponseWriter, r *http.Request) {
+		team := "null"
+		if teamSlug := r.FormValue("team_id"); teamSlug != "" {
+			team = fmt.Sprintf(`{"name": "Bogus Team", "slug": "%s"}`, teamSlug)
+		}
+		payloadBody := fmt.Sprintf(payloadTemplate, requestor, team, server.URL+"/")
 		fmt.Fprint(w, payloadBody)
 	})
 	mux.HandleFunc("/solutions/bogus-id", func(w http.ResponseWriter, r *http.Request) {
+		payloadBody := fmt.Sprintf(payloadTemplate, requestor, "null", server.URL+"/")
 		fmt.Fprint(w, payloadBody)
 	})
 
@@ -215,6 +220,7 @@ const payloadTemplate = `
 			"handle": "alice",
 			"is_requester": %s
 		},
+		"team": %s,
 		"exercise": {
 			"id": "bogus-exercise",
 			"instructions_url": "http://example.com/bogus-exercise",
@@ -226,9 +232,9 @@ const payloadTemplate = `
 		},
 		"file_download_base_url": "%s",
 		"files": [
-		"/file-1.txt",
-		"/subdir/file-2.txt",
-		"/file-3.txt"
+			"/file-1.txt",
+			"/subdir/file-2.txt",
+			"/file-3.txt"
 		],
 		"iteration": {
 			"submitted_at": "2017-08-21t10:11:12.130z"

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -107,6 +107,11 @@ func TestDownload(t *testing.T) {
 			expectedDir: filepath.Join("users", "alice"),
 			flags:       map[string]string{"uuid": "bogus-id"},
 		},
+		{
+			requester:   true,
+			expectedDir: filepath.Join("teams", "bogus-team"),
+			flags:       map[string]string{"exercise": "bogus-exercise", "track": "bogus-track", "team": "bogus-team"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/workspace/solution.go
+++ b/workspace/solution.go
@@ -19,6 +19,7 @@ type Solution struct {
 	Track       string     `json:"track"`
 	Exercise    string     `json:"exercise"`
 	ID          string     `json:"id"`
+	Team        string     `json:"team,omitempty"`
 	URL         string     `json:"url"`
 	Handle      string     `json:"handle"`
 	IsRequester bool       `json:"is_requester"`


### PR DESCRIPTION
We're working on implementing teams, which is pretty different from how it worked on the old site. In short, teams are a whole separate thing. If you are working on `bob` in Python on the main site, and you're a member of a team, then your `bob` does not automatically end up in the team pool of solutions. You need to explicitly submit it with a `--team` flag (not yet implemented in the CLI). Likewise, to work on an exercise for a team, you need to download it so that you get the correct metadata, then you can copy over your solution from your main track.

Closes #546 