### PR TITLE
[WIP] Link to community solutions after submitting

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -251,6 +251,14 @@ func runSubmit(cfg config.Configuration, flags *pflag.FlagSet, args []string) er
 	}
 	fmt.Fprintf(Err, msg, suffix)
 	fmt.Fprintf(Out, "    %s\n\n", solution.URL)
+
+	siteURL := config.InferSiteURL(usrCfg.GetString("apibaseurl"))
+	msg = `
+    View other solutions to this exercise at:
+    %s/tracks/%s/exercises/%s/solutions
+
+`
+	fmt.Fprintf(Err, msg, siteURL, solution.Track, solution.Exercise)
 	return nil
 }
 


### PR DESCRIPTION
After submitting, some people like to browse other solutions. This provides a link to the community solutions, in addition to the usual link to your own solution.

Closes https://github.com/exercism/exercism.io/issues/3868

## Do we even want this?

I am worried that we are robbing people of good learning opportunities by directing people to the community solutions before they've interacted with a mentor. One of the things that a good mentor does, is point to the underlying _reasons_ why code might end up one way or another, or _resources_ to help push people to explore.

If we point people directly to community solutions, it's a lot more likely that they will use things that they find without having the benefit of the discussion about why that thing might be appropriate or inappropriate.

Instead, if you are in normal mode, I think that it might be worth considering only pointing to community solutions after you've _completed_ the exercise.

In independent mode, we could point to community solutions immediately.