### PR TITLE
Fix Travis failing golang/dep install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ go:
   - tip
 
 install:
-  - go get -u github.com/golang/dep/...
+  - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
 
 script:
   - ./.travis.gofmt.sh
   - go test -cover ./...
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ go:
   - tip
 
 install:
-  - go get -u github.com/golang/dep/cmd/dep
+  - go get -u github.com/golang/dep/...
   - dep ensure
 
 script:
   - ./.travis.gofmt.sh
   - go test -cover ./...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ go:
   - tip
 
 install:
-  - go get -u github.com/golang/dep/cmd/dep
+  # install dep
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - dep ensure
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ go:
   - tip
 
 install:
-  # install dep
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - go get -u github.com/golang/dep/cmd/dep
   - dep ensure
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 script:
   - ./.travis.gofmt.sh
   - go test -cover ./...
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - echo %GOPATH%
   - go version
   - go env
-  - go get -u github.com/golang/dep/cmd/dep
+  - go get -u github.com/golang/dep/...
   - c:\gopath\bin\dep.exe ensure
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - echo %GOPATH%
   - go version
   - go env
-  - go get -u github.com/golang/dep/...
+  - go get -u github.com/golang/dep/cmd/dep
   - c:\gopath\bin\dep.exe ensure
 
 build_script:


### PR DESCRIPTION
Closes #781 

It seems there are a couple of potential fixes involving changing how `dep` gets installed:

1. `go get -u github.com/golang/dep/cmd/dep` - see https://github.com/exercism/cli/pull/782/commits/5b8988f6aacc39e8c236f5cbb3da708313ea91a3 

2. Install via github releases via golang/dep [install script](https://github.com/golang/dep/blob/master/install.sh) - see https://github.com/exercism/cli/pull/782/commits/9b1321104c8117879195a233562ac5a75926b3a3

https://golang.github.io/dep/docs/installation.html recommends using releases for stability but I'm not sure how workable that is with the AppVeyor install. It seems like a bad idea to have `dep` install versions differ for Travis vs AppVeyor; on the hand, it seems that `dep` might be more prone to similar failures in the future by not using a release.