### PR TITLE
Delete unnecessary flags in submit command

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -255,16 +255,6 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	return nil
 }
 
-func initSubmitCmd() {
-	setupSubmitFlags(submitCmd.Flags())
-}
-
-func setupSubmitFlags(flags *pflag.FlagSet) {
-	flags.StringP("track", "t", "", "the track ID")
-	flags.StringP("exercise", "e", "", "the exercise ID")
-	flags.StringSliceP("files", "f", make([]string, 0), "files to submit")
-}
-
 func init() {
 	RootCmd.AddCommand(submitCmd)
 }


### PR DESCRIPTION
Since we're operating with explicitly passed files, we detect the solution directory
by looking for the metadata file, and then use that to determine what we're submitting.

The flags were left over from a previous implementation where we were using them
to determine what the solution directory was.