### PR TITLE
Make all errors in cmd package checked

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -104,7 +104,9 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		// TODO: handle collisions
 		path := sf.relativePath()
 		dir := filepath.Join(metadata.Dir, filepath.Dir(path))
-		os.MkdirAll(dir, os.FileMode(0755))
+		if err = os.MkdirAll(dir, os.FileMode(0755)); err != nil {
+			return err
+		}
 
 		f, err := os.Create(filepath.Join(metadata.Dir, path))
 		if err != nil {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -21,8 +21,7 @@ Pass the path to the directory that contains the solution you want to see on the
 		if err != nil {
 			return err
 		}
-		browser.Open(metadata.URL)
-		return nil
+		return browser.Open(metadata.URL)
 	},
 }
 

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -124,7 +124,9 @@ func (status *Status) compile() (string, error) {
 	}
 
 	var bb bytes.Buffer
-	t.Execute(&bb, status)
+	if err = t.Execute(&bb, status); err != nil {
+		return "", err
+	}
 	return bb.String(), nil
 }
 


### PR DESCRIPTION
Linting of all code base has discovered several places in the code with unchecked error codes.
This PR adds missing error checks in cmd package.