### PR TITLE
fix #931 set DualStack on default api client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -17,7 +18,12 @@ var (
 	// TimeoutInSeconds is the timeout the default HTTP client will use.
 	TimeoutInSeconds = 60
 	// HTTPClient is the client used to make HTTP calls in the cli package.
-	HTTPClient = &http.Client{Timeout: time.Duration(TimeoutInSeconds) * time.Second}
+	HTTPClient = &http.Client{
+		Timeout: time.Duration(TimeoutInSeconds) * time.Second,
+		Transport: &http.Transport{DialContext: (&net.Dialer{
+			Timeout:   time.Duration(TimeoutInSeconds) * time.Second,
+			DualStack: true,
+		}).DialContext}}
 )
 
 // Client is an http client that is configured for Exercism.


### PR DESCRIPTION
When running on broken or incomplete DualStack networks (e.g. ipv6 and
ipv4 addresses are available, but only ipv4 routes to the internet),
enable HappyEyeballs (DualStack) fast-fallback in the Dial context
settings to ensure successful connections.

RFC-6555: https://tools.ietf.org/html/rfc6555