### PR TITLE
Enhance workspace command

### DIFF
--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/exercism/cli/config"
+	"github.com/exercism/cli/workspace"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -36,11 +41,66 @@ nothing will happen.
 		// Ignore error. If the file doesn't exist, that is fine.
 		_ = v.ReadInConfig()
 
-		fmt.Fprintf(Out, "%s\n", v.GetString("workspace"))
-		return nil
+		return runWorkspace(v, cmd.Flags())
 	},
+}
+
+func runWorkspace(v *viper.Viper, flags *pflag.FlagSet) error {
+	if err := validateUserConfig(v); err != nil {
+		return err
+	}
+
+	path := v.GetString("workspace")
+	teamDir, _ := flags.GetString("team")
+	if teamDir != "" {
+		path = filepath.Join(path, "teams", teamDir)
+	}
+
+	ws, err := workspace.New(path)
+	if err != nil {
+		if os.IsNotExist(err) && teamDir != "" {
+			return errors.New("team not found in workspace")
+		}
+		return err
+	}
+
+	if track, _ := flags.GetBool("track"); track {
+		trackPaths, err := ws.TrackPaths()
+		if err != nil {
+			return err
+		}
+
+		for _, trackPath := range trackPaths {
+			fmt.Fprintf(Out, "%s\n", filepath.Join(ws.Dir, trackPath))
+		}
+
+		return nil
+	}
+
+	if ex, _ := flags.GetBool("exercise"); ex {
+		exercises, err := ws.Exercises()
+		if err != nil {
+			return err
+		}
+
+		for _, exercise := range exercises {
+			fmt.Fprintf(Out, "%s\n", filepath.Join(ws.Dir, exercise.Path()))
+		}
+
+		return nil
+	}
+
+	fmt.Fprintf(Out, "%s\n", ws.Dir)
+	return nil
 }
 
 func init() {
 	RootCmd.AddCommand(workspaceCmd)
+	setupWorkspaceFlags(workspaceCmd.Flags())
+}
+
+func setupWorkspaceFlags(flags *pflag.FlagSet) {
+	flags.BoolP("track", "t", false, "print track paths")
+	flags.BoolP("exercise", "e", false, "print exercise paths")
+	flags.StringP("team", "T", "", "the team slug")
 }

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkspaceCmdWithoutWorkspace(t *testing.T) {
+	v := viper.New()
+	v.Set("Token", "abc123")
+	err := runWorkspace(v, pflag.NewFlagSet("fake", pflag.PanicOnError))
+	if assert.Error(t, err) {
+		assert.Regexp(t, "re-run the configure", err.Error())
+	}
+}
+func TestWorkspaceCmdWithNonexistentTeam(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "fake-workspace")
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+	v.Set("apibaseurl", "http://example.com")
+
+	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+	setupWorkspaceFlags(flags)
+	flags.Set("team", "NonExistentTeam")
+
+	err = runWorkspace(v, flags)
+	if assert.Error(t, err) {
+		assert.Regexp(t, "team not found", err.Error())
+	}
+}
+
+func TestWorkspaceCmd(t *testing.T) {
+	co := newCapturedOutput()
+	defer co.reset()
+
+	tmpDir, err := ioutil.TempDir("", "fake-workspace")
+	setupTrackandExercises(tmpDir, t)
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	v := viper.New()
+	v.Set("token", "abc123")
+	v.Set("workspace", tmpDir)
+	v.Set("apibaseurl", "http://example.com")
+
+	testCases := []struct {
+		desc     string
+		args     []string
+		expected string
+	}{
+		{
+			desc:     "It prints the workspace path",
+			args:     []string{},
+			expected: tmpDir,
+		},
+		{
+			desc:     "It prints the team workspace",
+			args:     []string{"--team", "alice"},
+			expected: filepath.Join(tmpDir, "teams/alice"),
+		},
+		{
+			desc:     "It prints the tracks",
+			args:     []string{"--track"},
+			expected: filepath.Join(tmpDir, "track-a"),
+		},
+		{
+			desc:     "It prints the team's tracks",
+			args:     []string{"--track", "--team", "alice"},
+			expected: filepath.Join(tmpDir, "teams/alice/track-a"),
+		},
+		{
+			desc:     "It prints the exercises",
+			args:     []string{"--exercise"},
+			expected: filepath.Join(tmpDir, "track-a", "exercise-one"),
+		},
+		{
+			desc:     "It prints the team's exercises",
+			args:     []string{"--exercise", "--team", "alice"},
+			expected: filepath.Join(tmpDir, "teams/alice/track-a/exercise-one"),
+		},
+	}
+
+	for _, tc := range testCases {
+		co.newOut = &bytes.Buffer{}
+		co.override()
+
+		flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
+		setupWorkspaceFlags(flags)
+
+		err := flags.Parse(tc.args)
+		assert.NoError(t, err)
+
+		err = runWorkspace(v, flags)
+		assert.NoError(t, err)
+
+		assert.Regexp(t, tc.expected, Out, tc.desc)
+	}
+}
+
+func setupTrackandExercises(tmpDir string, t *testing.T) {
+	a1 := filepath.Join(tmpDir, "track-a", "exercise-one")
+
+	teamDir := filepath.Join(tmpDir, "teams", "alice", "track-a", "exercise-one")
+
+	for _, path := range []string{a1, teamDir} {
+		metadataAbsoluteFilepath := filepath.Join(path, ".exercism/metadata.json")
+		err := os.MkdirAll(filepath.Dir(metadataAbsoluteFilepath), os.FileMode(0755))
+		assert.NoError(t, err)
+
+		err = ioutil.WriteFile(metadataAbsoluteFilepath, []byte{}, os.FileMode(0600))
+		assert.NoError(t, err)
+	}
+}

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -57,28 +57,6 @@ func (ws Workspace) PotentialExercises() ([]Exercise, error) {
 			continue
 		}
 
