### PR TITLE
Add GoReportCard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Exercism Command-line Interface (CLI)
 
 [![Build Status](https://travis-ci.org/exercism/cli.svg?branch=master)](https://travis-ci.org/exercism/cli)
+[![Go Report Card](https://goreportcard.com/badge/github.com/exercism/cli)](https://goreportcard.com/report/github.com/exercism/cli)
 
 The CLI is the link between the [Exercism][exercism] website and your local work environment. It lets you download exercises and submit your solution to the site.
 


### PR DESCRIPTION
GoReportCard displays a number of Go "health" metrics and links back into the Github source allowing quick corrections.
The project's report can be reviewed at https://goreportcard.com/report/github.com/exercism/cli