### PR TITLE
Add missing teardown for test artifacts

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -61,6 +61,7 @@ type CommandTest struct {
 // fail the test if the creation of the temporary directory fails.
 func (test *CommandTest) Setup(t *testing.T) {
 	dir, err := ioutil.TempDir("", "command-test")
+	defer os.RemoveAll(dir)
 	assert.NoError(t, err)
 
 	test.TmpDir = dir

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -374,6 +374,7 @@ func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
 	defer ts.Close()
 
 	tmpDir, err := ioutil.TempDir("", "no-clobber")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	cfg := config.Configuration{
@@ -412,6 +413,7 @@ func TestConfigureExplicitWorkspaceWithoutClobberingNonDirectory(t *testing.T) {
 	}()
 
 	tmpDir, err := ioutil.TempDir("", "no-clobber")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	v := viper.New()

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -30,10 +30,12 @@ func TestSubmitFilesInSymlinkedPath(t *testing.T) {
 	defer ts.Close()
 
 	tmpDir, err := ioutil.TempDir("", "symlink-destination")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 	dstDir := filepath.Join(tmpDir, "workspace")
 
 	srcDir, err := ioutil.TempDir("", "symlink-source")
+	defer os.RemoveAll(srcDir)
 	assert.NoError(t, err)
 
 	err = os.Symlink(srcDir, dstDir)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -42,6 +42,7 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 
 func TestSubmitNonExistentFile(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	v := viper.New()
@@ -70,6 +71,7 @@ func TestSubmitNonExistentFile(t *testing.T) {
 
 func TestSubmitExerciseWithoutSolutionMetadataFile(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "no-metadata-file")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
@@ -96,6 +98,7 @@ func TestSubmitExerciseWithoutSolutionMetadataFile(t *testing.T) {
 
 func TestSubmitFilesAndDir(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	v := viper.New()
@@ -137,6 +140,7 @@ func TestSubmitFiles(t *testing.T) {
 	defer ts.Close()
 
 	tmpDir, err := ioutil.TempDir("", "submit-files")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
@@ -196,6 +200,7 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	defer ts.Close()
 
 	tmpDir, err := ioutil.TempDir("", "empty-file")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
@@ -236,6 +241,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	}()
 
 	tmpDir, err := ioutil.TempDir("", "just-an-empty-file")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
@@ -262,6 +268,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 
 func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "dir-1-submit")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir1 := filepath.Join(tmpDir, "bogus-track", "bogus-exercise-1")
@@ -335,6 +342,7 @@ func TestSubmitRelativePath(t *testing.T) {
 	defer ts.Close()
 
 	tmpDir, err := ioutil.TempDir("", "relative-path")
+	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -51,6 +52,7 @@ func TestIsSolutionPath(t *testing.T) {
 
 func TestResolveSolutionPath(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "resolve-solution-path")
+	defer os.RemoveAll(tmpDir)
 	ws, err := New(tmpDir)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Many tests call `ioutil.TempDir` but don't perform any teardown. This change
attempts to add the teardown in all locations where it is lacking.