-		if topInfo.Name() == "teams" {
-			subInfos, err := ioutil.ReadDir(filepath.Join(ws.Dir, "teams"))
-			if err != nil {
-				return nil, err
-			}
-
-			for _, subInfo := range subInfos {
-				teamWs, err := New(filepath.Join(ws.Dir, "teams", subInfo.Name()))
-				if err != nil {
-					return nil, err
-				}
-
-				teamExercises, err := teamWs.PotentialExercises()
-				if err != nil {
-					return nil, err
-				}
-
-				exercises = append(exercises, teamExercises...)
-			}
-			continue
-		}
-
 		subInfos, err := ioutil.ReadDir(filepath.Join(ws.Dir, topInfo.Name()))
 		if err != nil {
 			return nil, err

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -20,16 +20,13 @@ func TestWorkspacePotentialExercises(t *testing.T) {
 	b1 := filepath.Join(tmpDir, "track-b", "exercise-one")
 	b2 := filepath.Join(tmpDir, "track-b", "exercise-two")
 
-	// It should find teams exercises
-	team := filepath.Join(tmpDir, "teams", "some-team", "track-c", "exercise-one")
-
 	// It should ignore other people's exercises.
 	alice := filepath.Join(tmpDir, "users", "alice", "track-a", "exercise-one")
 
 	// It should ignore nested dirs within exercises.
 	nested := filepath.Join(a1, "subdir", "deeper-dir", "another-deep-dir")
 
-	for _, path := range []string{a1, b1, b2, team, alice, nested} {
+	for _, path := range []string{a1, b1, b2, alice, nested} {
 		err := os.MkdirAll(path, os.FileMode(0755))
 		assert.NoError(t, err)
 	}
@@ -39,7 +36,7 @@ func TestWorkspacePotentialExercises(t *testing.T) {
 
 	exercises, err := ws.PotentialExercises()
 	assert.NoError(t, err)
-	if assert.Equal(t, 4, len(exercises)) {
+	if assert.Equal(t, 3, len(exercises)) {
 		paths := make([]string, len(exercises))
 		for i, e := range exercises {
 			paths[i] = e.Path()
@@ -49,7 +46,6 @@ func TestWorkspacePotentialExercises(t *testing.T) {
 		assert.Equal(t, paths[0], "track-a/exercise-one")
 		assert.Equal(t, paths[1], "track-b/exercise-one")
 		assert.Equal(t, paths[2], "track-b/exercise-two")
-		assert.Equal(t, paths[3], "track-c/exercise-one")
 	}
 }
 

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTrackPaths(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "walk")
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	a1 := filepath.Join(tmpDir, "track-a", "exercise-one")
+	b1 := filepath.Join(tmpDir, "track-b", "exercise-one")
+	b2 := filepath.Join(tmpDir, "track-b", "exercise-two")
+
+	// It should ignore user and team directory
+	userDir := filepath.Join(tmpDir, "users", "alice", "track-a", "exercise-one")
+	teamDir := filepath.Join(tmpDir, "teams", "alice", "track-a", "exercise-one")
+
+	for _, path := range []string{a1, b1, b2, userDir, teamDir} {
+		err := os.MkdirAll(path, os.FileMode(0755))
+		assert.NoError(t, err)
+	}
+
+	ws, err := New(tmpDir)
+	assert.NoError(t, err)
+
+	paths, err := ws.TrackPaths()
+	assert.NoError(t, err)
+	if assert.Equal(t, 2, len(paths)) {
+		sort.Strings(paths)
+		assert.Equal(t, paths[0], "track-a")
+		assert.Equal(t, paths[1], "track-b")
+	}
+}
+
 func TestWorkspacePotentialExercises(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "walk")
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
I have also reverted the change made in this PR #827
It added team exercises to Potential Exercises in workspace.

I think instead of polluting root workspace's PotentialExercises with team's exercises.
A better way would be to think of each Team directory as a seperate workspace. Since they essentially mirror the structure of the root workspace.

```
$WORKSPACE
├── go
│   └── hello-world
├── ruby
│   └── hello-world
└── teams
    └── funfun
        └── go
            └── gigasecond
    └── foobar
```

So the workspace for team funfun would be `workspace.new("/teams/funfun")`. And it's potential exercises can be retrieved just like any other workspace. I believe this is easier to wrap one's head around and lends itself better to changes. 

Thoughts?