### PR TITLE
Remove dead code from configure_test

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -82,7 +82,7 @@ func TestConfigureShow(t *testing.T) {
 	assert.NotRegexp(t, "override.example", Err)
 
 	assert.Regexp(t, "configured-token", Err)
-	assert.NotRegexp(t, "token-overrid", Err)
+	assert.NotRegexp(t, "token-override", Err)
 
 	assert.Regexp(t, "configured-workspace", Err)
 	assert.NotRegexp(t, "workspace-override", Err)

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -18,14 +18,6 @@ import (
 )
 
 func TestBareConfigure(t *testing.T) {
-	oldErr := Err
-	defer func() {
-		Err = oldErr
-	}()
-
-	var buf bytes.Buffer
-	Err = &buf
-
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 	setupConfigureFlags(flags)
 
@@ -150,17 +142,12 @@ func TestConfigureToken(t *testing.T) {
 	defer ts.Close()
 
 	oldOut := Out
-	oldErr := Err
 	Out = ioutil.Discard
 	defer func() {
 		Out = oldOut
-		Err = oldErr
 	}()
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
-		Err = &buf
-
 		flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 		setupConfigureFlags(flags)
 
@@ -238,17 +225,12 @@ func TestConfigureAPIBaseURL(t *testing.T) {
 	}
 
 	oldOut := Out
-	oldErr := Err
 	Out = ioutil.Discard
 	defer func() {
 		Out = oldOut
-		Err = oldErr
 	}()
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
-		Err = &buf
-
 		flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 		setupConfigureFlags(flags)
 

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -41,8 +41,7 @@ func TestConfigureShow(t *testing.T) {
 		Err = oldErr
 	}()
 
-	var buf bytes.Buffer
-	Err = &buf
+	Err = &bytes.Buffer{}
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 	setupConfigureFlags(flags)


### PR DESCRIPTION
I was looking at `configure_test` and noticed that several tests have similar setup for spying on stdout/err but in few places it's not actually being cashed out. These changes attempt to remove the dead code.