### PR TITLE
Handle windows filepaths that accidentally got submitted to the server

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -199,6 +199,10 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 
 		// TODO: if there's a collision, interactively resolve (show diff, ask if overwrite).
 		// TODO: handle --force flag to overwrite without asking.
+
+		// Rewrite paths submitted with an older, buggy client where the Windows path is being treated as part of the filename.
+		file = strings.Replace(file, "\\", "/", -1)
+
 		relativePath := filepath.FromSlash(file)
 		dir := filepath.Join(solution.Dir, filepath.Dir(relativePath))
 		os.MkdirAll(dir, os.FileMode(0755))

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -170,6 +170,13 @@ func fakeDownloadServer(requestor, teamSlug string) *httptest.Server {
 		fmt.Fprint(w, "this is a special file")
 	})
 
+	mux.HandleFunc("/\\with-leading-backslash.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "with backslash in name")
+	})
+	mux.HandleFunc("/\\with\\backslashes\\in\\path.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "with backslash in path")
+	})
+
 	mux.HandleFunc("/with-leading-slash.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "this has a slash")
 	})
@@ -220,6 +227,16 @@ func assertDownloadedCorrectFiles(t *testing.T, targetDir string) {
 			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "with-leading-slash.txt"),
 			contents: "this has a slash",
 		},
+		{
+			desc:     "a file with a leading backslash",
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "with-leading-backslash.txt"),
+			contents: "with backslash in name",
+		},
+		{
+			desc:     "a file with backslashes in path",
+			path:     filepath.Join(targetDir, "bogus-track", "bogus-exercise", "with", "backslashes", "in", "path.txt"),
+			contents: "with backslash in path",
+		},
 	}
 
 	for _, file := range expectedFiles {
@@ -259,6 +276,8 @@ const payloadTemplate = `
 			"subdir/file-2.txt",
 			"special-char-filename#.txt",
 			"/with-leading-slash.txt",
+			"\\with-leading-backslash.txt",
+			"\\with\\backslashes\\in\\path.txt",
 			"file-3.txt"
 		],
 		"iteration": {


### PR DESCRIPTION
Some of the older CLIs did not submit a normalized path for the file, but rather submitted the
filepath. This means that we sometimes had forward slashes and sometimes had backslashes.

The CLI now always submits the normalized path with forward slashes.

This ensures that when we receive files submitted with a buggy client we rewrite the paths
correctly.

Closes https://github.com/exercism/exercism/issues/4260
Closes https://github.com/exercism/exercism/issues/4101
Closes https://github.com/exercism/exercism/issues/4072