### PR TITLE
Refactor download cmd - compose & extract shared behavior for new doctor cmd

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -95,8 +95,8 @@ type download struct {
 
 // newDownloadFromFlags initiates a download from flags.
 // This is the primary interaction for downloading from the Exercism API.
-func newDownloadFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*download, error) {
-	downloadParams, err := newDownloadParamsFromFlags(usrCfg, flags)
+func newDownloadFromFlags(flags *pflag.FlagSet, usrCfg *viper.Viper) (*download, error) {
+	downloadParams, err := newDownloadParamsFromFlags(flags, usrCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +106,8 @@ func newDownloadFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*download,
 // newDownloadFromExercise initiates a download from an exercise.
 // This is used to get metadata and isn't the primary interaction for downloading.
 // Only allows writing metadata, not exercise files.
-func newDownloadFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*download, error) {
-	downloadParams, err := newDownloadParamsFromExercise(usrCfg, exercise)
+func newDownloadFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*download, error) {
+	downloadParams, err := newDownloadParamsFromExercise(exercise, usrCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ type downloadParams struct {
 }
 
 // newDownloadParamsFromExercise creates a new downloadParams given an exercise.
-func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {
+func newDownloadParamsFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*downloadParams, error) {
 	d := &downloadParams{
 		slug:             exercise.Slug,
 		track:            exercise.Track,
@@ -401,7 +401,7 @@ func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*
 }
 
 // newDownloadParamsFromFlags creates a new downloadParams given flags.
-func newDownloadParamsFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*downloadParams, error) {
+func newDownloadParamsFromFlags(flags *pflag.FlagSet, usrCfg *viper.Viper) (*downloadParams, error) {
 	d := &downloadParams{downloadableFrom: downloadableFromFlags{}}
 	var err error
 	d.uuid, err = flags.GetString("uuid")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -180,11 +180,11 @@ func (d *download) setPayload() error {
 		return err
 	}
 
-	req, err := client.NewRequest("GET", d.requestURL(), nil)
+	req, err := client.NewRequest("GET", d.payloadURL(), nil)
 	if err != nil {
 		return err
 	}
-	d.buildQuery(req.URL)
+	d.buildPayloadQueryParams(req.URL)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -217,7 +217,7 @@ func (d *download) setPayload() error {
 	return nil
 }
 
-func (d download) requestURL() string {
+func (d download) payloadURL() string {
 	id := "latest"
 	if d.params.uuid != "" {
 		id = d.params.uuid
@@ -225,7 +225,8 @@ func (d download) requestURL() string {
 	return fmt.Sprintf("%s/solutions/%s", d.params.apibaseurl, id)
 }
 
-func (d download) buildQuery(url *netURL.URL) {
+// buildPayloadQueryParams adds optional query parameters to the URL.
+func (d download) buildPayloadQueryParams(url *netURL.URL) {
 	query := url.Query()
 	if d.params.slug != "" {
 		query.Add("exercise_id", d.params.slug)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -321,7 +321,7 @@ func (w fileDownloadWriter) writeMetadata() error {
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
 func (w fileDownloadWriter) writeSolutionFiles() error {
-	if err := w.download.params.ensureWritable(); err != nil {
+	if err := w.download.params.ensureExerciseFilesWritable(); err != nil {
 		return err
 	}
 	for _, filename := range w.download.payload.Solution.Files {
@@ -443,9 +443,10 @@ func (d *downloadParams) validate() error {
 	return nil
 }
 
-func (d downloadParams) ensureWritable() error {
+// ensureExerciseFilesWritable checks permission for writing exercise files.
+func (d downloadParams) ensureExerciseFilesWritable() error {
 	if !d.downloadableFrom.writeExerciseFilesPermitted() {
-		return errors.New("writing exercise files not permitted")
+		return errors.New("writing exercise files not permitted when downloading from this type")
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -122,11 +122,9 @@ func newDownload(params *downloadParams, writer downloadWriter) (*download, erro
 	}
 
 	d := &download{params: params}
-
 	d.payload, err = d.requestPayload()
 	if err != nil {
 		return nil, err
-
 	}
 
 	writer.init(d)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -373,7 +373,7 @@ func newDownloadParamsFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*
 		track:            exercise.Track,
 		downloadableFrom: downloadableFromExercise{},
 	}
-	return d.newDownloadParams(usrCfg)
+	return d.build(usrCfg)
 }
 
 // newDownloadParamsFromFlags creates a new downloadParams given flags.
@@ -396,11 +396,11 @@ func newDownloadParamsFromFlags(flags *pflag.FlagSet, usrCfg *viper.Viper) (*dow
 	if err != nil {
 		return nil, err
 	}
-	return d.newDownloadParams(usrCfg)
+	return d.build(usrCfg)
 }
 
-// newDownloadParams contains the common creation logic for creating downloadParams.
-func (d *downloadParams) newDownloadParams(usrCfg *viper.Viper) (*downloadParams, error) {
+// build contains the common creation logic for creating downloadParams.
+func (d *downloadParams) build(usrCfg *viper.Viper) (*downloadParams, error) {
 	d.token = usrCfg.GetString("token")
 	d.apibaseurl = usrCfg.GetString("apibaseurl")
 	d.workspace = usrCfg.GetString("workspace")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -321,32 +321,37 @@ func (d fileDownloadWriter) writeSolutionFiles() error {
 		return err
 	}
 	for _, filename := range d.Solution.Files {
-		res, err := d.requestSolutionFile(filename)
-		if err != nil {
-			return err
-		}
-		if res == nil {
-			continue
-		}
-		defer res.Body.Close()
+		d.writeSolutionFile(filename)
+	}
+	return nil
+}
 
-		// TODO: if there's a collision, interactively resolve (show diff, ask if overwrite).
-		// TODO: handle --force flag to overwrite without asking.
+func (d fileDownloadWriter) writeSolutionFile(filename string) error {
+	res, err := d.requester.requestSolutionFile(filename)
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return nil
+	}
+	defer res.Body.Close()
 
-		destination := filepath.Join(
-			d.destination(),
-			sanitizeLegacyFilepath(filename, d.exercise().Slug))
-		if err = os.MkdirAll(filepath.Dir(destination), os.FileMode(0755)); err != nil {
-			return err
-		}
-		f, err := os.Create(destination)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		if _, err := io.Copy(f, res.Body); err != nil {
-			return err
-		}
+	// TODO: if there's a collision, interactively resolve (show diff, ask if overwrite).
+	// TODO: handle --force flag to overwrite without asking.
+
+	destination := filepath.Join(
+		d.destination(),
+		sanitizeLegacyFilepath(filename, d.exercise().Slug))
+	if err = os.MkdirAll(filepath.Dir(destination), os.FileMode(0755)); err != nil {
+		return err
+	}
+	f, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, res.Body); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -103,18 +103,21 @@ type download struct {
 	*downloadWriter
 }
 
-// newDownloadFromExercise is a convenience wrapper for creating a new download.
-func newDownloadFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*download, error) {
-	downloadParams, err := newDownloadParamsFromExercise(usrCfg, exercise)
+// newDownloadFromFlags initiates a download from flags.
+// This is the primary interaction for downloading from the Exercism API.
+func newDownloadFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*download, error) {
+	downloadParams, err := newDownloadParamsFromFlags(usrCfg, flags)
 	if err != nil {
 		return nil, err
 	}
 	return newDownload(downloadParams)
 }
 
-// newDownloadFromFlags is a convenience wrapper for creating a new download.
-func newDownloadFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*download, error) {
-	downloadParams, err := newDownloadParamsFromFlags(usrCfg, flags)
+// newDownloadFromExercise initiates a download from an exercise.
+// This is used to get metadata and isn't the primary interaction for downloading.
+// Only allows writing metadata, not exercise files.
+func newDownloadFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*download, error) {
+	downloadParams, err := newDownloadParamsFromExercise(usrCfg, exercise)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -293,7 +293,7 @@ func (d downloadWriter) writeMetadata() error {
 // All successful file responses are written except when 0 Content-Length.
 func (d downloadWriter) writeSolutionFiles() error {
 	if d.params.fromExercise {
-		return errors.New("existing exercise files should not be overwritten")
+		return errors.New("download via exercise not allowed to write solution files")
 	}
 	for _, filename := range d.Solution.Files {
 		res, err := d.requestFile(filename)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -217,6 +217,8 @@ func (d *download) setPayload() error {
 	return nil
 }
 
+// payloadURL is the URL used to request a downloadPayload.
+// The latest solution is used unless given a UUID.
 func (d download) payloadURL() string {
 	id := "latest"
 	if d.params.uuid != "" {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -368,21 +368,21 @@ type downloadParams struct {
 
 func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {
 	d := &downloadParams{slug: exercise.Slug, track: exercise.Track, fromExercise: true}
-	d.setFromConfig(usrCfg)
+	d.setFieldsFromConfig(usrCfg)
 	return d, d.validate()
 }
 
 func newDownloadParamsFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*downloadParams, error) {
 	d := &downloadParams{fromFlags: true}
-	d.setFromConfig(usrCfg)
-	if err := d.setFromFlags(flags); err != nil {
+	d.setFieldsFromConfig(usrCfg)
+	if err := d.setFieldsFromFlags(flags); err != nil {
 		return nil, err
 	}
 	return d, d.validate()
 }
 
-// setFromFlags sets the fields derived from flags.
-func (d *downloadParams) setFromFlags(flags *pflag.FlagSet) error {
+// setFieldsFromFlags sets the fields derived from flags.
+func (d *downloadParams) setFieldsFromFlags(flags *pflag.FlagSet) error {
 	var err error
 	d.uuid, err = flags.GetString("uuid")
 	if err != nil {
@@ -403,8 +403,8 @@ func (d *downloadParams) setFromFlags(flags *pflag.FlagSet) error {
 	return nil
 }
 
-// setFromConfig sets the fields derived from the user config.
-func (d *downloadParams) setFromConfig(usrCfg *viper.Viper) {
+// setFieldsFromConfig sets the fields derived from the user config.
+func (d *downloadParams) setFieldsFromConfig(usrCfg *viper.Viper) {
 	d.token = usrCfg.GetString("token")
 	d.apibaseurl = usrCfg.GetString("apibaseurl")
 	d.workspace = usrCfg.GetString("workspace")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -332,7 +332,9 @@ func (w fileDownloadWriter) writeSolutionFiles() error {
 		return err
 	}
 	for _, filename := range w.download.payload.Solution.Files {
-		w.writeSolutionFile(filename)
+		if err := w.writeSolutionFile(filename); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -103,9 +103,8 @@ func newDownloadFromFlags(flags *pflag.FlagSet, usrCfg *viper.Viper) (*download,
 	return newDownload(downloadParams, &fileDownloadWriter{})
 }
 
-// newDownloadFromExercise initiates a download from an exercise.
+// newDownloadFromExercise initiates a download from an existing exercise directory.
 // This is used to get metadata and isn't the primary interaction for downloading.
-// Only allows writing metadata, not solution files.
 func newDownloadFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*download, error) {
 	downloadParams, err := newDownloadParamsFromExercise(exercise, usrCfg)
 	if err != nil {
@@ -392,7 +391,7 @@ type downloadParams struct {
 	downloadableFrom
 }
 
-// newDownloadParamsFromExercise creates a new downloadParams given an exercise.
+// newDownloadParamsFromExercise creates a new downloadParams from an exercise.
 func newDownloadParamsFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*downloadParams, error) {
 	d := &downloadParams{
 		slug:             exercise.Slug,
@@ -480,7 +479,7 @@ func (d downloadableFromFlags) errGivenTrackOrTeamMissingSlug() error {
 	return errors.New("--track or --team requires --exercise (not --uuid)")
 }
 
-// downloadableFromExercise represents downloadParams created from an exercise.
+// downloadableFromExercise represents downloadParams created from an existing exercise directory.
 // This delegates to the template default.
 type downloadableFromExercise struct{ *downloadParams }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -87,9 +87,9 @@ type solutionRequester interface {
 
 // download is a download from the Exercism API.
 type download struct {
-	params *downloadParams
+	params  *downloadParams
 	payload *downloadPayload
-	downloadWriter
+	writer  downloadWriter
 }
 
 // newDownloadFromFlags initiates a download from flags.
@@ -167,7 +167,7 @@ func (d *download) setWriter(writer downloadWriter) error {
 	if err := writer.init(d); err != nil {
 		return err
 	}
-	d.downloadWriter = writer
+	d.writer = writer
 	return nil
 }
 
@@ -301,7 +301,7 @@ type downloadWriter interface {
 
 // fileDownloadWriter writes download contents to the file system.
 type fileDownloadWriter struct {
-	download *download
+	download  *download
 	requester solutionRequester
 }
 
@@ -382,8 +382,8 @@ type downloadParams struct {
 
 func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {
 	d := &downloadParams{
-		slug:              exercise.Slug,
-		track:             exercise.Track,
+		slug:             exercise.Slug,
+		track:            exercise.Track,
 		downloadableFrom: downloadableFromExercise{},
 	}
 	d.setFieldsFromConfig(usrCfg)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -487,7 +487,7 @@ func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 	return nil
 }
 
-// downloadableFrom is the interface to faciliate polymorphism when creating downloadParams from different types.
+// downloadableFrom is the interface to facilitate polymorphism when creating downloadParams from different types.
 type downloadableFrom interface {
 	writeExerciseFilesPermitted() bool
 	missingSlugOrUUIDError() error

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -81,6 +81,10 @@ func validateUserConfig(cfg *viper.Viper) error {
 	return nil
 }
 
+type solutionRequester interface {
+	requestSolutionFile(string) (*http.Response, error)
+}
+
 // download is a download from the Exercism API.
 type download struct {
 	params *downloadParams
@@ -294,10 +298,12 @@ type downloadWriter interface {
 // fileDownloadWriter writes download contents to the file system.
 type fileDownloadWriter struct {
 	*download
+	requester solutionRequester
 }
 
 func (d *fileDownloadWriter) init(dl *download) error {
 	d.download = dl
+	d.requester = dl
 	return dl.validate()
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -439,7 +439,7 @@ func (d downloadParams) errGivenTrackOrTeamMissingSlug() error {
 	return errors.New("programmer error")
 }
 
-// downloadableFrom is an interface for variant behavior for downloads initiated from different types.
+// downloadableFrom is a polymorphic interface for downloads initiated from different types.
 // Clients can embed downloadParams to delegate to the default implementation.
 type downloadableFrom interface {
 	// indicates permission to write solution files from the payload.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -422,12 +422,12 @@ func (d downloadParams) writeSolutionFilesPermitted() bool { return false }
 
 // errMissingSlugOrUUID is the default error.
 func (d downloadParams) errMissingSlugOrUUID() error {
-	return errors.New("need a 'slug' or a 'uuid'")
+	return errors.New("programmer error")
 }
 
 // errGivenTrackOrTeamMissingSlug is the default error.
 func (d downloadParams) errGivenTrackOrTeamMissingSlug() error {
-	return errors.New("track or team requires slug (not uuid)")
+	return errors.New("programmer error")
 }
 
 // downloadableFrom is an interface for variant behavior for downloads initiated from different types.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -289,26 +289,19 @@ func (d download) validate() error {
 	return nil
 }
 
-// downloadWriter writes download contents.
-type downloadWriter interface {
-	writeMetadata() error
-	writeSolutionFiles() error
-	destination() string
-}
-
-// fileDownloadWriter writes download contents to the file system.
-type fileDownloadWriter struct {
+// downloadWriter writes download contents to the file system.
+type downloadWriter struct {
 	download  *download
 	requester solutionRequester
 }
 
-// newFileDownloadWriter creates a fileDownloadWriter.
-func newFileDownloadWriter(dl *download) *fileDownloadWriter {
-	return &fileDownloadWriter{download: dl, requester: dl}
+// newDownloadWriter creates a downloadWriter.
+func newDownloadWriter(dl *download) *downloadWriter {
+	return &downloadWriter{download: dl, requester: dl}
 }
 
 // writeMetadata writes the exercise metadata.
-func (w fileDownloadWriter) writeMetadata() error {
+func (w downloadWriter) writeMetadata() error {
 	metadata := w.download.metadata()
 	return metadata.Write(w.destination())
 }
@@ -316,7 +309,7 @@ func (w fileDownloadWriter) writeMetadata() error {
 // writeSolutionFiles attempts to write each file that is part of the downloaded solution.
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
-func (w fileDownloadWriter) writeSolutionFiles() error {
+func (w downloadWriter) writeSolutionFiles() error {
 	for _, filename := range w.download.payload.Solution.Files {
 		if err := w.writeSolutionFile(filename); err != nil {
 			return err
@@ -325,7 +318,7 @@ func (w fileDownloadWriter) writeSolutionFiles() error {
 	return nil
 }
 
-func (w fileDownloadWriter) writeSolutionFile(filename string) error {
+func (w downloadWriter) writeSolutionFile(filename string) error {
 	if err := w.download.ensureSolutionFilesWritable(); err != nil {
 		return err
 	}
@@ -359,7 +352,7 @@ func (w fileDownloadWriter) writeSolutionFile(filename string) error {
 }
 
 // destination is the download destination path.
-func (w fileDownloadWriter) destination() string {
+func (w downloadWriter) destination() string {
 	return w.download.exercise().MetadataDir()
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -282,7 +282,7 @@ func (d download) solutionBelongsToOtherUser() bool {
 // ensureSolutionWritable checks permission for writing solution files.
 func (d download) ensureSolutionWritable() error {
 	if !d.params.downloadableFrom.writeSolutionPermitted() {
-		return errors.New("writing solution files not permitted when downloading from this type")
+		return errors.New("writing solution files not permitted in this context")
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -115,10 +115,6 @@ func newDownloadFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*downlo
 // newDownload creates a write ready download by requesting a downloadPayload from the Exercism API.
 func newDownload(params *downloadParams) (*download, error) {
 	var err error
-	if err = params.validate(); err != nil {
-		return nil, err
-	}
-
 	d := &download{params: params}
 	d.payload, err = d.requestPayload()
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -191,7 +191,7 @@ func (d *download) setWriter(writer downloadWriter) error {
 	return nil
 }
 
-func (d *download) requestURL() string {
+func (d download) requestURL() string {
 	id := "latest"
 	if d.params.uuid != "" {
 		id = d.params.uuid
@@ -199,7 +199,7 @@ func (d *download) requestURL() string {
 	return fmt.Sprintf("%s/solutions/%s", d.params.apibaseurl, id)
 }
 
-func (d *download) buildQuery(url *netURL.URL) {
+func (d download) buildQuery(url *netURL.URL) {
 	query := url.Query()
 	if d.params.slug != "" {
 		query.Add("exercise_id", d.params.slug)
@@ -215,7 +215,7 @@ func (d *download) buildQuery(url *netURL.URL) {
 
 // requestSolutionFile requests a Solution file from the API, returning an HTTP response.
 // Non-200 responses and 0 Content-Length responses are swallowed, returning nil.
-func (d *download) requestSolutionFile(filename string) (*http.Response, error) {
+func (d download) requestSolutionFile(filename string) (*http.Response, error) {
 	parsedURL, err := netURL.ParseRequestURI(
 		fmt.Sprintf("%s%s", d.Solution.FileDownloadBaseURL, filename))
 	if err != nil {
@@ -244,7 +244,7 @@ func (d *download) requestSolutionFile(filename string) (*http.Response, error) 
 	return res, nil
 }
 
-func (d *download) metadata() ws.ExerciseMetadata {
+func (d download) metadata() ws.ExerciseMetadata {
 	return ws.ExerciseMetadata{
 		AutoApprove: d.Solution.Exercise.AutoApprove,
 		Track:       d.Solution.Exercise.Track.ID,
@@ -257,7 +257,7 @@ func (d *download) metadata() ws.ExerciseMetadata {
 	}
 }
 
-func (d *download) exercise() ws.Exercise {
+func (d download) exercise() ws.Exercise {
 	return ws.Exercise{
 		Root:  d.solutionRoot(),
 		Track: d.Solution.Exercise.Track.ID,
@@ -267,7 +267,7 @@ func (d *download) exercise() ws.Exercise {
 
 // solutionRoot builds the root path based on the solution
 // being part of a team and/or owned by another user.
-func (d *download) solutionRoot() string {
+func (d download) solutionRoot() string {
 	root := d.params.workspace
 
 	if d.isTeamSolution() {
@@ -279,16 +279,16 @@ func (d *download) solutionRoot() string {
 	return root
 }
 
-func (d *download) isTeamSolution() bool {
+func (d download) isTeamSolution() bool {
 	return d.Solution.Team.Slug != ""
 }
 
-func (d *download) solutionBelongsToOtherUser() bool {
+func (d download) solutionBelongsToOtherUser() bool {
 	return !d.Solution.User.IsRequester
 }
 
 // validate validates the presence of an ID and checks for an error message.
-func (d *download) validate() error {
+func (d download) validate() error {
 	if d.Solution.ID == "" {
 		return errors.New("download missing an ID")
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -459,7 +459,7 @@ type downloadParamsValidator struct {
 // needsSlugXorUUID checks the presence of either a slug or a uuid (but not both).
 func (d downloadParamsValidator) needsSlugXorUUID() error {
 	if d.slug != "" && d.uuid != "" || d.uuid == d.slug {
-		return d.downloadableFrom.missingSlugOrUUIDError()
+		return d.downloadableFrom.errMissingSlugOrUUID()
 	}
 	return nil
 }
@@ -483,7 +483,7 @@ func (d downloadParamsValidator) needsUserConfigValues() error {
 // (track/team meaningless when given a uuid).
 func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 	if (d.team != "" || d.track != "") && d.slug == "" {
-		return d.downloadableFrom.givenTrackOrTeamMissingSlugError()
+		return d.downloadableFrom.errGivenTrackOrTeamMissingSlug()
 	}
 	return nil
 }
@@ -491,19 +491,19 @@ func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 // downloadableFrom is the interface to facilitate polymorphism when creating downloadParams from different types.
 type downloadableFrom interface {
 	writeExerciseFilesPermitted() bool
-	missingSlugOrUUIDError() error
-	givenTrackOrTeamMissingSlugError() error
+	errMissingSlugOrUUID() error
+	errGivenTrackOrTeamMissingSlug() error
 }
 
 type downloadableFromFlags struct{}
 
 func (d downloadableFromFlags) writeExerciseFilesPermitted() bool { return true }
 
-func (d downloadableFromFlags) missingSlugOrUUIDError() error {
+func (d downloadableFromFlags) errMissingSlugOrUUID() error {
 	return errors.New("need an --exercise name or a solution --uuid")
 }
 
-func (d downloadableFromFlags) givenTrackOrTeamMissingSlugError() error {
+func (d downloadableFromFlags) errGivenTrackOrTeamMissingSlug() error {
 	return errors.New("--track or --team requires --exercise (not --uuid)")
 }
 
@@ -511,11 +511,11 @@ type downloadableFromExercise struct{}
 
 func (d downloadableFromExercise) writeExerciseFilesPermitted() bool { return false }
 
-func (d downloadableFromExercise) missingSlugOrUUIDError() error {
+func (d downloadableFromExercise) errMissingSlugOrUUID() error {
 	return errors.New("need a 'slug' or a 'uuid'")
 }
 
-func (d downloadableFromExercise) givenTrackOrTeamMissingSlugError() error {
+func (d downloadableFromExercise) errGivenTrackOrTeamMissingSlug() error {
 	return errors.New("programmer error - should never happen")
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -124,9 +124,7 @@ func newDownload(params *downloadParams, writer downloadWriter) (*download, erro
 	if err := d.setPayload(); err != nil {
 		return nil, err
 	}
-	if err := d.setWriter(writer); err != nil {
-		return nil, err
-	}
+	d.setWriter(writer)
 	return d, d.validate()
 }
 
@@ -162,15 +160,9 @@ func (d download) requestSolutionFile(filename string) (*http.Response, error) {
 }
 
 // setWriter initializes the downloadWriter and sets the field.
-func (d *download) setWriter(writer downloadWriter) error {
-	if writer == nil {
-		errors.New("writer is empty")
-	}
-	if err := writer.init(d); err != nil {
-		return err
-	}
+func (d *download) setWriter(writer downloadWriter) {
+	writer.init(d)
 	d.writer = writer
-	return nil
 }
 
 // setPayload sets the payload by requesting a downloadPayload from the Exercism API.
@@ -301,7 +293,7 @@ func (d download) validate() error {
 
 // downloadWriter writes download contents.
 type downloadWriter interface {
-	init(*download) error
+	init(*download)
 	writeMetadata() error
 	writeSolutionFiles() error
 	destination() string
@@ -314,10 +306,9 @@ type fileDownloadWriter struct {
 }
 
 // init inititates the writer by setting its download dependent fields.
-func (w *fileDownloadWriter) init(dl *download) error {
+func (w *fileDownloadWriter) init(dl *download) {
 	w.download = dl
 	w.requester = dl
-	return dl.validate()
 }
 
 // writeMetadata writes the exercise metadata.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -116,12 +116,14 @@ func newDownloadFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*downlo
 
 // newDownload creates a write ready download by requesting a downloadPayload from the Exercism API.
 func newDownload(params *downloadParams, writer downloadWriter) (*download, error) {
-	if err := params.validate(); err != nil {
+	var err error
+	if err = params.validate(); err != nil {
 		return nil, err
 	}
 
 	d := &download{params: params}
-	if err := d.setPayload(); err != nil {
+	d.payload, err = d.requestPayload()
+	if err != nil {
 		return nil, err
 	}
 	d.setWriter(writer)
@@ -165,31 +167,32 @@ func (d *download) setWriter(writer downloadWriter) {
 	d.writer = writer
 }
 
-// setPayload sets the payload by requesting a downloadPayload from the Exercism API.
-func (d *download) setPayload() error {
+// requestPayload returns a downloadPayload from the Exercism API.
+func (d download) requestPayload() (*downloadPayload, error) {
 	client, err := api.NewClient(d.params.token, d.params.apibaseurl)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := client.NewRequest("GET", d.payloadURL(), nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	d.buildPayloadQueryParams(req.URL)
 
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer res.Body.Close()
 
-	if err := json.NewDecoder(res.Body).Decode(&d.payload); err != nil {
-		return fmt.Errorf("unable to parse API response - %s", err)
+	var payload *downloadPayload
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("unable to parse API response - %s", err)
 	}
 
 	if res.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"unauthorized request. Please run the configure command. You can find your API token at %s/my/settings",
 			config.InferSiteURL(d.params.apibaseurl),
 		)
@@ -197,16 +200,16 @@ func (d *download) setPayload() error {
 	if res.StatusCode != http.StatusOK {
 		switch d.payload.Error.Type {
 		case "track_ambiguous":
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"%s: %s",
 				d.payload.Error.Message,
 				strings.Join(d.payload.Error.PossibleTrackIDs, ", "),
 			)
 		default:
-			return errors.New(d.payload.Error.Message)
+			return nil, errors.New(d.payload.Error.Message)
 		}
 	}
-	return nil
+	return payload, nil
 }
 
 // payloadURL is the URL used to request a downloadPayload.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -305,33 +305,33 @@ type fileDownloadWriter struct {
 	requester solutionRequester
 }
 
-func (d *fileDownloadWriter) init(dl *download) error {
-	d.download = dl
-	d.requester = dl
+func (w *fileDownloadWriter) init(dl *download) error {
+	w.download = dl
+	w.requester = dl
 	return dl.validate()
 }
 
 // writeMetadata writes the exercise metadata.
-func (d fileDownloadWriter) writeMetadata() error {
-	metadata := d.download.metadata()
-	return metadata.Write(d.destination())
+func (w fileDownloadWriter) writeMetadata() error {
+	metadata := w.download.metadata()
+	return metadata.Write(w.destination())
 }
 
 // writeSolutionFiles attempts to write each exercise file that is part of the downloaded Solution.
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
-func (d fileDownloadWriter) writeSolutionFiles() error {
-	if err := d.download.params.ensureWritable(); err != nil {
+func (w fileDownloadWriter) writeSolutionFiles() error {
+	if err := w.download.params.ensureWritable(); err != nil {
 		return err
 	}
-	for _, filename := range d.download.payload.Solution.Files {
-		d.writeSolutionFile(filename)
+	for _, filename := range w.download.payload.Solution.Files {
+		w.writeSolutionFile(filename)
 	}
 	return nil
 }
 
-func (d fileDownloadWriter) writeSolutionFile(filename string) error {
-	res, err := d.requester.requestSolutionFile(filename)
+func (w fileDownloadWriter) writeSolutionFile(filename string) error {
+	res, err := w.requester.requestSolutionFile(filename)
 	if err != nil {
 		return err
 	}
@@ -344,8 +344,8 @@ func (d fileDownloadWriter) writeSolutionFile(filename string) error {
 	// TODO: handle --force flag to overwrite without asking.
 
 	destination := filepath.Join(
-		d.destination(),
-		sanitizeLegacyFilepath(filename, d.download.exercise().Slug))
+		w.destination(),
+		sanitizeLegacyFilepath(filename, w.download.exercise().Slug))
 	if err = os.MkdirAll(filepath.Dir(destination), os.FileMode(0755)); err != nil {
 		return err
 	}
@@ -361,8 +361,8 @@ func (d fileDownloadWriter) writeSolutionFile(filename string) error {
 }
 
 // destination is the download destination path.
-func (d fileDownloadWriter) destination() string {
-	return d.download.exercise().MetadataDir()
+func (w fileDownloadWriter) destination() string {
+	return w.download.exercise().MetadataDir()
 }
 
 // downloadParams is required to create a download.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -397,7 +397,7 @@ func newDownloadParamsFromExercise(exercise ws.Exercise, usrCfg *viper.Viper) (*
 		track:            exercise.Track,
 		downloadableFrom: downloadableFromExercise{},
 	}
-	return d.build(usrCfg)
+	return d.newDownloadParams(usrCfg)
 }
 
 // newDownloadParamsFromFlags creates a new downloadParams given flags.
@@ -420,11 +420,11 @@ func newDownloadParamsFromFlags(flags *pflag.FlagSet, usrCfg *viper.Viper) (*dow
 	if err != nil {
 		return nil, err
 	}
-	return d.build(usrCfg)
+	return d.newDownloadParams(usrCfg)
 }
 
-// build contains the common creation logic for creating downloadParams.
-func (d *downloadParams) build(usrCfg *viper.Viper) (*downloadParams, error) {
+// newDownloadParams contains the common creation logic for creating downloadParams.
+func (d *downloadParams) newDownloadParams(usrCfg *viper.Viper) (*downloadParams, error) {
 	d.token = usrCfg.GetString("token")
 	d.apibaseurl = usrCfg.GetString("apibaseurl")
 	d.workspace = usrCfg.GetString("workspace")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -297,7 +297,7 @@ type downloadWriter interface {
 
 // fileDownloadWriter writes download contents to the file system.
 type fileDownloadWriter struct {
-	*download
+	download *download
 	requester solutionRequester
 }
 
@@ -309,7 +309,7 @@ func (d *fileDownloadWriter) init(dl *download) error {
 
 // writeMetadata writes the exercise metadata.
 func (d fileDownloadWriter) writeMetadata() error {
-	metadata := d.metadata()
+	metadata := d.download.metadata()
 	return metadata.Write(d.destination())
 }
 
@@ -317,10 +317,10 @@ func (d fileDownloadWriter) writeMetadata() error {
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
 func (d fileDownloadWriter) writeSolutionFiles() error {
-	if err := d.params.ensureWritable(); err != nil {
+	if err := d.download.params.ensureWritable(); err != nil {
 		return err
 	}
-	for _, filename := range d.Solution.Files {
+	for _, filename := range d.download.Solution.Files {
 		d.writeSolutionFile(filename)
 	}
 	return nil
@@ -341,7 +341,7 @@ func (d fileDownloadWriter) writeSolutionFile(filename string) error {
 
 	destination := filepath.Join(
 		d.destination(),
-		sanitizeLegacyFilepath(filename, d.exercise().Slug))
+		sanitizeLegacyFilepath(filename, d.download.exercise().Slug))
 	if err = os.MkdirAll(filepath.Dir(destination), os.FileMode(0755)); err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (d fileDownloadWriter) writeSolutionFile(filename string) error {
 
 // destination is the download destination path.
 func (d fileDownloadWriter) destination() string {
-	return d.exercise().MetadataDir()
+	return d.download.exercise().MetadataDir()
 }
 
 // downloadParams is required to create a download.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -397,47 +397,38 @@ func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*
 		track:            exercise.Track,
 		downloadableFrom: downloadableFromExercise{},
 	}
-	d.setFieldsFromConfig(usrCfg)
-	return d, d.validate()
+	return d.build(usrCfg)
 }
 
 // newDownloadParamsFromFlags creates a new downloadParams given flags.
 func newDownloadParamsFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*downloadParams, error) {
 	d := &downloadParams{downloadableFrom: downloadableFromFlags{}}
-	d.setFieldsFromConfig(usrCfg)
-	if err := d.setFieldsFromFlags(flags); err != nil {
-		return nil, err
-	}
-	return d, d.validate()
-}
-
-// setFieldsFromFlags sets the fields derived from flags.
-func (d *downloadParams) setFieldsFromFlags(flags *pflag.FlagSet) error {
 	var err error
 	d.uuid, err = flags.GetString("uuid")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	d.slug, err = flags.GetString("exercise")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	d.track, err = flags.GetString("track")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	d.team, err = flags.GetString("team")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return d.build(usrCfg)
 }
 
-// setFieldsFromConfig sets the fields derived from the user config.
-func (d *downloadParams) setFieldsFromConfig(usrCfg *viper.Viper) {
+// build contains the common creation logic for creating downloadParams.
+func (d *downloadParams) build(usrCfg *viper.Viper) (*downloadParams, error) {
 	d.token = usrCfg.GetString("token")
 	d.apibaseurl = usrCfg.GetString("apibaseurl")
 	d.workspace = usrCfg.GetString("workspace")
+	return d, d.validate()
 }
 
 // validate validates creation of downloadParams.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -122,11 +122,16 @@ func newDownload(params *downloadParams, writer downloadWriter) (*download, erro
 	}
 
 	d := &download{params: params}
+
 	d.payload, err = d.requestPayload()
 	if err != nil {
 		return nil, err
+
 	}
-	d.setWriter(writer)
+
+	writer.init(d)
+	d.writer = writer
+
 	return d, d.validate()
 }
 
@@ -159,12 +164,6 @@ func (d download) requestSolutionFile(filename string) (*http.Response, error) {
 	}
 
 	return res, nil
-}
-
-// setWriter initializes the downloadWriter and sets the field.
-func (d *download) setWriter(writer downloadWriter) {
-	writer.init(d)
-	d.writer = writer
 }
 
 // requestPayload returns a downloadPayload from the Exercism API.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -359,11 +359,9 @@ type downloadParams struct {
 	token, apibaseurl, workspace string
 
 	// optional
-	track string
-	team  string
+	track, team string
 
-	fromExercise bool
-	fromFlags    bool
+	fromExercise, fromFlags bool
 }
 
 func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -280,6 +280,14 @@ func (d download) solutionBelongsToOtherUser() bool {
 	return !d.payload.Solution.User.IsRequester
 }
 
+// ensureExerciseFilesWritable checks permission for writing exercise files.
+func (d download) ensureExerciseFilesWritable() error {
+	if !d.params.downloadableFrom.writeExerciseFilesPermitted() {
+		return errors.New("writing exercise files not permitted when downloading from this type")
+	}
+	return nil
+}
+
 // validate verifies creation of a valid download.
 func (d download) validate() error {
 	if d.payload.Solution.ID == "" {
@@ -321,7 +329,7 @@ func (w fileDownloadWriter) writeMetadata() error {
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
 func (w fileDownloadWriter) writeSolutionFiles() error {
-	if err := w.download.params.ensureExerciseFilesWritable(); err != nil {
+	if err := w.download.ensureExerciseFilesWritable(); err != nil {
 		return err
 	}
 	for _, filename := range w.download.payload.Solution.Files {
@@ -331,7 +339,7 @@ func (w fileDownloadWriter) writeSolutionFiles() error {
 }
 
 func (w fileDownloadWriter) writeSolutionFile(filename string) error {
-	if err := w.download.params.ensureExerciseFilesWritable(); err != nil {
+	if err := w.download.ensureExerciseFilesWritable(); err != nil {
 		return err
 	}
 	res, err := w.requester.requestSolutionFile(filename)
@@ -437,14 +445,6 @@ func (d downloadParams) validate() error {
 	}
 	if err := validator.needsSlugWhenGivenTrackOrTeam(); err != nil {
 		return err
-	}
-	return nil
-}
-
-// ensureExerciseFilesWritable checks permission for writing exercise files.
-func (d downloadParams) ensureExerciseFilesWritable() error {
-	if !d.downloadableFrom.writeExerciseFilesPermitted() {
-		return errors.New("writing exercise files not permitted when downloading from this type")
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -361,6 +361,7 @@ type downloadParams struct {
 	// optional
 	track, team string
 
+	// duck-type for downloadParams created from varying types
 	downloadParamsFrom
 }
 
@@ -471,6 +472,7 @@ func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 	return nil
 }
 
+// downloadParamsFrom is the interface to faciliate polymorphism when creating downloadParams from different types.
 type downloadParamsFrom interface {
 	writeExerciseFilesPermitted() bool
 	missingSlugOrUUIDError() error

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -373,7 +373,7 @@ type downloadParams struct {
 	track, team string
 
 	// duck-type for downloadParams created from varying types
-	downloadableFrom
+	downloadableFrom downloadableFrom
 }
 
 func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {
@@ -440,7 +440,7 @@ func (d *downloadParams) validate() error {
 }
 
 func (d downloadParams) ensureWritable() error {
-	if !d.writeExerciseFilesPermitted() {
+	if !d.downloadableFrom.writeExerciseFilesPermitted() {
 		return errors.New("writing exercise files not permitted")
 	}
 	return nil
@@ -454,7 +454,7 @@ type downloadParamsValidator struct {
 // needsSlugXorUUID checks the presence of either a slug or a uuid (but not both).
 func (d downloadParamsValidator) needsSlugXorUUID() error {
 	if d.slug != "" && d.uuid != "" || d.uuid == d.slug {
-		return d.missingSlugOrUUIDError()
+		return d.downloadableFrom.missingSlugOrUUIDError()
 	}
 	return nil
 }
@@ -478,7 +478,7 @@ func (d downloadParamsValidator) needsUserConfigValues() error {
 // (track/team meaningless when given a uuid).
 func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 	if (d.team != "" || d.track != "") && d.slug == "" {
-		return d.givenTrackOrTeamMissingSlugError()
+		return d.downloadableFrom.givenTrackOrTeamMissingSlugError()
 	}
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -312,7 +312,10 @@ func (d fileDownloadWriter) writeMetadata() error {
 // All successful file responses are written except when 0 Content-Length.
 func (d fileDownloadWriter) writeSolutionFiles() error {
 	if !d.params.writeExerciseFilesPermitted() {
-		return errors.New("exercise files not writable")
+		return fmt.Errorf(
+			"writing exercise files not permitted when downloading from %s",
+			d.params.downloadParamsFrom,
+		)
 	}
 	for _, filename := range d.Solution.Files {
 		res, err := d.requestSolutionFile(filename)
@@ -468,6 +471,7 @@ type downloadParamsFrom interface {
 	writeExerciseFilesPermitted() bool
 	missingSlugOrUUIDError() error
 	givenTrackOrTeamMissingSlugError() error
+	String() string
 }
 
 type downloadParamsFromFlags struct{}
@@ -482,6 +486,8 @@ func (d downloadParamsFromFlags) givenTrackOrTeamMissingSlugError() error {
 	return errors.New("--track or --team requires --exercise (not --uuid)")
 }
 
+func (d downloadParamsFromFlags) String() string { return "flags" }
+
 type downloadParamsFromExercise struct{}
 
 func (d downloadParamsFromExercise) writeExerciseFilesPermitted() bool { return false }
@@ -493,6 +499,8 @@ func (d downloadParamsFromExercise) missingSlugOrUUIDError() error {
 func (d downloadParamsFromExercise) givenTrackOrTeamMissingSlugError() error {
 	return errors.New("programmer error - should never happen")
 }
+
+func (d downloadParamsFromExercise) String() string { return "exercise" }
 
 // sanitizeLegacyFilepath is a workaround for a path bug due to an early design
 // decision (later reversed) to allow numeric suffixes for exercise directories,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -432,8 +432,8 @@ func (d *downloadParams) build(usrCfg *viper.Viper) (*downloadParams, error) {
 }
 
 // validate validates creation of downloadParams.
-func (d *downloadParams) validate() error {
-	validator := downloadParamsValidator{params: d}
+func (d downloadParams) validate() error {
+	validator := downloadParamsValidator{params: &d}
 
 	if err := validator.needsSlugXorUUID(); err != nil {
 		return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -257,15 +257,15 @@ func (d download) metadata() ws.ExerciseMetadata {
 
 func (d download) exercise() ws.Exercise {
 	return ws.Exercise{
-		Root:  d.solutionRoot(),
+		Root:  d.solutionRootFilepath(),
 		Track: d.payload.Solution.Exercise.Track.ID,
 		Slug:  d.payload.Solution.Exercise.ID,
 	}
 }
 
-// solutionRoot builds the root path based on the solution
+// solutionRootFilepath builds the root path based on the solution
 // being part of a team and/or owned by another user.
-func (d download) solutionRoot() string {
+func (d download) solutionRootFilepath() string {
 	root := d.params.workspace
 
 	if d.isTeamSolution() {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -81,11 +81,6 @@ func validateUserConfig(cfg *viper.Viper) error {
 	return nil
 }
 
-// solutionRequester is the interface for requesting a solution file from the Exercism API.
-type solutionRequester interface {
-	requestSolutionFile(string) (*http.Response, error)
-}
-
 // download is a download from the Exercism API.
 type download struct {
 	params  *downloadParams
@@ -291,13 +286,12 @@ func (d download) validate() error {
 
 // downloadWriter writes download contents to the file system.
 type downloadWriter struct {
-	download  *download
-	requester solutionRequester
+	download *download
 }
 
 // newDownloadWriter creates a downloadWriter.
 func newDownloadWriter(dl *download) *downloadWriter {
-	return &downloadWriter{download: dl, requester: dl}
+	return &downloadWriter{download: dl}
 }
 
 // writeMetadata writes the exercise metadata.
@@ -322,7 +316,7 @@ func (w downloadWriter) writeSolutionFile(filename string) error {
 	if err := w.download.ensureSolutionFilesWritable(); err != nil {
 		return err
 	}
-	res, err := w.requester.requestSolutionFile(filename)
+	res, err := w.download.requestSolutionFile(filename)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -331,6 +331,9 @@ func (w fileDownloadWriter) writeSolutionFiles() error {
 }
 
 func (w fileDownloadWriter) writeSolutionFile(filename string) error {
+	if err := w.download.params.ensureExerciseFilesWritable(); err != nil {
+		return err
+	}
 	res, err := w.requester.requestSolutionFile(filename)
 	if err != nil {
 		return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -373,21 +373,21 @@ type downloadParams struct {
 	track, team string
 
 	// duck-type for downloadParams created from varying types
-	downloadParamsFrom
+	downloadableFrom
 }
 
 func newDownloadParamsFromExercise(usrCfg *viper.Viper, exercise ws.Exercise) (*downloadParams, error) {
 	d := &downloadParams{
-		slug:               exercise.Slug,
-		track:              exercise.Track,
-		downloadParamsFrom: downloadParamsFromExercise{},
+		slug:              exercise.Slug,
+		track:             exercise.Track,
+		downloadableFrom: downloadableFromExercise{},
 	}
 	d.setFieldsFromConfig(usrCfg)
 	return d, d.validate()
 }
 
 func newDownloadParamsFromFlags(usrCfg *viper.Viper, flags *pflag.FlagSet) (*downloadParams, error) {
-	d := &downloadParams{downloadParamsFrom: downloadParamsFromFlags{}}
+	d := &downloadParams{downloadableFrom: downloadableFromFlags{}}
 	d.setFieldsFromConfig(usrCfg)
 	if err := d.setFieldsFromFlags(flags); err != nil {
 		return nil, err
@@ -483,34 +483,34 @@ func (d downloadParamsValidator) needsSlugWhenGivenTrackOrTeam() error {
 	return nil
 }
 
-// downloadParamsFrom is the interface to faciliate polymorphism when creating downloadParams from different types.
-type downloadParamsFrom interface {
+// downloadableFrom is the interface to faciliate polymorphism when creating downloadParams from different types.
+type downloadableFrom interface {
 	writeExerciseFilesPermitted() bool
 	missingSlugOrUUIDError() error
 	givenTrackOrTeamMissingSlugError() error
 }
 
-type downloadParamsFromFlags struct{}
+type downloadableFromFlags struct{}
 
-func (d downloadParamsFromFlags) writeExerciseFilesPermitted() bool { return true }
+func (d downloadableFromFlags) writeExerciseFilesPermitted() bool { return true }
 
-func (d downloadParamsFromFlags) missingSlugOrUUIDError() error {
+func (d downloadableFromFlags) missingSlugOrUUIDError() error {
 	return errors.New("need an --exercise name or a solution --uuid")
 }
 
-func (d downloadParamsFromFlags) givenTrackOrTeamMissingSlugError() error {
+func (d downloadableFromFlags) givenTrackOrTeamMissingSlugError() error {
 	return errors.New("--track or --team requires --exercise (not --uuid)")
 }
 
-type downloadParamsFromExercise struct{}
+type downloadableFromExercise struct{}
 
-func (d downloadParamsFromExercise) writeExerciseFilesPermitted() bool { return false }
+func (d downloadableFromExercise) writeExerciseFilesPermitted() bool { return false }
 
-func (d downloadParamsFromExercise) missingSlugOrUUIDError() error {
+func (d downloadableFromExercise) missingSlugOrUUIDError() error {
 	return errors.New("need a 'slug' or a 'uuid'")
 }
 
-func (d downloadParamsFromExercise) givenTrackOrTeamMissingSlugError() error {
+func (d downloadableFromExercise) givenTrackOrTeamMissingSlugError() error {
 	return errors.New("programmer error - should never happen")
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -388,7 +388,7 @@ type downloadParams struct {
 	// optional
 	track, team string
 
-	// duck-type for downloadParams created from varying types
+	// polymorphic reference for downloads initiated via different types
 	downloadableFrom
 }
 
@@ -449,22 +449,18 @@ func (d downloadParams) validate() error {
 	return nil
 }
 
-// writeExerciseFilesPermitted is a template pattern default.
 func (d downloadParams) writeExerciseFilesPermitted() bool { return false }
 
-// errMissingSlugOrUUID is a template pattern default.
 func (d downloadParams) errMissingSlugOrUUID() error {
 	return errors.New("need a 'slug' or a 'uuid'")
 }
 
-// errGivenTrackOrTeamMissingSlug is a template pattern default.
 func (d downloadParams) errGivenTrackOrTeamMissingSlug() error {
 	return errors.New("track or team requires slug (not uuid)")
 }
 
-// downloadableFrom is the interface to use the template pattern when creating downloadParams from different types.
+// downloadableFrom is an interface for variant behavior for downloads initiated from different types.
 // Clients can embed downloadParams to delegate to the default implementation.
-// This allows fine-grained specializations without having to define the entire interface.
 type downloadableFrom interface {
 	writeExerciseFilesPermitted() bool
 	errMissingSlugOrUUID() error

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -491,7 +491,7 @@ type downloadParamsValidator struct {
 	params *downloadParams
 }
 
-// needsSlugXorUUID checks the presence of either a slug or a uuid (but not both).
+// needsSlugXorUUID checks the presence of slug XOR uuid.
 func (d downloadParamsValidator) needsSlugXorUUID() error {
 	if d.params.slug != "" && d.params.uuid != "" || d.params.uuid == d.params.slug {
 		return d.params.downloadableFrom.errMissingSlugOrUUID()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -328,9 +328,6 @@ func (w fileDownloadWriter) writeMetadata() error {
 // An HTTP request is made using each filename and failed responses are swallowed.
 // All successful file responses are written except when 0 Content-Length.
 func (w fileDownloadWriter) writeSolutionFiles() error {
-	if err := w.download.ensureSolutionWritable(); err != nil {
-		return err
-	}
 	for _, filename := range w.download.payload.Solution.Files {
 		if err := w.writeSolutionFile(filename); err != nil {
 			return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,7 +66,7 @@ const msgMissingMetadata = `
 
 `
 
-// validateUserConfig validates the presense of required user config values
+// validateUserConfig validates the presence of required user config values
 func validateUserConfig(cfg *viper.Viper) error {
 	if cfg.GetString("token") == "" {
 		return fmt.Errorf(
@@ -305,7 +305,7 @@ type fileDownloadWriter struct {
 	requester solutionRequester
 }
 
-// init inititates the writer by setting its download dependent fields.
+// init initiates the writer by setting its download dependent fields.
 func (w *fileDownloadWriter) init(dl *download) {
 	w.download = dl
 	w.requester = dl

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -428,6 +428,10 @@ func (d *downloadParams) newDownloadParams(usrCfg *viper.Viper) (*downloadParams
 	d.token = usrCfg.GetString("token")
 	d.apibaseurl = usrCfg.GetString("apibaseurl")
 	d.workspace = usrCfg.GetString("workspace")
+
+	if d.downloadableFrom == nil {
+		d.downloadableFrom = d
+	}
 	return d, d.validate()
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -46,7 +46,6 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	if err != nil {
 		return err
 	}
-
 	writer := newFileDownloadWriter(download)
 	if err := writer.writeSolutionFiles(); err != nil {
 		return err
@@ -55,9 +54,13 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(Err, "\nDownloaded to\n")
-	fmt.Fprintf(Out, "%s\n", writer.destination())
+	printDownloadResult(writer.destination())
 	return nil
+}
+
+func printDownloadResult(destination string) {
+	fmt.Fprintf(Err, "\nDownloaded to\n")
+	fmt.Fprintf(Out, "%s\n", destination)
 }
 
 func setupDownloadFlags(flags *pflag.FlagSet) {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -46,7 +46,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	if err != nil {
 		return err
 	}
-	writer := newFileDownloadWriter(download)
+	writer := newDownloadWriter(download)
 	if err := writer.writeSolutionFiles(); err != nil {
 		return err
 	}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -47,16 +47,16 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 
-	if err = download.writer.writeSolutionFiles(); err != nil {
+	writer := newFileDownloadWriter(download)
+	if err := writer.writeSolutionFiles(); err != nil {
 		return err
 	}
-
-	if err := download.writer.writeMetadata(); err != nil {
+	if err := writer.writeMetadata(); err != nil {
 		return err
 	}
 
 	fmt.Fprintf(Err, "\nDownloaded to\n")
-	fmt.Fprintf(Out, "%s\n", download.writer.destination())
+	fmt.Fprintf(Out, "%s\n", writer.destination())
 	return nil
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -42,7 +42,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 
-	download, err := newDownloadFromFlags(cfg.UserViperConfig, flags)
+	download, err := newDownloadFromFlags(flags, cfg.UserViperConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -47,16 +47,16 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 
-	if err = download.writeSolutionFiles(); err != nil {
+	if err = download.writer.writeSolutionFiles(); err != nil {
 		return err
 	}
 
-	if err := download.writeMetadata(); err != nil {
+	if err := download.writer.writeMetadata(); err != nil {
 		return err
 	}
 
 	fmt.Fprintf(Err, "\nDownloaded to\n")
-	fmt.Fprintf(Out, "%s\n", download.destination())
+	fmt.Fprintf(Out, "%s\n", download.writer.destination())
 	return nil
 }
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -252,12 +251,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusBadRequest {
-		var jsonErrBody apiErrorMessage
-		if err := json.NewDecoder(resp.Body).Decode(&jsonErrBody); err != nil {
-			return fmt.Errorf("failed to parse error response - %s", err)
-		}
-
-		return fmt.Errorf(jsonErrBody.Error.Message)
+		return decodedAPIError(resp)
 	}
 
 	bb := &bytes.Buffer{}
@@ -282,11 +276,4 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 
 func init() {
 	RootCmd.AddCommand(submitCmd)
-}
-
-type apiErrorMessage struct {
-	Error struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
 }


### PR DESCRIPTION
These changes are motivated by #744, in which the new `doctor` command needs to download missing metadata for exercises in the workspace. `cmd/download` contained the logic for this but to be usable it needed refactoring; due to the overlapping need for downloading metadata, it makes sense to extract it outside of an individual command and split the download logic into separate functions.