### PR TITLE
Add Descriptive Error Message to Upgrade Command

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -23,7 +23,14 @@ You can always delete this file.
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c := cli.New(Version)
-		return updateCLI(c)
+		err := updateCLI(c)
+		if err != nil {
+			err = fmt.Errorf(`We were not able to upgrade the cli because we encountered an error: %s
+Please check the FAQ for solutions to common upgrading issues.
+
+https://exercism.io/faqs`, err)
+		}
+		return err
 	},
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -25,12 +25,16 @@ You can always delete this file.
 		c := cli.New(Version)
 		err := updateCLI(c)
 		if err != nil {
-			err = fmt.Errorf(`We were not able to upgrade the cli because we encountered an error: %s
+			return fmt.Errorf(`
+
+We were not able to upgrade the cli because we encountered an error:
+%s
+
 Please check the FAQ for solutions to common upgrading issues.
 
 https://exercism.io/faqs`, err)
 		}
-		return err
+		return nil
 	},
 }
 


### PR DESCRIPTION
Hi there! I'm an exercism user but first time contributor. Happy Hacktoberfest! 😄 🎃 

## What This Does

Solves https://github.com/exercism/cli/issues/680

This PR adds a wrapper around the `exercism upgrade` command which provides a more human-readable error message along with instructions to visit the FAQ page.

Currently, the FAQ page does not yet have upgrade debugging solutions, so perhaps it would be best to wait until https://github.com/exercism/website-copy/pull/417 is merged as well.

Thanks for taking the time to read this PR!