### PR TITLE
Rename Exercise field on metadata type

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -130,14 +130,14 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 
 	metadata := workspace.ExerciseMetadata{
-		AutoApprove: payload.Solution.Exercise.AutoApprove,
-		Track:       payload.Solution.Exercise.Track.ID,
-		Team:        payload.Solution.Team.Slug,
-		Exercise:    payload.Solution.Exercise.ID,
-		ID:          payload.Solution.ID,
-		URL:         payload.Solution.URL,
-		Handle:      payload.Solution.User.Handle,
-		IsRequester: payload.Solution.User.IsRequester,
+		AutoApprove:  payload.Solution.Exercise.AutoApprove,
+		Track:        payload.Solution.Exercise.Track.ID,
+		Team:         payload.Solution.Team.Slug,
+		ExerciseSlug: payload.Solution.Exercise.ID,
+		ID:           payload.Solution.ID,
+		URL:          payload.Solution.URL,
+		Handle:       payload.Solution.User.Handle,
+		IsRequester:  payload.Solution.User.IsRequester,
 	}
 
 	root := usrCfg.GetString("workspace")
@@ -151,7 +151,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	exercise := workspace.Exercise{
 		Root:  root,
 		Track: metadata.Track,
-		Slug:  metadata.Exercise,
+		Slug:  metadata.ExerciseSlug,
 	}
 
 	dir := exercise.MetadataDir()
@@ -201,7 +201,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		// Work around a path bug due to an early design decision (later reversed) to
 		// allow numeric suffixes for exercise directories, allowing people to have
 		// multiple parallel versions of an exercise.
