### PR TITLE
Fix Oh my Zsh correct fpath

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -32,7 +32,11 @@ and then add the directory to your `$fpath` in your `.zshrc`, `.zsh_profile` or
 
 #### Oh my Zsh
 
-If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, move the file `exercism_completion.zsh` into `~/.oh-my-zsh/custom`.
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your zsh plugins, follow these steps:
+
+    mkdir -p ~/.oh-my-zsh/completions
+    mv ../shell/exercism_completion.zsh ~/.oh-my-zsh/completions
+
 
 ### Fish
 


### PR DESCRIPTION
Every time I open the terminal show this:
```/.oh-my-zsh/custom/exercism_completion.zsh:local:6: options: can't change type of autoloaded parameter```
You need to put the file in any `$fpath`, but `~/.oh-my-zsh/custom` is not one of them.

Look this: https://github.com/beetbox/beets/issues/1731