### PR TITLE
Add test for migration output

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -134,7 +134,7 @@ func runSubmit(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 	if verbose, _ := flags.GetBool("verbose"); verbose {
-		fmt.Fprintf(os.Stderr, migrationStatus.String())
+		fmt.Fprintf(Err, migrationStatus.String())
 	}
 	metadata, err := workspace.NewExerciseMetadata(exerciseDir)
 	if err != nil {


### PR DESCRIPTION
I realized I made a mistake in the past migration PR - these changes attempt to fix it.

Previously printing referenced `os.Stderr` instead of `Err` as done elsewhere.
Having fixed this, it seems fit to verify migration printing output.