### PR TITLE
Ensure closing response body

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -69,6 +69,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	debug.DumpResponse(res)
 	return res, nil
@@ -85,6 +86,8 @@ func (c *Client) TokenIsValid() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer resp.Body.Close()
+
 	return resp.StatusCode == http.StatusOK, nil
 }
 
@@ -99,6 +102,8 @@ func (c *Client) IsPingable() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API returned %s", resp.Status)
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -69,7 +69,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
 
 	debug.DumpResponse(res)
 	return res, nil


### PR DESCRIPTION
As per Go docs It is required to call resp.Body.Close(). 
[Doc Reference](https://golang.org/pkg/net/http/#Response)