### PR TITLE
improvement to bash snippet in RELEASE doc: don't parse ls

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,7 +46,7 @@ goreleaser --rm-dist
 snapcraft login
 
 # Push to snapcraft
-for f in `ls dist/*.snap`; do snapcraft push --release=stable $f; done
+for f in dist/*.snap; do snapcraft push --release=stable "$f"; done
 
 # [TODO] Push to homebrew
 ```


### PR DESCRIPTION
Fixing up the shell snippet: [Don't parse `ls`](https://mywiki.wooledge.org/ParsingLs)

