### PR TITLE
Omit the leading slash on the relative path of exercise files

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -170,6 +170,10 @@ func fakeDownloadServer(requestor, teamSlug string) *httptest.Server {
 		fmt.Fprint(w, "this is a special file")
 	})
 
+	mux.HandleFunc("/with-leading-slash.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "this has a slash")
+	})
+
 	mux.HandleFunc("/file-3.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "")
 	})
@@ -211,6 +215,11 @@ func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "special-char-filename#.txt"),
 			contents: "this is a special file",
 		},
+		{
+			desc:     "a file that has a leading slash",
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "with-leading-slash.txt"),
+			contents: "this has a slash",
+		},
 	}
 
 	for _, file := range expectedFiles {
@@ -246,10 +255,11 @@ const payloadTemplate = `
 		},
 		"file_download_base_url": "%s",
 		"files": [
-			"/file-1.txt",
-			"/subdir/file-2.txt",
-			"/special-char-filename#.txt",
-			"/file-3.txt"
+			"file-1.txt",
+			"subdir/file-2.txt",
+			"special-char-filename#.txt",
+			"/with-leading-slash.txt",
+			"file-3.txt"
 		],
 		"iteration": {
 			"submitted_at": "2017-08-21t10:11:12.130z"

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -185,7 +185,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 
 		dirname := fmt.Sprintf("%s%s%s", string(os.PathSeparator), solution.Exercise, string(os.PathSeparator))
 		pieces := strings.Split(path, dirname)
-		filename := fmt.Sprintf("%s%s", string(os.PathSeparator), pieces[len(pieces)-1])
+		filename := pieces[len(pieces)-1]
 
 		part, err := writer.CreateFormFile("files[]", filename)
 		if err != nil {

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -64,5 +64,5 @@ func TestSubmitFilesInSymlinkedPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(submittedFiles))
-	assert.Equal(t, "This is a file.", submittedFiles["/file.txt"])
+	assert.Equal(t, "This is a file.", submittedFiles["file.txt"])
 }

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -179,9 +179,9 @@ func TestSubmitFiles(t *testing.T) {
 
 	assert.Equal(t, 3, len(submittedFiles))
 
-	assert.Equal(t, "This is file 1.", submittedFiles[string(os.PathSeparator)+"file-1.txt"])
-	assert.Equal(t, "This is file 2.", submittedFiles[string(os.PathSeparator)+filepath.Join("subdir", "file-2.txt")])
-	assert.Equal(t, "This is the readme.", submittedFiles[string(os.PathSeparator)+"README.md"])
+	assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
+	assert.Equal(t, "This is file 2.", submittedFiles[filepath.Join("subdir", "file-2.txt")])
+	assert.Equal(t, "This is the readme.", submittedFiles["README.md"])
 }
 
 func TestSubmitWithEmptyFile(t *testing.T) {
@@ -227,7 +227,7 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(submittedFiles))
-	assert.Equal(t, "This is file 2.", submittedFiles[string(os.PathSeparator)+"file-2.txt"])
+	assert.Equal(t, "This is file 2.", submittedFiles["file-2.txt"])
 }
 
 func TestSubmitFilesForTeamExercise(t *testing.T) {
@@ -277,8 +277,8 @@ func TestSubmitFilesForTeamExercise(t *testing.T) {
 
 	assert.Equal(t, 2, len(submittedFiles))
 
-	assert.Equal(t, "This is file 1.", submittedFiles[string(os.PathSeparator)+"file-1.txt"])
-	assert.Equal(t, "This is file 2.", submittedFiles[string(os.PathSeparator)+filepath.Join("subdir", "file-2.txt")])
+	assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
+	assert.Equal(t, "This is file 2.", submittedFiles[filepath.Join("subdir", "file-2.txt")])
 }
 
 func TestSubmitOnlyEmptyFile(t *testing.T) {
@@ -420,7 +420,7 @@ func TestSubmitRelativePath(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(submittedFiles))
-	assert.Equal(t, "This is a file.", submittedFiles[string(os.PathSeparator)+"file.txt"])
+	assert.Equal(t, "This is a file.", submittedFiles["file.txt"])
 }
 
 func writeFakeSolution(t *testing.T, dir, trackID, exerciseSlug string) {


### PR DESCRIPTION
This updates the download and submit commands to no longer use a leading slash on the relative path for exercise files.

I added an extra file in the download test that has a leading slash, to show that we still handle the leading slash where present.