### PR TITLE
Use explicit struct fields in download test

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -87,9 +87,24 @@ func TestDownload(t *testing.T) {
 		expectedDir     string
 		flag, flagValue string
 	}{
-		{requestorSelf, "", "exercise", "bogus-exercise"},
-		{requestorSelf, "", "uuid", "bogus-id"},
-		{requestorOther, filepath.Join("users", "alice"), "uuid", "bogus-id"},
+		{
+			requestor:   requestorSelf,
+			expectedDir: "",
+			flag:        "exercise",
+			flagValue:   "bogus-exercise",
+		},
+		{
+			requestor:   requestorSelf,
+			expectedDir: "",
+			flag:        "uuid",
+			flagValue:   "bogus-id",
+		},
+		{
+			requestor:   requestorOther,
+			expectedDir: filepath.Join("users", "alice"),
+			flag:        "uuid",
+			flagValue:   "bogus-id",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We're going to expand the test case to include more fields,
and this reformats it so it doesn't become impossible to read
once we do.

This is a tiny refactoring, should be quick to review.