### PR TITLE
Update Bash Completion

### DIFF
--- a/shell/exercism_completion.bash
+++ b/shell/exercism_completion.bash
@@ -68,4 +68,5 @@ _exercism () {
   return 0
 }
 
-complete -F _exercism exercism
+complete -o bashdefault -o default -o nospace -F _exercism exercism 2>/dev/null \
+	|| complete -o default -o nospace -F _exercism exercism


### PR DESCRIPTION
Update Bash completion script with [strategy found in Git's Bash completion library](https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L3034-L3035) which ensures that default tab completion still functions.

For example, running `exercism submit hello<TAB>` when in the Scheme track directory should list `hello-world-test.scm  hello-world.scm`.