### PR TITLE
Submit handles non 2xx responses

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -268,12 +267,8 @@ func (s *submitCmdContext) submit(metadata *workspace.ExerciseMetadata, docs []w
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusBadRequest {
-		return decodedAPIError(resp)
-	}
-
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return fmt.Errorf("submission unsuccessful (%s)", resp.Status)
+		return decodedAPIError(resp)
 	}
 
 	bb := &bytes.Buffer{}

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -272,6 +272,10 @@ func (s *submitCmdContext) submit(metadata *workspace.ExerciseMetadata, docs []w
 		return decodedAPIError(resp)
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("submission unsuccessful (%s)", resp.Status)
+	}
+
 	bb := &bytes.Buffer{}
 	_, err = bb.ReadFrom(resp.Body)
 	if err != nil {

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -611,7 +611,7 @@ func TestSubmitServerErr(t *testing.T) {
 	assert.Regexp(t, "test error", err.Error())
 }
 
-func TestHandle404Response(t *testing.T) {
+func TestHandleErrorResponse(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)
 	})
@@ -646,10 +646,9 @@ func TestHandle404Response(t *testing.T) {
 	}
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), files)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "unsuccessful")
-	}
+	assert.Error(t, err)
 }
+
 func TestSubmissionNotConnectedToRequesterAccount(t *testing.T) {
 	submittedFiles := map[string]string{}
 	ts := fakeSubmitServer(t, submittedFiles)


### PR DESCRIPTION
Previously, 404s silently continue to misleading success output. This change throws an error for all non 2xx responses.

Closes #790.