### PR TITLE
Make the timeout configurable globally

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -15,7 +15,7 @@ var (
 	UserAgent = "github.com/exercism/cli"
 
 	// TimeoutInSeconds is the timeout the default HTTP client will use.
-	TimeoutInSeconds = 10
+	TimeoutInSeconds = 60
 	// HTTPClient is the client used to make HTTP calls in the cli package.
 	HTTPClient = &http.Client{Timeout: time.Duration(TimeoutInSeconds) * time.Second}
 )

--- a/api/client.go
+++ b/api/client.go
@@ -14,8 +14,10 @@ var (
 	// It's overridden from the root command so that we can set the version.
 	UserAgent = "github.com/exercism/cli"
 
-	// HTTPClient configures a timeout to use by default.
-	HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	// TimeoutInSeconds is the timeout the default HTTP client will use.
+	TimeoutInSeconds = 10
+	// HTTPClient is the client used to make HTTP calls in the cli package.
+	HTTPClient = &http.Client{Timeout: time.Duration(TimeoutInSeconds) * time.Second}
 )
 
 // Client is an http client that is configured for Exercism.

--- a/api/client.go
+++ b/api/client.go
@@ -14,8 +14,8 @@ var (
 	// It's overridden from the root command so that we can set the version.
 	UserAgent = "github.com/exercism/cli"
 
-	// DefaultHTTPClient configures a timeout to use by default.
-	DefaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+	// HTTPClient configures a timeout to use by default.
+	HTTPClient = &http.Client{Timeout: 10 * time.Second}
 )
 
 // Client is an http client that is configured for Exercism.
@@ -29,7 +29,7 @@ type Client struct {
 // NewClient returns an Exercism API client.
 func NewClient(token, baseURL string) (*Client, error) {
 	return &Client{
-		Client:     DefaultHTTPClient,
+		Client:     HTTPClient,
 		Token:      token,
 		APIBaseURL: baseURL,
 	}, nil
@@ -38,7 +38,7 @@ func NewClient(token, baseURL string) (*Client, error) {
 // NewRequest returns an http.Request with information for the Exercism API.
 func (c *Client) NewRequest(method, url string, body io.Reader) (*http.Request, error) {
 	if c.Client == nil {
-		c.Client = DefaultHTTPClient
+		c.Client = HTTPClient
 	}
 
 	req, err := http.NewRequest(method, url, body)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -43,8 +43,10 @@ var (
 )
 
 var (
+	// TimeoutInSeconds is the timeout the default HTTP client will use.
+	TimeoutInSeconds = 10
 	// HTTPClient is the client used to make HTTP calls in the cli package.
-	HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	HTTPClient = &http.Client{Timeout: time.Duration(TimeoutInSeconds) * time.Second}
 	// ReleaseURL is the endpoint that provides information about cli releases.
 	ReleaseURL = "https://api.github.com/repos/exercism/cli/releases"
 )

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,7 +44,7 @@ var (
 
 var (
 	// TimeoutInSeconds is the timeout the default HTTP client will use.
-	TimeoutInSeconds = 10
+	TimeoutInSeconds = 60
 	// HTTPClient is the client used to make HTTP calls in the cli package.
 	HTTPClient = &http.Client{Timeout: time.Duration(TimeoutInSeconds) * time.Second}
 	// ReleaseURL is the endpoint that provides information about cli releases.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/exercism/cli/api"
+	"github.com/exercism/cli/cli"
 	"github.com/exercism/cli/config"
 	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
@@ -39,6 +40,10 @@ Download exercises and submit your solutions.`,
 		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
 			debug.Verbose = verbose
 		}
+		if timeout, _ := cmd.Flags().GetInt("timeout"); timeout > 0 {
+			cli.TimeoutInSeconds = timeout
+			api.TimeoutInSeconds = timeout
+		}
 	},
 }
 
@@ -57,4 +62,5 @@ func init() {
 	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+	RootCmd.PersistentFlags().IntP("timeout", "", 0, "override the default HTTP timeout (seconds)")
 }

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"net/http"
 	"runtime"
 	"strings"
 	"sync"
@@ -30,7 +29,7 @@ If you're running into trouble, copy and paste the output from the troubleshoot
 command into a GitHub issue so we can help figure out what's going on.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cli.HTTPClient = &http.Client{Timeout: 20 * time.Second}
+		cli.TimeoutInSeconds = 20
 		c := cli.New(Version)
 
 		cfg := config.NewConfig()

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -29,7 +29,7 @@ If you're running into trouble, copy and paste the output from the troubleshoot
 command into a GitHub issue so we can help figure out what's going on.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cli.TimeoutInSeconds = 20
+		cli.TimeoutInSeconds = cli.TimeoutInSeconds * 2
 		c := cli.New(Version)
 
 		cfg := config.NewConfig()


### PR DESCRIPTION
This tweaks the HTTP clients that we create to use a package variable for the timeout instead of hard-coding it.

Then it adds a persistent flag to the root command, which lets the 'pre-run' logic override the package variables if the flag is populated with something other than the zero value.

Closes https://github.com/exercism/cli/issues/701