### PR TITLE
Tweak output of troubleshoot command when the CLI is unconfigured

### DIFF
--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -114,7 +114,7 @@ func (status *Status) check() (string, error) {
 	status.Version = newVersionStatus(status.cli)
 	status.System = newSystemStatus()
 	status.Configuration = newConfigurationStatus(status)
-	status.APIReachability = newAPIReachabilityStatus(status.cfg.UserViperConfig.GetString("apibaseurl"))
+	status.APIReachability = newAPIReachabilityStatus(status.cfg)
 
 	return status.compile()
 }
@@ -129,7 +129,11 @@ func (status *Status) compile() (string, error) {
 	return bb.String(), nil
 }
 
-func newAPIReachabilityStatus(baseURL string) apiReachabilityStatus {
+func newAPIReachabilityStatus(cfg config.Configuration) apiReachabilityStatus {
+	baseURL := cfg.UserViperConfig.GetString("apibaseurl")
+	if baseURL == "" {
+		baseURL = cfg.DefaultBaseURL
+	}
 	ar := apiReachabilityStatus{
 		Services: []*apiPing{
 			{Service: "GitHub", URL: "https://api.github.com"},

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -84,7 +84,7 @@ type systemStatus struct {
 type configurationStatus struct {
 	Home      string
 	Workspace string
-	File      string
+	Dir       string
 	Token     string
 	TokenURL  string
 }
@@ -185,7 +185,7 @@ func newConfigurationStatus(status *Status) configurationStatus {
 	cs := configurationStatus{
 		Home:      status.cfg.Home,
 		Workspace: workspace,
-		File:      v.ConfigFileUsed(),
+		Dir:       status.cfg.Dir,
 		Token:     token,
 		TokenURL:  config.InferSiteURL(v.GetString("apibaseurl")) + "/my/settings",
 	}
@@ -244,7 +244,7 @@ Configuration
 ----------------
 Home:      {{ .Configuration.Home }}
 Workspace: {{ .Configuration.Workspace }}
-Config:    {{ .Configuration.File }}
+Config:    {{ .Configuration.Dir }}
 API key:   {{ with .Configuration.Token }}{{ . }}{{ else }}<not configured>
 Find your API key at {{ .Configuration.TokenURL }}{{ end }}
 

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -175,10 +175,16 @@ func newSystemStatus() systemStatus {
 
 func newConfigurationStatus(status *Status) configurationStatus {
 	v := status.cfg.UserViperConfig
+
+	workspace := v.GetString("workspace")
+	if workspace == "" {
+		workspace = fmt.Sprintf("%s (default)", config.DefaultWorkspaceDir(status.cfg))
+	}
+
 	token := v.GetString("token")
 	cs := configurationStatus{
 		Home:      status.cfg.Home,
-		Workspace: v.GetString("workspace"),
+		Workspace: workspace,
 		File:      v.ConfigFileUsed(),
 		Token:     token,
 		TokenURL:  config.InferSiteURL(v.GetString("apibaseurl")) + "/my/settings",

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -181,16 +181,15 @@ func newConfigurationStatus(status *Status) configurationStatus {
 		workspace = fmt.Sprintf("%s (default)", config.DefaultWorkspaceDir(status.cfg))
 	}
 
-	token := v.GetString("token")
 	cs := configurationStatus{
 		Home:      status.cfg.Home,
 		Workspace: workspace,
 		Dir:       status.cfg.Dir,
-		Token:     token,
+		Token:     v.GetString("token"),
 		TokenURL:  config.InferSiteURL(v.GetString("apibaseurl")) + "/my/settings",
 	}
-	if status.Censor && token != "" {
-		cs.Token = redact(token)
+	if status.Censor && cs.Token != "" {
+		cs.Token = redact(cs.Token)
 	}
 	return cs
 }

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -177,7 +177,7 @@ func newConfigurationStatus(status *Status) configurationStatus {
 	v := status.cfg.UserViperConfig
 	token := v.GetString("token")
 	cs := configurationStatus{
-		Home:      v.GetString("home"),
+		Home:      status.cfg.Home,
 		Workspace: v.GetString("workspace"),
 		File:      v.ConfigFileUsed(),
 		Token:     token,

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -186,7 +186,7 @@ func newConfigurationStatus(status *Status) configurationStatus {
 		Workspace: workspace,
 		Dir:       status.cfg.Dir,
 		Token:     v.GetString("token"),
-		TokenURL:  config.InferSiteURL(v.GetString("apibaseurl")) + "/my/settings",
+		TokenURL:  config.SettingsURL(v.GetString("apibaseurl")),
 	}
 	if status.Censor && cs.Token != "" {
 		cs.Token = redact(cs.Token)


### PR DESCRIPTION
Right now the output of troubleshoot is a bit unhelpful when the CLI is unconfigured.

```
Configuration
----------------
Home:      
Workspace: 
Config:    
API key:   <not configured>
Find your API key at https://exercism.io/my/settings

API Reachability
----------------
Exercism:
    * /ping
    * [Get /ping: unsupported protocol scheme &#34;&#34;]
    * 52.222µs
```

The configuration section should be able to tell us what the home directory is, no matter what (that should not rely on configuring the CLI).

We can output what the default workspace _would_ be, as long as we clarify that it's not actually configured.

The `Config` field should show the default config directory, even if we haven't create it.

Lastly, we should use the default site URL for ping.

This PR fixes all of the above:

```
Configuration
----------------
Home:      /Users/kytrinyx
Workspace: /Users/kytrinyx/Test-On-Branch (default)
Config:    /Users/kytrinyx/.config/test-on-branch
API key:   <not configured>
Find your API key at https://exercism.io/my/settings

API Reachability
----------------
Exercism:
    * https://api.exercism.io/v1/ping
    * [connected]
    * 663.848701ms

```

It is probably easiest to review commit-by-commit.

Closes #671