### PR TITLE
Move some logic out of download command into exercise metadata type

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -130,22 +130,7 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 
 	metadata := payload.metadata()
-
-	root := usrCfg.GetString("workspace")
-	if metadata.Team != "" {
-		root = filepath.Join(root, "teams", metadata.Team)
-	}
-	if !metadata.IsRequester {
-		root = filepath.Join(root, "users", metadata.Handle)
-	}
-
-	exercise := workspace.Exercise{
-		Root:  root,
-		Track: metadata.Track,
-		Slug:  metadata.ExerciseSlug,
-	}
-
-	dir := exercise.MetadataDir()
+	dir := metadata.Exercise(usrCfg.GetString("workspace")).MetadataDir()
 
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		return err

--- a/workspace/exercise_metadata.go
+++ b/workspace/exercise_metadata.go
@@ -87,3 +87,23 @@ func (em *ExerciseMetadata) PathToParent() string {
 	}
 	return filepath.Join(dir, em.Track)
 }
+
+// Exercise is an implementation of a problem on disk.
+func (em *ExerciseMetadata) Exercise(workspace string) Exercise {
+	return Exercise{
+		Root:  em.root(workspace),
+		Track: em.Track,
+		Slug:  em.ExerciseSlug,
+	}
+}
+
+// root represents the root of the exercise.
+func (em *ExerciseMetadata) root(workspace string) string {
+	if em.Team != "" {
+		return filepath.Join(workspace, "teams", em.Team)
+	}
+	if !em.IsRequester {
+		return filepath.Join(workspace, "users", em.Handle)
+	}
+	return workspace
+}


### PR DESCRIPTION
This is a tiny refactoring that helps get some of the nitty gritty details out of the download flow, and into the `ExerciseMetadata` type. This seems fairly cohesive, since it relies mostly on data from the ExerciseMetadata value anyhow.

This is inspired by changes made by @jdsutherland in https://github.com/exercism/cli/pull/756