### PR TITLE
Update Oh My Zsh instructions

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -27,4 +27,7 @@ the following snippet
       source ~/.config/exercism/exercism_completion.zsh
     fi
 
-**Note:** If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, move the file `exercism_completion.zsh` into `~/.oh-my-zsh/custom`.
+
+#### Oh my Zsh
+
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, move the file `exercism_completion.zsh` into `~/.oh-my-zsh/custom`.

--- a/shell/README.md
+++ b/shell/README.md
@@ -27,4 +27,4 @@ the following snippet
       source ~/.config/exercism/exercism_completion.zsh
     fi
 
-**Note:** If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside the `~/.oh-my-zsh/custom`.
+**Note:** If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, move the file `exercism_completion.zsh` into `~/.oh-my-zsh/custom`.


### PR DESCRIPTION
Hello :-)

I followed the current instructions but got confused by the `Note`. I tried placing an empty `exercism_completion.zsh` into that folder. The suggested instructions got the following to work for me on macOS 10.13.6 with [CLI version 3.0.9](https://github.com/exercism/cli/releases/v3.0.9):

![screen shot 2018-09-02 at 16 40 07](https://user-images.githubusercontent.com/9948149/44971898-93b61780-af57-11e8-8f6c-7c281dd3522f.png)

How about additionally turning that whole section into an H4 with `####`?