### PR TITLE
Isolate file logic from http and filesystem logic in download

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -75,15 +75,11 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		return err
 	}
 
-	for _, file := range download.payload.Solution.Files {
-		unparsedURL := fmt.Sprintf("%s%s", download.payload.Solution.FileDownloadBaseURL, file)
-		parsedURL, err := netURL.ParseRequestURI(unparsedURL)
-
+	for _, sf := range download.payload.files() {
+		url, err := sf.url()
 		if err != nil {
 			return err
 		}
-
-		url := parsedURL.String()
 
 		req, err := client.NewRequest("GET", url, nil)
 		if err != nil {
@@ -105,26 +101,12 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 			continue
 		}
 
-		// TODO: if there's a collision, interactively resolve (show diff, ask if overwrite).
-		// TODO: handle --force flag to overwrite without asking.
-
-		// Work around a path bug due to an early design decision (later reversed) to
-		// allow numeric suffixes for exercise directories, allowing people to have
-		// multiple parallel versions of an exercise.
-		pattern := fmt.Sprintf(`\A.*[/\\]%s-\d*/`, metadata.ExerciseSlug)
-		rgxNumericSuffix := regexp.MustCompile(pattern)
-		if rgxNumericSuffix.MatchString(file) {
-			file = string(rgxNumericSuffix.ReplaceAll([]byte(file), []byte("")))
-		}
-
-		// Rewrite paths submitted with an older, buggy client where the Windows path is being treated as part of the filename.
-		file = strings.Replace(file, "\\", "/", -1)
-
-		relativePath := filepath.FromSlash(file)
-		dir := filepath.Join(metadata.Dir, filepath.Dir(relativePath))
+		// TODO: handle collisions
+		path := sf.relativePath()
+		dir := filepath.Join(metadata.Dir, filepath.Dir(path))
 		os.MkdirAll(dir, os.FileMode(0755))
 
-		f, err := os.Create(filepath.Join(metadata.Dir, relativePath))
+		f, err := os.Create(filepath.Join(metadata.Dir, path))
 		if err != nil {
 			return err
 		}
@@ -309,6 +291,51 @@ func (dp downloadPayload) metadata() workspace.ExerciseMetadata {
 		Handle:       dp.Solution.User.Handle,
 		IsRequester:  dp.Solution.User.IsRequester,
 	}
+}
+
+func (dp downloadPayload) files() []solutionFile {
+	fx := make([]solutionFile, 0, len(dp.Solution.Files))
+	for _, file := range dp.Solution.Files {
+		f := solutionFile{
+			path:    file,
+			baseURL: dp.Solution.FileDownloadBaseURL,
+			slug:    dp.Solution.Exercise.ID,
+		}
+		fx = append(fx, f)
+	}
+	return fx
+}
+
+type solutionFile struct {
+	path, baseURL, slug string
+}
+
+func (sf solutionFile) url() (string, error) {
+	url, err := netURL.ParseRequestURI(fmt.Sprintf("%s%s", sf.baseURL, sf.path))
+
+	if err != nil {
+		return "", err
+	}
+
+	return url.String(), nil
+}
+
+func (sf solutionFile) relativePath() string {
+	file := sf.path
+
+	// Work around a path bug due to an early design decision (later reversed) to
+	// allow numeric suffixes for exercise directories, letting people have
+	// multiple parallel versions of an exercise.
+	pattern := fmt.Sprintf(`\A.*[/\\]%s-\d*/`, sf.slug)
+	rgxNumericSuffix := regexp.MustCompile(pattern)
+	if rgxNumericSuffix.MatchString(sf.path) {
+		file = string(rgxNumericSuffix.ReplaceAll([]byte(sf.path), []byte("")))
+	}
+
+	// Rewrite paths submitted with an older, buggy client where the Windows path is being treated as part of the filename.
+	file = strings.Replace(file, "\\", "/", -1)
+
+	return filepath.FromSlash(file)
 }
 
 func setupDownloadFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
This creates a new type upon which we can hang logic specific to the solution file in the big for loop in download.

@jdsutherland this is an example of what I mean by a smaller step. What I like about this abstraction is that it doesn't know anything about the filesystem or the API, it just hides some of the noisy cruft that made the for loop bigger and more unwieldy. I don't think this is the end of the refactoring, there's more to do, but I think it's a cohesive change that doesn't make guesses or hide necessary information.

@nywilken if you have time to look at this one, I'd love your input!