### PR TITLE
Extract download client from download command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"io"
 
+	"github.com/exercism/cli/api"
 	"github.com/exercism/cli/config"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -89,4 +92,116 @@ func decodedAPIError(resp *http.Response) error {
 		return fmt.Errorf(apiError.Error.Message)
 	}
 	return fmt.Errorf("unexpected API response: %d", resp.StatusCode)
+}
+
+type downloadClient struct {
+	flags  *pflag.FlagSet
+	usrCfg *viper.Viper
+	uuid   string
+	slug   string
+	track  string
+	team   string
+}
+
+func newDownloadClient(flags *pflag.FlagSet, usrCfg *viper.Viper) *downloadClient {
+	return &downloadClient{
+		flags:  flags,
+		usrCfg: usrCfg,
+	}
+}
+
+func (dlc *downloadClient) Do() (*http.Response, error) {
+	if err := dlc.validateInput(); err != nil {
+		return nil, err
+	}
+
+	client, err := api.NewClient(dlc.usrCfg.GetString("token"), dlc.usrCfg.GetString("apibaseurl"))
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := dlc.url()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req = dlc.encodeQueryParams(req)
+
+	return client.Do(req)
+}
+
+func (dlc *downloadClient) validateInput() error {
+	uuid, err := dlc.flags.GetString("uuid")
+	if err != nil {
+		return err
+	}
+	dlc.uuid = uuid
+
+	slug, err := dlc.flags.GetString("exercise")
+	if err != nil {
+		return err
+	}
+	dlc.slug = slug
+
+	track, err := dlc.flags.GetString("track")
+	if err != nil {
+		return err
+	}
+	dlc.track = track
+
+	team, err := dlc.flags.GetString("team")
+	if err != nil {
+		return err
+	}
+	dlc.team = team
+
+	if uuid != "" && slug != "" || uuid == slug {
+		return errors.New("need an --exercise name or a solution --uuid")
+	}
+	return nil
+}
+
+func (dlc downloadClient) url() (string, error) {
+	identifier := "latest"
+	if dlc.uuid != "" {
+		identifier = dlc.uuid
+	}
+	return fmt.Sprintf("%s/solutions/%s", dlc.usrCfg.GetString("apibaseurl"), identifier), nil
+}
+
+func (dlc *downloadClient) req(client *api.Client) (*http.Request, error) {
+	url, err := dlc.url()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req = dlc.encodeQueryParams(req)
+	return req, nil
+}
+
+func (dlc *downloadClient) encodeQueryParams(req *http.Request) *http.Request {
+	if dlc.uuid != "" {
+		return req
+	}
+
+	q := req.URL.Query()
+	q.Add("exercise_id", dlc.slug)
+	if dlc.track != "" {
+		q.Add("track_id", dlc.track)
+	}
+	if dlc.team != "" {
+		q.Add("team_id", dlc.team)
+	}
+	req.URL.RawQuery = q.Encode()
+	return req
 }


### PR DESCRIPTION
This consolidates the logic related to making the first HTTP request
to the API in the download command.

This should let us reuse it in the doctor command.

The abstraction has a `Do()` method, which makes it feel like the api.Client,
but it doesn't actually embed the *api.Client, as that felt like overkill.

The first commit creates the abstraction, the second uses it in the download.
It will probably be easiest to view each commit separately.

This is very much inspired by the work that @jdsutherland did in https://github.com/exercism/cli/pull/756, so I've added him as co-author on the commit.

@jdsutherland I'd love your thoughts on this variation of your approach.
