### PR TITLE
Error message returned if the track is locked

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -188,6 +188,9 @@ func newDownload(flags *pflag.FlagSet, usrCfg *viper.Viper) (*download, error) {
 	if err := json.NewDecoder(res.Body).Decode(&d.payload); err != nil {
 		return nil, decodedAPIError(res)
 	}
+	if d.payload.Error.Message != "" {
+		return nil, errors.New(d.payload.Error.Message)
+	}
 
 	return d, nil
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -187,10 +187,14 @@ func newDownload(flags *pflag.FlagSet, usrCfg *viper.Viper) (*download, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return nil, decodedAPIError(res)
+	}
+
+	body, _ := ioutil.ReadAll(res.Body)
 	res.Body = ioutil.NopCloser(bytes.NewReader(body))
 
-	if err := json.Unmarshal(body, &d.payload); err != nil || res.StatusCode < 200 || res.StatusCode > 299 {
+	if err := json.Unmarshal(body, &d.payload); err != nil {
 		return nil, decodedAPIError(res)
 	}
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -302,9 +302,7 @@ func TestDownloadError(t *testing.T) {
 
 	err = runDownload(cfg, flags, []string{})
 
-	fmt.Println(err)
-
-	assert.Regexp(t, "test error", err.Error())
+	assert.Equal(t, "test error", err.Error())
 
 }
 


### PR DESCRIPTION
This fixes #870.

If the user has not unlocked the track that they have requested to download, the cli will return an error.