### PR TITLE
[WIP] Checking whether user is in workspace shouldn't be case-sensitive 🤔

### DIFF
--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,10 @@ func TestSolutionDir(t *testing.T) {
 			ok:   true,
 		},
 		{
+			path: strings.ToUpper(filepath.Join(ws.Dir, "exercise")),
+			ok:   true,
+		},
+		{
 			path: filepath.Join(ws.Dir, "exercise", "file.txt"),
 			ok:   true,
 		},
@@ -130,10 +135,13 @@ func TestSolutionDir(t *testing.T) {
 
 	for _, test := range tests {
 		dir, err := ws.SolutionDir(test.path)
+
 		if !test.ok {
 			assert.Error(t, err, test.path)
 			continue
 		}
+
+		assert.NoError(t, err)
 		assert.Equal(t, filepath.Join(ws.Dir, "exercise"), dir, test.path)
 	}
 }


### PR DESCRIPTION
Here's a problem I observed: 

```
➜  cli (workspace-case-fix) ✔ exercism workspace
/Users/andrewlouis/Exercism
```

Workspace directory was actually created with lowercase though (if this is not the expectation - possible because this was the case in an earlier version?):

```
➜  ~ ls | grep exercism
exercism
```

And so when trying to submit from my workspace, I'd repeatedly see: 

![image](https://user-images.githubusercontent.com/996681/45001677-262cda00-af9d-11e8-96e7-d5b150947b96.png)

cd-ing into `Exercism` addressed the problem, so I figured this is since no normalization is occurring before validating that the user is in the workspace. The test in the first commit verifies this. 

Please take a look, let me know what y'all think.
