### PR TITLE
Add debug as alias for troubleshoot

### DIFF
--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -22,7 +22,7 @@ var fullAPIKey bool
 // troubleshootCmd does a diagnostic self-check.
 var troubleshootCmd = &cobra.Command{
 	Use:     "troubleshoot",
-	Aliases: []string{"t"},
+	Aliases: []string{"t", "debug"},
 	Short:   "Troubleshoot does a diagnostic self-check.",
 	Long: `Provides output to help with troubleshooting.
 


### PR DESCRIPTION
A lot of exercise READMEs have instructions to run the 'debug'
command if you get stuck. E.g. every exercise in Python:
https://github.com/exercism/python/blob/a83f53697a1a213967838a78b86f2b358727d76f/exercises/etl/README.md#submitting-exercises

We can update these, however in the website we pin people's solution
to the HEAD SHA of the track repo at the time when they unlock the solution.
So only people who have not already unlocked an exercise with the incorrect
command would get the update.

Adding 'debug' as an alias makes this 'just work'.