### PR TITLE
Distinguish between path and filepath

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -162,7 +162,11 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 			fmt.Fprintf(Err, msg, file)
 			continue
 		}
-		exercise.Documents = append(exercise.Documents, workspace.NewDocument(exercise.Filepath(), file))
+		doc, err := workspace.NewDocument(exercise.Filepath(), file)
+		if err != nil {
+			return err
+		}
+		exercise.Documents = append(exercise.Documents, doc)
 	}
 
 	if len(exercise.Documents) == 0 {
@@ -178,7 +182,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	writer := multipart.NewWriter(body)
 
 	for _, doc := range exercise.Documents {
-		file, err := os.Open(doc.Filepath)
+		file, err := os.Open(doc.Filepath())
 		if err != nil {
 			return err
 		}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -162,7 +162,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 			fmt.Fprintf(Err, msg, file)
 			continue
 		}
-		exercise.Documents = append(exercise.Documents, exercise.NewDocument(file))
+		exercise.Documents = append(exercise.Documents, workspace.NewDocument(exercise.Filepath(), file))
 	}
 
 	if len(exercise.Documents) == 0 {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -8,7 +8,6 @@ import (
 	"mime/multipart"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/exercism/cli/api"
 	"github.com/exercism/cli/config"
@@ -125,6 +124,8 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		exerciseDir = dir
 	}
 
+	exercise := workspace.NewExerciseFromDir(exerciseDir)
+
 	solution, err := workspace.NewSolution(exerciseDir)
 	if err != nil {
 		return err
@@ -143,7 +144,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return fmt.Errorf(msg, BinaryName, solution.Exercise, solution.Track)
 	}
 
-	paths := make([]string, 0, len(args))
+	exercise.Documents = make([]workspace.Document, 0, len(args))
 	for _, file := range args {
 		// Don't submit empty files
 		info, err := os.Stat(file)
@@ -161,10 +162,10 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 			fmt.Fprintf(Err, msg, file)
 			continue
 		}
-		paths = append(paths, file)
+		exercise.Documents = append(exercise.Documents, exercise.NewDocument(file))
 	}
 
