### PR TITLE
Move assertion for solution metadata out of helper

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -134,8 +136,18 @@ func TestDownload(t *testing.T) {
 		targetDir := filepath.Join(tmpDir, tc.expectedDir)
 		assertDownloadedCorrectFiles(t, targetDir, tc.requestor)
 
-		metadata := `{"track":"bogus-track","exercise":"bogus-exercise","id":"bogus-id","url":"","handle":"alice","is_requester":%s,"auto_approve":false}`
+		metadata := `{
+			"track": "bogus-track",
+			"exercise":"bogus-exercise",
+			"id":"bogus-id",
+			"url":"",
+			"handle":"alice",
+			"is_requester":%s,
+			"auto_approve":false
+		}`
 		metadata = fmt.Sprintf(metadata, tc.requestor)
+		metadata = compact(t, metadata)
+
 		path := filepath.Join(targetDir, "bogus-track", "bogus-exercise", ".solution.json")
 		b, err := ioutil.ReadFile(path)
 		assert.NoError(t, err)
@@ -236,3 +248,10 @@ const payloadTemplate = `
 	}
 }
 `
+
+func compact(t *testing.T, s string) string {
+	buffer := new(bytes.Buffer)
+	err := json.Compact(buffer, []byte(s))
+	assert.NoError(t, err)
+	return buffer.String()
+}

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -108,6 +108,7 @@ func TestDownload(t *testing.T) {
 
 	for _, tc := range testCases {
 		tmpDir, err := ioutil.TempDir("", "download-cmd")
+		defer os.RemoveAll(tmpDir)
 		assert.NoError(t, err)
 
 		ts := fakeDownloadServer(tc.requestor)


### PR DESCRIPTION
The solution metadata varies on a test-by-test basis.
I don't like hiding that away in a helper.