### PR TITLE
Fix panic when submit not given args

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -290,6 +290,9 @@ type submitValidator struct {
 
 // filesExistAndNotADir checks that each file exists and is not a directory.
 func (s submitValidator) filesExistAndNotADir(submitPaths []string) error {
+	if len(submitPaths) == 0 {
+		return fmt.Errorf("usage: %s submit FILE1 [FILE2 ...]", BinaryName)
+	}
 	for _, path := range submitPaths {
 		path, err := filepath.Abs(path)
 		if err != nil {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -28,6 +28,7 @@ var submitCmd = &cobra.Command{
 
     Call the command with the list of files you want to submit.
 `,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.NewConfig()
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -290,9 +290,6 @@ type submitValidator struct {
 
 // filesExistAndNotADir checks that each file exists and is not a directory.
 func (s submitValidator) filesExistAndNotADir(submitPaths []string) error {
-	if len(submitPaths) == 0 {
-		return fmt.Errorf("usage: %s submit FILE1 [FILE2 ...]", BinaryName)
-	}
 	for _, path := range submitPaths {
 		path, err := filepath.Abs(path)
 		if err != nil {

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -47,30 +47,6 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 	}
 }
 
-func TestSubmitWithoutArgs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "submit-no-args")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
-
-	v := viper.New()
-	v.Set("token", "abc123")
-	v.Set("workspace", tmpDir)
-	v.Set("apibaseurl", "http://api.example.com")
-
-	cfg := config.Config{
-		Persister:       config.InMemoryPersister{},
-		UserViperConfig: v,
-		DefaultBaseURL:  "http://example.com",
-	}
-
-	var noCLIArguments []string
-
-	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), noCLIArguments)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "usage")
-	}
-}
-
 func TestSubmitNonExistentFile(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
 	defer os.RemoveAll(tmpDir)

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -47,6 +47,30 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 	}
 }
 
+func TestSubmitWithoutArgs(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "submit-no-args")
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+	v.Set("apibaseurl", "http://api.example.com")
+
+	cfg := config.Config{
+		Persister:       config.InMemoryPersister{},
+		UserViperConfig: v,
+		DefaultBaseURL:  "http://example.com",
+	}
+
+	var noCLIArguments []string
+
+	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), noCLIArguments)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "usage")
+	}
+}
+
 func TestSubmitNonExistentFile(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
Currently, submit panics when run without args (i.e., `exercism submit`) due to attempting to index
an empty slice:

    exercise, err := ctx.exercise(submitPaths[0])