-		pattern := fmt.Sprintf(`\A.*[/\\]%s-\d*/`, metadata.Exercise)
+		pattern := fmt.Sprintf(`\A.*[/\\]%s-\d*/`, metadata.ExerciseSlug)
 		rgxNumericSuffix := regexp.MustCompile(pattern)
 		if rgxNumericSuffix.MatchString(file) {
 			file = string(rgxNumericSuffix.ReplaceAll([]byte(file), []byte("")))

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -144,7 +144,7 @@ func TestDownload(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, "bogus-track", metadata.Track)
-		assert.Equal(t, "bogus-exercise", metadata.Exercise)
+		assert.Equal(t, "bogus-exercise", metadata.ExerciseSlug)
 		assert.Equal(t, tc.requester, metadata.IsRequester)
 	}
 }

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -389,7 +389,7 @@ func (s submitValidator) submissionNotEmpty(docs []workspace.Document) error {
 
 // metadataMatchesExercise checks that the metadata refers to the exercise being submitted.
 func (s submitValidator) metadataMatchesExercise(metadata *workspace.ExerciseMetadata, exercise workspace.Exercise) error {
-	if metadata.Exercise != exercise.Slug {
+	if metadata.ExerciseSlug != exercise.Slug {
 		// TODO: error msg should suggest running future doctor command
 		msg := `
 
@@ -400,7 +400,7 @@ func (s submitValidator) metadataMatchesExercise(metadata *workspace.ExerciseMet
     Please rename the directory '%[1]s' to '%[2]s' and try again.
 
         `
-		return fmt.Errorf(msg, exercise.Slug, metadata.Exercise)
+		return fmt.Errorf(msg, exercise.Slug, metadata.ExerciseSlug)
 	}
 	return nil
 }
@@ -416,7 +416,7 @@ func (s submitValidator) isRequestor(metadata *workspace.ExerciseMetadata) error
         %s download --exercise=%s --track=%s
 
         `
-		return fmt.Errorf(msg, BinaryName, metadata.Exercise, metadata.Track)
+		return fmt.Errorf(msg, BinaryName, metadata.ExerciseSlug, metadata.Track)
 	}
 	return nil
 }

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -218,11 +218,11 @@ func TestLegacyMetadataMigration(t *testing.T) {
 	os.MkdirAll(dir, os.FileMode(0755))
 
 	metadata := &workspace.ExerciseMetadata{
-		ID:          "bogus-solution-uuid",
-		Track:       "bogus-track",
-		Exercise:    "bogus-exercise",
-		URL:         "http://example.com/bogus-url",
-		IsRequester: true,
+		ID:           "bogus-solution-uuid",
+		Track:        "bogus-track",
+		ExerciseSlug: "bogus-exercise",
+		URL:          "http://example.com/bogus-url",
+		IsRequester:  true,
 	}
 	b, err := json.Marshal(metadata)
 	assert.NoError(t, err)
@@ -585,11 +585,11 @@ func TestSubmissionNotConnectedToRequesterAccount(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 
 	metadata := &workspace.ExerciseMetadata{
-		ID:          "bogus-solution-uuid",
-		Track:       "bogus-track",
-		Exercise:    "bogus-exercise",
-		URL:         "http://example.com/bogus-url",
-		IsRequester: false,
+		ID:           "bogus-solution-uuid",
+		Track:        "bogus-track",
+		ExerciseSlug: "bogus-exercise",
+		URL:          "http://example.com/bogus-url",
+		IsRequester:  false,
 	}
 	err = metadata.Write(dir)
 	assert.NoError(t, err)
@@ -651,11 +651,11 @@ func TestExerciseDirnameMatchesMetadataSlug(t *testing.T) {
 
 func writeFakeMetadata(t *testing.T, dir, trackID, exerciseSlug string) {
 	metadata := &workspace.ExerciseMetadata{
-		ID:          "bogus-solution-uuid",
-		Track:       trackID,
-		Exercise:    exerciseSlug,
-		URL:         "http://example.com/bogus-url",
-		IsRequester: true,
+		ID:           "bogus-solution-uuid",
+		Track:        trackID,
+		ExerciseSlug: exerciseSlug,
+		URL:          "http://example.com/bogus-url",
+		IsRequester:  true,
 	}
 	err := metadata.Write(dir)
 	assert.NoError(t, err)

--- a/workspace/exercise_metadata.go
+++ b/workspace/exercise_metadata.go
@@ -18,16 +18,16 @@ var metadataFilepath = filepath.Join(ignoreSubdir, metadataFilename)
 
 // ExerciseMetadata contains metadata about a user's exercise.
 type ExerciseMetadata struct {
-	Track       string     `json:"track"`
-	Exercise    string     `json:"exercise"`
-	ID          string     `json:"id"`
-	Team        string     `json:"team,omitempty"`
-	URL         string     `json:"url"`
-	Handle      string     `json:"handle"`
-	IsRequester bool       `json:"is_requester"`
-	SubmittedAt *time.Time `json:"submitted_at,omitempty"`
-	Dir         string     `json:"-"`
-	AutoApprove bool       `json:"auto_approve"`
+	Track        string     `json:"track"`
+	ExerciseSlug string     `json:"exercise"`
+	ID           string     `json:"id"`
+	Team         string     `json:"team,omitempty"`
+	URL          string     `json:"url"`
+	Handle       string     `json:"handle"`
+	IsRequester  bool       `json:"is_requester"`
+	SubmittedAt  *time.Time `json:"submitted_at,omitempty"`
+	Dir          string     `json:"-"`
+	AutoApprove  bool       `json:"auto_approve"`
 }
 
 // NewExerciseMetadata reads exercise metadata from a file in the given directory.
@@ -48,11 +48,11 @@ func NewExerciseMetadata(dir string) (*ExerciseMetadata, error) {
 // This is appended to avoid name conflicts, and does not indicate a particular
 // iteration.
 func (em *ExerciseMetadata) Suffix() string {
-	return strings.Trim(strings.Replace(filepath.Base(em.Dir), em.Exercise, "", 1), "-.")
+	return strings.Trim(strings.Replace(filepath.Base(em.Dir), em.ExerciseSlug, "", 1), "-.")
 }
 
 func (em *ExerciseMetadata) String() string {
-	str := fmt.Sprintf("%s/%s", em.Track, em.Exercise)
+	str := fmt.Sprintf("%s/%s", em.Track, em.ExerciseSlug)
 	if em.Suffix() != "" {
 		str = fmt.Sprintf("%s (%s)", str, em.Suffix())
 	}

--- a/workspace/exercise_metadata_test.go
+++ b/workspace/exercise_metadata_test.go
@@ -15,13 +15,13 @@ func TestExerciseMetadata(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	em1 := &ExerciseMetadata{
-		Track:       "a-track",
-		Exercise:    "bogus-exercise",
-		ID:          "abc",
-		URL:         "http://example.com",
-		Handle:      "alice",
-		IsRequester: true,
-		Dir:         dir,
+		Track:        "a-track",
+		ExerciseSlug: "bogus-exercise",
+		ID:           "abc",
+		URL:          "http://example.com",
+		Handle:       "alice",
+		IsRequester:  true,
+		Dir:          dir,
 	}
 	err = em1.Write(dir)
 	assert.NoError(t, err)
@@ -49,29 +49,29 @@ func TestSuffix(t *testing.T) {
 	}{
 		{
 			metadata: ExerciseMetadata{
-				Exercise: "bat",
-				Dir:      "",
+				ExerciseSlug: "bat",
+				Dir:          "",
 			},
 			suffix: "",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Exercise: "bat",
-				Dir:      "/path/to/bat",
+				ExerciseSlug: "bat",
+				Dir:          "/path/to/bat",
 			},
 			suffix: "",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Exercise: "bat",
-				Dir:      "/path/to/bat-2",
+				ExerciseSlug: "bat",
+				Dir:          "/path/to/bat-2",
 			},
 			suffix: "2",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Exercise: "bat",
-				Dir:      "/path/to/bat-200",
+				ExerciseSlug: "bat",
+				Dir:          "/path/to/bat-200",
 			},
 			suffix: "200",
 		},
@@ -92,48 +92,48 @@ func TestExerciseMetadataString(t *testing.T) {
 	}{
 		{
 			metadata: ExerciseMetadata{
-				Track:    "elixir",
-				Exercise: "secret-handshake",
-				Handle:   "",
-				Dir:      "",
+				Track:        "elixir",
+				ExerciseSlug: "secret-handshake",
+				Handle:       "",
+				Dir:          "",
 			},
 			desc: "elixir/secret-handshake",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Track:       "cpp",
-				Exercise:    "clock",
-				Handle:      "alice",
-				IsRequester: true,
+				Track:        "cpp",
+				ExerciseSlug: "clock",
+				Handle:       "alice",
+				IsRequester:  true,
 			},
 			desc: "cpp/clock",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Track:       "cpp",
-				Exercise:    "clock",
-				Handle:      "alice",
-				IsRequester: true,
-				Dir:         "/path/to/clock-2",
+				Track:        "cpp",
+				ExerciseSlug: "clock",
+				Handle:       "alice",
+				IsRequester:  true,
+				Dir:          "/path/to/clock-2",
 			},
 			desc: "cpp/clock (2)",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Track:       "fsharp",
-				Exercise:    "hello-world",
-				Handle:      "bob",
-				IsRequester: false,
+				Track:        "fsharp",
+				ExerciseSlug: "hello-world",
+				Handle:       "bob",
+				IsRequester:  false,
 			},
 			desc: "fsharp/hello-world by @bob",
 		},
 		{
 			metadata: ExerciseMetadata{
-				Track:       "haskell",
-				Exercise:    "allergies",
-				Handle:      "charlie",
-				IsRequester: false,
-				Dir:         "/path/to/allergies-2",
+				Track:        "haskell",
+				ExerciseSlug: "allergies",
+				Handle:       "charlie",
+				IsRequester:  false,
+				Dir:          "/path/to/allergies-2",
 			},
 			desc: "haskell/allergies (2) by @charlie",
 		},


### PR DESCRIPTION
We are going to want to move some behavior onto the ExerciseMetadata type,
and the naming is going to crash.

ExerciseSlug, while more verbose, is also more correct.

This is a straight-up rename, so if it compiles we're good.

Inspired by work that @jdsutherland did in #756 