### PR TITLE
Improve the API ping in configure command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -87,15 +87,18 @@ func (c *Client) TokenIsValid() (bool, error) {
 }
 
 // IsPingable calls the API /ping to determine whether the API can be reached.
-func (c *Client) IsPingable() (bool, error) {
+func (c *Client) IsPingable() error {
 	url := fmt.Sprintf("%s/ping", c.APIBaseURL)
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
-		return false, err
+		return err
 	}
 	resp, err := c.Do(req)
 	if err != nil {
-		return false, err
+		return err
 	}
-	return resp.StatusCode == http.StatusOK, nil
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API returned %s", resp.Status)
+	}
+	return nil
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -91,8 +91,7 @@ func runConfigure(configuration config.Configuration, flags *pflag.FlagSet) erro
 			return err
 		}
 
-		ok, err := client.IsPingable()
-		if !ok || err != nil {
+		if err := client.IsPingable(); err != nil {
 			return fmt.Errorf("The base API URL '%s' cannot be reached.\n\n%s", baseURL, err)
 		}
 	}


### PR DESCRIPTION
This distinguishes between an error in the HTTP request (e.g.
no service at URL), and an error returned from the API (e.g. 500 error).

Previous output in the case of an HTTP 500

```
$ ./testercism configure --api=http://localhost:3000/api/v1
Error: The base API URL 'http://localhost:3000/api/v1' cannot be reached.



```

Now:

```
$ ./testercism configure --api=http://localhost:3000/api/v1
Error: The base API URL 'http://localhost:3000/api/v1' cannot be reached.

API returned 500 Internal Server Error
```