### PR TITLE
Add mentorship CTA to download and submit commands

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -229,6 +229,8 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 	fmt.Fprintf(Err, "\nDownloaded to\n")
 	fmt.Fprintf(Out, "%s\n", metadata.Dir)
+	fmt.Fprintf(Err, "\nExercism relies on volunteer mentors. If you would like to be a mentor, sign up at:\n")
+	fmt.Fprintf(Err, "\nhttps://exercism.io/mentor\n")
 	return nil
 }
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -257,6 +257,8 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 	fmt.Fprintf(Err, msg, suffix)
 	fmt.Fprintf(Out, "    %s\n\n", metadata.URL)
+	fmt.Fprintf(Err, "\nExercism relies on volunteer mentors. If you would like to be a mentor, sign up at:\n")
+	fmt.Fprintf(Err, "\nhttps://exercism.io/mentor\n")
 	return nil
 }
 


### PR DESCRIPTION
Adds the desired CTA for potential new mentors to visit https://exercism.io/mentor when downloading new problems on a track. I also took the liberty of adding the CTA to the `submit` command output, since `download` and `submit` are the most commonly used.

I was a bit confused about the use of `Err` vs `Out` with the `fmt.Fprintf()` calls, so let me know if that needs to change.

Fixes #715