### PR TITLE
Add reference to docs repo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 First, thank you! :tada:
 Exercism would be impossible without people like you being willing to spend time and effort making things better.
 
+## Docs
+Exercism has a [docs repo](https://github.com/exercism/docs) containing project-wide documentation.
+[glossary](https://github.com/exercism/docs/blob/master/about/glossary.md)
+[architecture](https://github.com/exercism/docs/blob/master/about/architecture.md)
+
 ## Dependencies
 
 You'll need Go version 1.9 or higher. Follow the directions on http://golang.org/doc/install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,10 @@
 First, thank you! :tada:
 Exercism would be impossible without people like you being willing to spend time and effort making things better.
 
-## Docs
-Exercism has a [docs repo](https://github.com/exercism/docs) containing project-wide documentation.
-[glossary](https://github.com/exercism/docs/blob/master/about/glossary.md)
-[architecture](https://github.com/exercism/docs/blob/master/about/architecture.md)
+## Documentation
+* [Exercism Documentation Repository](https://github.com/exercism/docs)
+* [Exercism Glossary](https://github.com/exercism/docs/blob/master/about/glossary.md)
+* [Exercism Architecture](https://github.com/exercism/docs/blob/master/about/architecture.md)
 
 ## Dependencies
 


### PR DESCRIPTION
I was looking for documentation of terminology and found https://github.com/exercism/docs/blob/master/about/glossary.md.

I think this is a useful reference worth pointing contributors to.