### PR TITLE
Silence noisy output in cmd tests

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,8 +20,6 @@ var (
 	Out io.Writer
 	// Err is used to write errors.
 	Err io.Writer
-	// In is used to provide mocked test input (i.e. for prompts).
-	In io.Reader
 )
 
 const msgWelcomePleaseConfigure = `

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,8 +3,25 @@ package cmd
 import (
 	"fmt"
 
+	"io"
+
 	"github.com/exercism/cli/config"
 	"github.com/spf13/viper"
+)
+
+var (
+	// BinaryName is the name of the app.
+	// By default this is exercism, but people
+	// are free to name this however they want.
+	// The usage examples and help strings should reflect
+	// the actual name of the binary.
+	BinaryName string
+	// Out is used to write to information.
+	Out io.Writer
+	// Err is used to write errors.
+	Err io.Writer
+	// In is used to provide mocked test input (i.e. for prompts).
+	In io.Reader
 )
 
 const msgWelcomePleaseConfigure = `

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -89,4 +90,31 @@ func (test *CommandTest) Teardown(t *testing.T) {
 	if err := os.RemoveAll(test.TmpDir); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// capturedOutput lets us more easily redirect streams in the tests.
+type capturedOutput struct {
+	oldOut, oldErr, newOut, newErr io.Writer
+}
+
+// newCapturedOutput creates a new value to override the streams.
+func newCapturedOutput() capturedOutput {
+	return capturedOutput{
+		oldOut: Out,
+		oldErr: Err,
+		newOut: ioutil.Discard,
+		newErr: ioutil.Discard,
+	}
+}
+
+// override sets the package variables to the fake streams.
+func (co capturedOutput) override() {
+	Out = co.newOut
+	Err = co.newErr
+}
+
+// reset puts back the original streams for the commands to write to.
+func (co capturedOutput) reset() {
+	Out = co.oldOut
+	Err = co.oldErr
 }

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -38,12 +38,10 @@ func TestBareConfigure(t *testing.T) {
 }
 
 func TestConfigureShow(t *testing.T) {
-	oldErr := Err
-	defer func() {
-		Err = oldErr
-	}()
-
-	Err = &bytes.Buffer{}
+	co := newCapturedOutput()
+	co.newErr = &bytes.Buffer{}
+	co.override()
+	defer co.reset()
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 	setupConfigureFlags(flags)
@@ -82,6 +80,10 @@ func TestConfigureShow(t *testing.T) {
 }
 
 func TestConfigureToken(t *testing.T) {
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
+
 	testCases := []struct {
 		desc       string
 		configured string
@@ -142,12 +144,6 @@ func TestConfigureToken(t *testing.T) {
 	ts := httptest.NewServer(endpoint)
 	defer ts.Close()
 
-	oldOut := Out
-	Out = ioutil.Discard
-	defer func() {
-		Out = oldOut
-	}()
-
 	for _, tc := range testCases {
 		flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 		setupConfigureFlags(flags)
@@ -173,6 +169,10 @@ func TestConfigureToken(t *testing.T) {
 }
 
 func TestConfigureAPIBaseURL(t *testing.T) {
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
+
 	endpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ping" {
 			w.WriteHeader(http.StatusNotFound)
@@ -225,12 +225,6 @@ func TestConfigureAPIBaseURL(t *testing.T) {
 		},
 	}
 
-	oldOut := Out
-	Out = ioutil.Discard
-	defer func() {
-		Out = oldOut
-	}()
-
 	for _, tc := range testCases {
 		flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
 		setupConfigureFlags(flags)
@@ -256,11 +250,9 @@ func TestConfigureAPIBaseURL(t *testing.T) {
 }
 
 func TestConfigureWorkspace(t *testing.T) {
-	oldErr := Err
-	Err = ioutil.Discard
-	defer func() {
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	testCases := []struct {
 		desc       string
@@ -342,14 +334,9 @@ func TestConfigureWorkspace(t *testing.T) {
 }
 
 func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	// Stub server to always be 200 OK
 	endpoint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
@@ -387,14 +374,9 @@ func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
 }
 
 func TestConfigureExplicitWorkspaceWithoutClobberingNonDirectory(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	tmpDir, err := ioutil.TempDir("", "no-clobber")
 	defer os.RemoveAll(tmpDir)

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -78,14 +78,9 @@ func TestDownloadWithoutFlags(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	testCases := []struct {
 		requester   bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 
@@ -11,21 +10,6 @@ import (
 	"github.com/exercism/cli/config"
 	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
-)
-
-var (
-	// BinaryName is the name of the app.
-	// By default this is exercism, but people
-	// are free to name this however they want.
-	// The usage examples and help strings should reflect
-	// the actual name of the binary.
-	BinaryName string
-	// Out is used to write to information.
-	Out io.Writer
-	// Err is used to write errors.
-	Err io.Writer
-	// In is used to provide mocked test input (i.e. for prompts).
-	In io.Reader
 )
 
 // RootCmd represents the base command when called without any subcommands.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,6 @@ func init() {
 	config.SetDefaultDirName(BinaryName)
 	Out = os.Stdout
 	Err = os.Stderr
-	In = os.Stdin
 	api.UserAgent = fmt.Sprintf("github.com/exercism/cli v%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().IntP("timeout", "", 0, "override the default HTTP timeout (seconds)")

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -15,14 +15,9 @@ import (
 )
 
 func TestSubmitFilesInSymlinkedPath(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -142,14 +142,10 @@ func TestSubmitFilesAndDir(t *testing.T) {
 }
 
 func TestSubmitFiles(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
+
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}
 	ts := fakeSubmitServer(t, submittedFiles)
@@ -201,11 +197,10 @@ func TestSubmitFiles(t *testing.T) {
 }
 
 func TestLegacyMetadataMigration(t *testing.T) {
-	oldErr := Err
-	defer func() {
-		Err = oldErr
-	}()
-	Err = &bytes.Buffer{}
+	co := newCapturedOutput()
+	co.newErr = &bytes.Buffer{}
+	co.override()
+	defer co.reset()
 
 	submittedFiles := map[string]string{}
 	ts := fakeSubmitServer(t, submittedFiles)
@@ -265,14 +260,9 @@ func TestLegacyMetadataMigration(t *testing.T) {
 }
 
 func TestSubmitWithEmptyFile(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}
@@ -311,14 +301,9 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 }
 
 func TestSubmitWithEnormousFile(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}
@@ -358,14 +343,10 @@ func TestSubmitWithEnormousFile(t *testing.T) {
 }
 
 func TestSubmitFilesForTeamExercise(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
+
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}
 	ts := fakeSubmitServer(t, submittedFiles)
@@ -409,14 +390,9 @@ func TestSubmitFilesForTeamExercise(t *testing.T) {
 }
 
 func TestSubmitOnlyEmptyFile(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	tmpDir, err := ioutil.TempDir("", "just-an-empty-file")
 	defer os.RemoveAll(tmpDir)
@@ -512,14 +488,10 @@ func fakeSubmitServer(t *testing.T, submittedFiles map[string]string) *httptest.
 }
 
 func TestSubmitRelativePath(t *testing.T) {
-	oldOut := Out
-	oldErr := Err
-	Out = ioutil.Discard
-	Err = ioutil.Discard
-	defer func() {
-		Out = oldOut
-		Err = oldErr
-	}()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
+
 	// The fake endpoint will populate this when it receives the call from the command.
 	submittedFiles := map[string]string{}
 	ts := fakeSubmitServer(t, submittedFiles)

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,9 +21,9 @@ func (fc *fakeCLI) Upgrade() error {
 }
 
 func TestUpgrade(t *testing.T) {
-	oldOut := Out
-	Out = ioutil.Discard
-	defer func() { Out = oldOut }()
+	co := newCapturedOutput()
+	co.override()
+	defer co.reset()
 
 	testCases := []struct {
 		desc     string


### PR DESCRIPTION
If you run the tests for just the `cmd` package from within the `cmd` directory on master, the output is very noisy:

```
You have configured the Exercism command-line client:

Config dir:                       
Token:         (-t, --token)      existing-token
Workspace:     (-w, --workspace)  
API Base URL:  (-a, --api)        http://127.0.0.1:57279


You have configured the Exercism command-line client:

Config dir:                       
Token:         (-t, --token)      a-token
Workspace:     (-w, --workspace)  
API Base URL:  (-a, --api)        http://127.0.0.1:57279


You have configured the Exercism command-line client:

Config dir:                       
Token:         (-t, --token)      replacement-token
Workspace:     (-w, --workspace)  
API Base URL:  (-a, --api)        http://127.0.0.1:57279

    http://example.com/bogus-url

PASS
ok  	github.com/exercism/cli/cmd	0.189s
```

This is because we typically write to both the `Out` and the `Err` stream, but often were only overwriting one of them in the tests.

This sets up a helper struct to make it easier to setup and reset the overrides correctly, and then uses it across the board, which silences the test output.