### PR TITLE
Update max allowed file size error to include filename

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -163,12 +163,13 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		}
 		const maxFileSize int64 = 65535
 		if info.Size() >= maxFileSize {
-			msg :=`
+			msg := `
 
-      The submitted file is larger than the max allowed file size of %d bytes. Please reduce the size of the file and try again.
+      The submitted file '%s' is larger than the max allowed file size of %d bytes.
+      Please reduce the size of the file and try again.
 
 			`
-			return fmt.Errorf(msg, maxFileSize)
+			return fmt.Errorf(msg, file, maxFileSize)
 		}
 		if info.Size() == 0 {
 


### PR DESCRIPTION
Currently when submitting a file that is larger than the max allowed size the user receives an error indicating that a submitted file is larger than the max allowed file size, but it does not include the actual name of the file.

This is not really an issue when submitting a single file, but when a user submits two or more files the error message is a bit of a guessing game.