### PR TITLE
download: fix support for uuid flag

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -69,7 +69,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 
 	param := "latest"
-	if param == "" {
+	if uuid != "" {
 		param = uuid
 	}
 	url := fmt.Sprintf("%s/solutions/%s", usrCfg.GetString("apibaseurl"), param)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -64,8 +64,18 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	if err != nil {
 		return err
 	}
-	if uuid == "" && slug == "" {
+	if uuid != "" && slug != "" || uuid == slug {
 		return errors.New("need an --exercise name or a solution --uuid")
+	}
+
+	track, err := flags.GetString("track")
+	if err != nil {
+		return err
+	}
+
+	team, err := flags.GetString("team")
+	if err != nil {
+		return err
 	}
 
 	param := "latest"
@@ -80,16 +90,6 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 
 	req, err := client.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-
-	track, err := flags.GetString("track")
-	if err != nil {
-		return err
-	}
-
-	team, err := flags.GetString("team")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change fixes the issue #712 where calling download with a solution UUID errors because the command is overriding the provided UUID with the string latest. This change also adds a mutual exclusive check for the uuid and exercise flag used by the download command.