### PR TITLE
Avoid 'core' terminology in team context

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -252,7 +252,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
     %s
 `
 	suffix := "View it at:\n\n    "
-	if metadata.AutoApprove {
+	if metadata.AutoApprove && metadata.Team == "" {
 		suffix = "You can complete the exercise and unlock the next core exercise at:\n"
 	}
 	fmt.Fprintf(Err, msg, suffix)


### PR DESCRIPTION
The teams site does not have core exercises.
This will only show the 'core' messaging for auto-approvable exercises on the main site. (Auto-approve only makes sense in the context of core exercises, which block progression).