### PR TITLE
Improve the assertions for the downloaded solution metadata

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -134,7 +134,7 @@ func TestDownload(t *testing.T) {
 		assert.NoError(t, err)
 
 		targetDir := filepath.Join(tmpDir, tc.expectedDir)
-		assertDownloadedCorrectFiles(t, targetDir, tc.requestor)
+		assertDownloadedCorrectFiles(t, targetDir)
 
 		metadata := `{
 			"track": "bogus-track",
@@ -182,7 +182,7 @@ func fakeDownloadServer(requestor string) *httptest.Server {
 	return server
 }
 
-func assertDownloadedCorrectFiles(t *testing.T, targetDir, requestor string) {
+func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 	expectedFiles := []struct {
 		desc     string
 		path     string


### PR DESCRIPTION
The hard-coded JSON for the metadata was annoying me. The big JSON is hard to read. We improved it a bit by writing the JSON as multiline, and then compacting it using `json.Compact()` but it still felt brittle.

This improves it further by reading the JSON into a solution struct and just checking the fields we care about.