### PR TITLE
Fix test failure panics when err is nil

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -32,7 +32,9 @@ func TestBareConfigure(t *testing.T) {
 	}
 
 	err = runConfigure(cfg, flags)
-	assert.Regexp(t, "no token configured", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "no token configured", err.Error())
+	}
 }
 
 func TestConfigureShow(t *testing.T) {
@@ -379,8 +381,9 @@ func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = runConfigure(cfg, flags)
-	assert.Error(t, err)
-	assert.Regexp(t, "already something", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "already something", err.Error())
+	}
 }
 
 func TestConfigureExplicitWorkspaceWithoutClobberingNonDirectory(t *testing.T) {

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -24,8 +24,10 @@ func TestSubmitWithoutToken(t *testing.T) {
 	}
 
 	err := runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
-	assert.Regexp(t, "Welcome to Exercism", err.Error())
-	assert.Regexp(t, "exercism.io/my/settings", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "Welcome to Exercism", err.Error())
+		assert.Regexp(t, "exercism.io/my/settings", err.Error())
+	}
 }
 
 func TestSubmitWithoutWorkspace(t *testing.T) {
@@ -39,7 +41,9 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 	}
 
 	err := runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
-	assert.Regexp(t, "re-run the configure", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "re-run the configure", err.Error())
+	}
 }
 
 func TestSubmitNonExistentFile(t *testing.T) {
@@ -68,7 +72,9 @@ func TestSubmitNonExistentFile(t *testing.T) {
 		filepath.Join(tmpDir, "file-2.txt"),
 	}
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), files)
-	assert.Regexp(t, "cannot be found", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "cannot be found", err.Error())
+	}
 }
 
 func TestSubmitExerciseWithoutMetadataFile(t *testing.T) {
@@ -94,8 +100,9 @@ func TestSubmitExerciseWithoutMetadataFile(t *testing.T) {
 	}
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
-	assert.Error(t, err)
-	assert.Regexp(t, "doesn't have the necessary metadata", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "doesn't have the necessary metadata", err.Error())
+	}
 }
 
 func TestSubmitFilesAndDir(t *testing.T) {
@@ -124,8 +131,10 @@ func TestSubmitFilesAndDir(t *testing.T) {
 		filepath.Join(tmpDir, "file-2.txt"),
 	}
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), files)
-	assert.Regexp(t, "submitting a directory", err.Error())
-	assert.Regexp(t, "Please change into the directory and provide the path to the file\\(s\\) you wish to submit", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "submitting a directory", err.Error())
+		assert.Regexp(t, "Please change into the directory and provide the path to the file\\(s\\) you wish to submit", err.Error())
+	}
 }
 
 func TestSubmitFiles(t *testing.T) {
@@ -339,8 +348,9 @@ func TestSubmitWithEnormousFile(t *testing.T) {
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
 
-	assert.Error(t, err)
-	assert.Regexp(t, "Please reduce the size of the file and try again.", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "Please reduce the size of the file and try again.", err.Error())
+	}
 }
 
 func TestSubmitFilesForTeamExercise(t *testing.T) {
@@ -426,8 +436,9 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	err = ioutil.WriteFile(file, []byte(""), os.FileMode(0755))
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
-	assert.Error(t, err)
-	assert.Regexp(t, "No files found", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "No files found", err.Error())
+	}
 }
 
 func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
@@ -462,8 +473,9 @@ func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
 	}
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file1, file2})
-	assert.Error(t, err)
-	assert.Regexp(t, "different solutions", err.Error())
+	if assert.Error(t, err) {
+		assert.Regexp(t, "different solutions", err.Error())
+	}
 }
 
 func fakeSubmitServer(t *testing.T, submittedFiles map[string]string) *httptest.Server {


### PR DESCRIPTION
Currently several tests use `assert.Regexp(.. err.Error())` where err is
unchecked. If there is no error (it's nil) then the tests blow up and we
don't get a useful failure message.