### PR TITLE
Make zsh completion work on $fpath.

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -17,15 +17,17 @@ adding the following snippet:
 
 ### Zsh
 
+Load up the completion by placing the `exercism_completion.zsh` somewhere on
+your `$fpath` as `_exercism`. For example:
+
     mkdir -p ~/.config/exercism
-    mv ../shell/exercism_completion.zsh ~/.config/exercism/exercism_completion.zsh
+    mv ../shell/exercism_completion.zsh ~/.config/exercism/_exercism
 
-Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding
-the following snippet
+and then add the directory to your `$fpath` in your `.zshrc`, `.zsh_profile` or
+`.profile` before running `compinit`:
 
-    if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
-      source ~/.config/exercism/exercism_completion.zsh
-    fi
+    export fpath=(~/.config/exercism $fpath)
+    autoload -U compinit && compinit
 
 
 #### Oh my Zsh

--- a/shell/README.md
+++ b/shell/README.md
@@ -20,13 +20,13 @@ adding the following snippet:
 Load up the completion by placing the `exercism_completion.zsh` somewhere on
 your `$fpath` as `_exercism`. For example:
 
-    mkdir -p ~/.config/exercism
-    mv ../shell/exercism_completion.zsh ~/.config/exercism/_exercism
+    mkdir -p ~/.zsh/functions
+    mv ../shell/exercism_completion.zsh ~/.zsh/functions/_exercism
 
 and then add the directory to your `$fpath` in your `.zshrc`, `.zsh_profile` or
 `.profile` before running `compinit`:
 
-    export fpath=(~/.config/exercism $fpath)
+    export fpath=(~/.zsh/functions $fpath)
     autoload -U compinit && compinit
 
 
@@ -39,4 +39,3 @@ If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-z
 Completions must go in the user defined `$fish_complete_path`. By default, this is `~/.config/fish/completions`
 
     mv ../shell/exercism.fish ~/.config/fish/exercism.fish
-

--- a/shell/exercism_completion.zsh
+++ b/shell/exercism_completion.zsh
@@ -1,38 +1,34 @@
 #compdef exercism
 
-_exercism() {
-    local curcontext="$curcontext" state line
-    typeset -A opt_args
+local curcontext="$curcontext" state line
+typeset -A opt_args
 
-    local -a options
-    options=(configure:"Writes config values to a JSON file."
-             download:"Downloads and saves a specified submission into the local system"
-             open:"Opens a browser to exercism.io for the specified submission."
-             submit:"Submits a new iteration to a problem on exercism.io."
-             troubleshoot:"Outputs useful debug information."
-             upgrade:"Upgrades to the latest available version."
-             version:"Outputs version information."
-             workspace:"Outputs the root directory for Exercism exercises."
-             help:"Shows a list of commands or help for one command")
+local -a options
+options=(configure:"Writes config values to a JSON file."
+         download:"Downloads and saves a specified submission into the local system"
+         open:"Opens a browser to exercism.io for the specified submission."
+         submit:"Submits a new iteration to a problem on exercism.io."
+         troubleshoot:"Outputs useful debug information."
+         upgrade:"Upgrades to the latest available version."
+         version:"Outputs version information."
+         workspace:"Outputs the root directory for Exercism exercises."
+         help:"Shows a list of commands or help for one command")
 
-    _arguments -s -S \
-        {-h,--help}"[show help]"                \
-        {-t,--timeout}"[override default HTTP timeout]" \
-        {-v,--verbose}"[turn on verbose logging]" \
-        '(-): :->command'                       \
-        '(-)*:: :->option-or-argument'          \
-        && return 0;
+_arguments -s -S \
+    {-h,--help}"[show help]"                \
+    {-t,--timeout}"[override default HTTP timeout]" \
+    {-v,--verbose}"[turn on verbose logging]" \
+    '(-): :->command'                       \
+    '(-)*:: :->option-or-argument'          \
+    && return 0;
 
-    case $state in
-        (command)
-            _describe 'commands' options ;;
-        (option-or-argument)
-            case $words[1] in
-                s*)
-                    _files
-                    ;;
-            esac
-    esac
-}
-
-_exercism "$@"
+case $state in
+    (command)
+        _describe 'commands' options ;;
+    (option-or-argument)
+        case $words[1] in
+            s*)
+                _files
+                ;;
+        esac
+esac

--- a/shell/exercism_completion.zsh
+++ b/shell/exercism_completion.zsh
@@ -1,3 +1,5 @@
+#compdef exercism
+
 _exercism() {
     local curcontext="$curcontext" state line
     typeset -A opt_args
@@ -33,4 +35,4 @@ _exercism() {
     esac
 }
 
-compdef '_exercism' exercism
+_exercism "$@"


### PR DESCRIPTION
This allows the file to be placed, e.g., in a system-wide `site-functions` directory and just work automatically.

Now, I don't use zsh personally, but I tried to copy what the fd, ripgrep, and restic packages do, and also the [beginning of these zsh-completion instructions](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#telling-zsh-which-function-to-use-for-completing-a-command). I tested it out both system-wide, and user-only (with the instructions here), and it works. I don't know if the oh-my-zsh instructions are correct though.