### PR TITLE
Update shell tab completion for exercism cli

### DIFF
--- a/shell/exercism_completion.bash
+++ b/shell/exercism_completion.bash
@@ -5,20 +5,10 @@ _exercism () {
   cur=${COMP_WORDS[COMP_CWORD]}
   prev=${COMP_WORDS[COMP_CWORD-1]}
 
-  commands="configure debug download fetch list open
-  restore skip status submit tracks unsubmit
-  upgrade help"
-  tracks="csharp cpp clojure coffeescript lisp crystal
-  dlang ecmascript elixir elm elisp erlang
-  fsharp go haskell java javascript kotlin
-  lfe lua mips ocaml objective-c php
-  plsql perl5 python racket ruby rust scala
-  scheme swift typescript bash c ceylon
-  coldfusion delphi factor groovy haxe
-  idris julia nim perl6 pony prolog
-  purescript r sml vbnet powershell"
-  config_opts="--dir --host --key --api"
-  submit_opts="--test --comment"
+  commands="configure download open
+  submit troubleshoot upgrade version workspace help"
+  config_opts="--show"
+  version_opts="--latest"
 
   if [ "${#COMP_WORDS[@]}" -eq 2 ]; then
     COMPREPLY=( $( compgen -W  "${commands}" "${cur}" ) )
@@ -31,28 +21,8 @@ _exercism () {
         COMPREPLY=( $( compgen -W "${config_opts}" -- "${cur}" ) )
         return 0
         ;;
-      fetch)
-        COMPREPLY=( $( compgen -W "${tracks}" "${cur}" ) )
-        return 0
-        ;;
-      list)
-        COMPREPLY=( $( compgen -W "${tracks}" "${cur}" ) )
-        return 0
-        ;;
-      open)
-        COMPREPLY=( $( compgen -W "${tracks}" "${cur}" ) )
-        return 0
-        ;;
-      skip)
-        COMPREPLY=( $( compgen -W "${tracks}" "${cur}" ) )
-        return 0
-        ;;
-      status)
-        COMPREPLY=( $( compgen -W "${tracks}" "${cur}" ) )
-        return 0
-        ;;
-      submit)
-        COMPREPLY=( $( compgen -W "${submit_opts}" -- "${cur}" ) )
+      version)
+        COMPREPLY=( $( compgen -W "${version_opts}" -- "${cur}" ) )
         return 0
         ;;
       help)

--- a/shell/exercism_completion.bash
+++ b/shell/exercism_completion.bash
@@ -4,6 +4,7 @@ _exercism () {
   COMPREPLY=()   # Array variable storing the possible completions.
   cur=${COMP_WORDS[COMP_CWORD]}
   prev=${COMP_WORDS[COMP_CWORD-1]}
+  opts="--verbose --timeout"
 
   commands="configure download open
   submit troubleshoot upgrade version workspace help"
@@ -11,8 +12,16 @@ _exercism () {
   version_opts="--latest"
 
   if [ "${#COMP_WORDS[@]}" -eq 2 ]; then
-    COMPREPLY=( $( compgen -W  "${commands}" "${cur}" ) )
-    return 0
+    case "${cur}" in
+      -*)
+        COMPREPLY=( $( compgen -W  "${opts}" -- "${cur}" ) )
+        return 0
+        ;;
+      *)
+        COMPREPLY=( $( compgen -W  "${commands}" "${cur}" ) )
+        return 0
+        ;;
+    esac
   fi
 
   if [ "${#COMP_WORDS[@]}" -eq 3 ]; then

--- a/shell/exercism_completion.zsh
+++ b/shell/exercism_completion.zsh
@@ -3,17 +3,20 @@ _exercism() {
     typeset -A opt_args
 
     local -a options
-    options=(debug:"Outputs useful debug information."
-             configure:"Writes config values to a JSON file."
-             submit:"Submits a new iteration to a problem on exercism.io."
+    options=(configure:"Writes config values to a JSON file."
              download:"Downloads and saves a specified submission into the local system"
+             open:"Opens a browser to exercism.io for the specified submission."
+             submit:"Submits a new iteration to a problem on exercism.io."
+             troubleshoot:"Outputs useful debug information."
+             upgrade:"Upgrades to the latest available version."
+             version:"Outputs version information."
+             workspace:"Outputs the root directory for Exercism exercises."
              help:"Shows a list of commands or help for one command")
 
     _arguments -s -S \
-        {-c,--config}"[path to config file]:file:_files"    \
-        {-d,--debug}"[turn on verbose logging]" \
         {-h,--help}"[show help]"                \
-        {-v,--version}"[print the version]"     \
+        {-t,--timeout}"[override default HTTP timeout]" \
+        {-v,--verbose}"[turn on verbose logging]" \
         '(-): :->command'                       \
         '(-)*:: :->option-or-argument'          \
         && return 0;


### PR DESCRIPTION
### What this does?

The Bash and Zsh tab completion files being shipped with the latest release reference subcommands that no longer exist. This changes updates the shell completion files  with references to all of the implemented commands in Exercism v2.

** Note ** auto Bash completion generation in Cobra was looked into but it appears that Cobra requires a bit of configuration for each command we would want to generate bash completions for so I am going with manual update at this time.
### How to test?

1. Follow the shell completion file install steps outlined [here](https://github.com/exercism/cli/tree/master/shell)
1. Test tab completion for bash or zsh (`exercism <tab>`)
1. Verify list of commands as tab completion options

```zsh
exercism
configure     -- Writes config values to a JSON file.
download      -- Downloads and saves a specified submission into the local system
help          -- Shows a list of commands or help for one command
open          -- Opens a browser to exercism.io for the specified submission.
submit        -- Submits a new iteration to a problem on exercism.io.
troubleshoot  -- Outputs useful debug information.
upgrade       -- Upgrades to the latest available version.
version       -- Outputs version information.
workspace     -- Outputs the root directory for Exercism exercises.
```


resolves #666