### PR TITLE
Extract API error logic to helper

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -254,12 +253,7 @@ func (s *submitCmdContext) submit(metadata *workspace.ExerciseMetadata, docs []w
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusBadRequest {
-		var jsonErrBody apiErrorMessage
-		if err := json.NewDecoder(resp.Body).Decode(&jsonErrBody); err != nil {
-			return fmt.Errorf("failed to parse error response - %s", err)
-		}
-
-		return fmt.Errorf(jsonErrBody.Error.Message)
+		return decodedAPIError(resp)
 	}
 
 	bb := &bytes.Buffer{}
@@ -429,11 +423,4 @@ func (s submitValidator) isRequestor(metadata *workspace.ExerciseMetadata) error
 
 func init() {
 	RootCmd.AddCommand(submitCmd)
-}
-
-type apiErrorMessage struct {
-	Error struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
 }


### PR DESCRIPTION
The submit command handles API errors correctly.

We need to be able to share this logic so we can stop swallowing errors in other commands.

This adds a default error message that we can fall back to if the API doesn't return a `message`.

This change was made by @jdsutherland as part of https://github.com/exercism/cli/pull/756.