-	if len(paths) == 0 {
+	if len(exercise.Documents) == 0 {
 		msg := `
 
     No files found to submit.
@@ -176,18 +177,14 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	for _, path := range paths {
-		file, err := os.Open(path)
+	for _, doc := range exercise.Documents {
+		file, err := os.Open(doc.Filepath)
 		if err != nil {
 			return err
 		}
 		defer file.Close()
 
-		dirname := fmt.Sprintf("%s%s%s", string(os.PathSeparator), solution.Exercise, string(os.PathSeparator))
-		pieces := strings.Split(path, dirname)
-		filename := pieces[len(pieces)-1]
-
-		part, err := writer.CreateFormFile("files[]", filename)
+		part, err := writer.CreateFormFile("files[]", doc.Path())
 		if err != nil {
 			return err
 		}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -180,7 +180,7 @@ func TestSubmitFiles(t *testing.T) {
 	assert.Equal(t, 3, len(submittedFiles))
 
 	assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
-	assert.Equal(t, "This is file 2.", submittedFiles[filepath.Join("subdir", "file-2.txt")])
+	assert.Equal(t, "This is file 2.", submittedFiles["subdir/file-2.txt"])
 	assert.Equal(t, "This is the readme.", submittedFiles["README.md"])
 }
 
@@ -278,7 +278,7 @@ func TestSubmitFilesForTeamExercise(t *testing.T) {
 	assert.Equal(t, 2, len(submittedFiles))
 
 	assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
-	assert.Equal(t, "This is file 2.", submittedFiles[filepath.Join("subdir", "file-2.txt")])
+	assert.Equal(t, "This is file 2.", submittedFiles["subdir/file-2.txt"])
 }
 
 func TestSubmitOnlyEmptyFile(t *testing.T) {

--- a/workspace/document.go
+++ b/workspace/document.go
@@ -8,9 +8,9 @@ type Document struct {
 	RelativePath string
 }
 
-// NewDocument creates a document from a relative filepath.
+// NewDocument creates a document from the filepath.
 // The root is typically the root of the exercise, and
-// path is the relative path to the file within the root directory.
+// path is the absolute path to the file.
 func NewDocument(root, path string) (Document, error) {
 	path, err := filepath.Rel(root, path)
 	if err != nil {

--- a/workspace/document.go
+++ b/workspace/document.go
@@ -1,31 +1,34 @@
 package workspace
 
-import (
-	"os"
-	"path/filepath"
-	"strings"
-)
+import "path/filepath"
 
 // Document is a file in a directory.
 type Document struct {
-	Root     string
-	Filepath string
+	Root         string
+	RelativePath string
 }
 
-// NewDocument creates a document from a filepath.
+// NewDocument creates a document from a relative filepath.
 // The root is typically the root of the exercise, and
 // path is the relative path to the file within the root directory.
-func NewDocument(root, path string) Document {
-	return Document{
-		Root:     root,
-		Filepath: path,
+func NewDocument(root, path string) (Document, error) {
+	path, err := filepath.Rel(root, path)
+	if err != nil {
+		return Document{}, err
 	}
+	return Document{
+		Root:         root,
+		RelativePath: path,
+	}, nil
+}
+
+// Filepath is the absolute path to the document on the filesystem.
+func (doc Document) Filepath() string {
+	return filepath.Join(doc.Root, doc.RelativePath)
 }
 
 // Path is the normalized path.
 // It uses forward slashes regardless of the operating system.
 func (doc Document) Path() string {
-	path := strings.Replace(doc.Filepath, doc.Root, "", 1)
-	path = strings.TrimLeft(path, string(os.PathSeparator))
-	return filepath.ToSlash(path)
+	return filepath.ToSlash(doc.RelativePath)
 }

--- a/workspace/document.go
+++ b/workspace/document.go
@@ -13,10 +13,12 @@ type Document struct {
 }
 
 // NewDocument creates a document from a filepath.
-func NewDocument(root, file string) Document {
+// The root is typically the root of the exercise, and
+// path is the relative path to the file within the root directory.
+func NewDocument(root, path string) Document {
 	return Document{
 		Root:     root,
-		Filepath: file,
+		Filepath: path,
 	}
 }
 

--- a/workspace/document.go
+++ b/workspace/document.go
@@ -1,0 +1,29 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Document is a file in a directory.
+type Document struct {
+	Root     string
+	Filepath string
+}
+
+// NewDocument creates a document from a filepath.
+func NewDocument(root, file string) Document {
+	return Document{
+		Root:     root,
+		Filepath: file,
+	}
+}
+
+// Path is the normalized path.
+// It uses forward slashes regardless of the operating system.
+func (doc Document) Path() string {
+	path := strings.Replace(doc.Filepath, doc.Root, "", 1)
+	path = strings.TrimLeft(path, string(os.PathSeparator))
+	return filepath.ToSlash(path)
+}

--- a/workspace/document_test.go
+++ b/workspace/document_test.go
@@ -1,6 +1,8 @@
 package workspace
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -8,7 +10,13 @@ import (
 )
 
 func TestNormalizedDocumentPath(t *testing.T) {
-	root := filepath.Join("the", "root", "path", "the-track", "the-exercise")
+	root, err := ioutil.TempDir("", "docpath")
+	assert.NoError(t, err)
+	defer os.RemoveAll(root)
+
+	err = os.MkdirAll(filepath.Join(root, "subdirectory"), os.FileMode(0755))
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		filepath string
 		path     string
@@ -24,7 +32,12 @@ func TestNormalizedDocumentPath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		doc := NewDocument(root, tc.filepath)
-		assert.Equal(t, tc.path, doc.Path())
+		err = ioutil.WriteFile(tc.filepath, []byte("a file"), os.FileMode(0600))
+		assert.NoError(t, err)
+
+		doc, err := NewDocument(root, tc.filepath)
+		assert.NoError(t, err)
+
+		assert.Equal(t, doc.Path(), tc.path)
 	}
 }

--- a/workspace/document_test.go
+++ b/workspace/document_test.go
@@ -1,0 +1,30 @@
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizedDocumentPath(t *testing.T) {
+	root := filepath.Join("the", "root", "path", "the-track", "the-exercise")
+	testCases := []struct {
+		filepath string
+		path     string
+	}{
+		{
+			filepath: filepath.Join(root, "file.txt"),
+			path:     "file.txt",
+		},
+		{
+			filepath: filepath.Join(root, "subdirectory", "file.txt"),
+			path:     "subdirectory/file.txt",
+		},
+	}
+
+	for _, tc := range testCases {
+		doc := NewDocument(root, tc.filepath)
+		assert.Equal(t, tc.path, doc.Path())
+	}
+}

--- a/workspace/exercise.go
+++ b/workspace/exercise.go
@@ -8,9 +8,10 @@ import (
 
 // Exercise is an implementation of a problem in a track.
 type Exercise struct {
-	Root  string
-	Track string
-	Slug  string
+	Root      string
+	Track     string
+	Slug      string
+	Documents []Document
 }
 
 // NewExerciseFromDir constructs an exercise given the exercise directory.

--- a/workspace/exercise.go
+++ b/workspace/exercise.go
@@ -59,8 +59,3 @@ func (e Exercise) HasMetadata() (bool, error) {
 	}
 	return false, err
 }
-
-// NewDocument creates a document relative to the exercise.
-func (e Exercise) NewDocument(file string) Document {
-	return NewDocument(e.Filepath(), file)
-}

--- a/workspace/exercise.go
+++ b/workspace/exercise.go
@@ -59,3 +59,8 @@ func (e Exercise) HasMetadata() (bool, error) {
 	}
 	return false, err
 }
+
+// NewDocument creates a document relative to the exercise.
+func (e Exercise) NewDocument(file string) Document {
+	return NewDocument(e.Filepath(), file)
+}

--- a/workspace/exercise.go
+++ b/workspace/exercise.go
@@ -13,6 +13,15 @@ type Exercise struct {
 	Slug  string
 }
 
+// NewExerciseFromDir constructs an exercise given the exercise directory.
+func NewExerciseFromDir(dir string) Exercise {
+	slug := filepath.Base(dir)
+	dir = filepath.Dir(dir)
+	track := filepath.Base(dir)
+	root := filepath.Dir(dir)
+	return Exercise{Root: root, Track: track, Slug: slug}
+}
+
 // Path is the normalized relative path.
 // It always has forward slashes, regardless
 // of the operating system.

--- a/workspace/exercise_test.go
+++ b/workspace/exercise_test.go
@@ -33,3 +33,12 @@ func TestHasMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, ok)
 }
+
+func TestNewFromDir(t *testing.T) {
+	dir := filepath.Join("something", "another", "whatever", "the-track", "the-exercise")
+
+	exercise := NewExerciseFromDir(dir)
+	assert.Equal(t, filepath.Join("something", "another", "whatever"), exercise.Root)
+	assert.Equal(t, "the-track", exercise.Track)
+	assert.Equal(t, "the-exercise", exercise.Slug)
+}


### PR DESCRIPTION
Use a normalized path relative to the exercise directory and using forward slashes when submitting to the server. This is converted to a proper filepath on the file system, using `/` or `\` depending on the operating system.

This builds on top of the pull request in https://github.com/exercism/cli/pull/703 -- too look at just the difference between the two branches, compare [no-leading-slash to path-vs-filepath](https://github.com/exercism/cli/compare/no-leading-slash...path-vs-filepath?expand=1).

Closes https://github.com/exercism/cli/issues/698
Closes https://github.com/exercism/cli/issues/665