### PR TITLE
Add command to register a custom URI handler

### DIFF
--- a/cmd/handler-entrypoint.go
+++ b/cmd/handler-entrypoint.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 
@@ -19,13 +21,24 @@ var handlerEntrypointCmd = &cobra.Command{
 	},
 }
 
+func exit(exitCode int) {
+	fmt.Println("\nPress ENTER to exit.")
+	_, err := fmt.Scanln()
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(exitCode)
+}
+
 func dispatchURICommand(cmd *cobra.Command, args []string) error {
 	if runtime.GOOS != "windows" {
-		return errors.New("only supported on Windows")
+		fmt.Println("only supported on Windows")
+		exit(1)
 	}
 
 	if len(args) < 1 {
-		return errors.New("no arguments given")
+		fmt.Println("no arguments given")
+		exit(1)
 	}
 
 	params := strings.Split(args[0], ":")
@@ -34,22 +47,28 @@ func dispatchURICommand(cmd *cobra.Command, args []string) error {
 	switch params[0] {
 	case "download":
 		uuid := params[1]
-		fmt.Printf("Downloading %s...", uuid)
-		err := downloadCmd.RunE(cmd, []string{fmt.Sprintf("--uuid=%s", uuid)})
+		_cmd := exec.Command("exercism", "download", fmt.Sprintf("--uuid=%s", uuid))
+		_cmd.Stderr = os.Stderr
+		_cmd.Stdout = os.Stdout
+		err := _cmd.Run()
 		if err != nil {
-			log.Fatalf("download failed: %v", err)
+			exit(1)
 		}
-		return nil
+		exit(0)
 	case "configure":
-		if params[2] == "token" {
-			token := params[3]
-			fmt.Printf("Configuring token=%s...", token)
-			err := configureCmd.RunE(cmd, []string{fmt.Sprintf("--token=%s", token)})
+		if params[1] == "token" {
+			token := params[2]
+			//err := configureCmd.RunE(cmd, []string{fmt.Sprintf("--token=%s", token)})
+			_cmd := exec.Command("exercism", "configure", fmt.Sprintf("--token=%s", token))
+			_cmd.Stderr = os.Stderr
+			_cmd.Stdout = os.Stdout
+			err := _cmd.Run()
 			if err != nil {
-				log.Fatalf("configuring token failed: %v", err)
+				exit(1)
 			}
+			exit(0)
 		}
-		return nil
+		exit(1)
 	}
 
 	return errors.New("invalid command")

--- a/cmd/handler-entrypoint.go
+++ b/cmd/handler-entrypoint.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var handlerEntrypointCmd = &cobra.Command{
+	Use:   "handler-entrypoint",
+	Short: "",
+	Long:  "",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return dispatchURICommand(cmd, args)
+	},
+}
+
+func dispatchURICommand(cmd *cobra.Command, args []string) error {
+	if runtime.GOOS != "windows" {
+		return errors.New("only supported on Windows")
+	}
+
+	if len(args) < 1 {
+		return errors.New("no arguments given")
+	}
+
+	params := strings.Split(args[0], ":")
+	// TODO: Handle invalid inputs
+
+	switch params[0] {
+	case "download":
+		uuid := params[1]
+		fmt.Printf("Downloading %s...", uuid)
+		err := downloadCmd.RunE(cmd, []string{fmt.Sprintf("--uuid=%s", uuid)})
+		if err != nil {
+			log.Fatalf("download failed: %v", err)
+		}
+		return nil
+	case "configure":
+		if params[2] == "token" {
+			token := params[3]
+			fmt.Printf("Configuring token=%s...", token)
+			err := configureCmd.RunE(cmd, []string{fmt.Sprintf("--token=%s", token)})
+			if err != nil {
+				log.Fatalf("configuring token failed: %v", err)
+			}
+		}
+		return nil
+	}
+
+	return errors.New("invalid command")
+}
+
+func init() {
+	RootCmd.AddCommand(handlerEntrypointCmd)
+}

--- a/cmd/install-handler.go
+++ b/cmd/install-handler.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"errors"
+	"log"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/windows/registry"
+)
+
+var installHandlerCmd = &cobra.Command{
+	Use:   "install-handler",
+	Short: "Install a custom URI handler.",
+	Long:  "Install a custom URI handler.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return registerHandler()
+	},
+}
+
+func registerHandler() error {
+	if runtime.GOOS != "windows" {
+		return errors.New("Only supported on Windows")
+	}
+
+	// TODO: Probably don't need ALL_ACCESS 0xf003f here
+	newk, oldk, err := registry.CreateKey(registry.CLASSES_ROOT, "exercism", registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+	if oldk {
+		log.Println("Handler already registered.")
+		return nil
+	}
+
+	// Indicate that this key declares a custom URI handler
+	newk.SetStringValue("URL Protocol", "")
+
+	shellk, _, err := registry.CreateKey(newk, "shell", registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+
+	openk, _, err := registry.CreateKey(shellk, "open", registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+
+	commandk, _, err := registry.CreateKey(openk, "command", registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Check if exercism is in PATH
+	commandk.SetStringValue("", `cmd /K exercism download --uuid=%1`)
+
+	defer commandk.Close()
+	defer openk.Close()
+	defer shellk.Close()
+	defer newk.Close()
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(installHandlerCmd)
+}

--- a/cmd/install-handler.go
+++ b/cmd/install-handler.go
@@ -52,7 +52,8 @@ func registerHandler() error {
 	}
 
 	// TODO: Check if exercism is in PATH
-	commandk.SetStringValue("", `cmd /K exercism download --uuid=%1`)
+	// cmd.exe /k "C:\Users\WDAGUtilityAccount\Desktop\bin\exercism.exe handler-entrypoint %1" << registry
+	commandk.SetStringValue("", `iex exercism download --uuid=%1`)
 
 	defer commandk.Close()
 	defer openk.Close()

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/exercism/cli
 
+go 1.14
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/hashicorp/hcl v0.0.0-20170509225359-392dba7d905e h1:KJWs1uTCkN3E/J5of
 github.com/hashicorp/hcl v0.0.0-20170509225359-392dba7d905e/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.7.3 h1:6AOjgCKyZFMG/1yfReDPDz3CJZPxnYk7DGmj2HtyF24=
 github.com/magiconair/properties v1.7.3/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ golang.org/x/net v0.0.0-20170726083632-f5079bd7f6f7 h1:1Pw+ZX4dmGORIwGkTwnUr7RFu
 golang.org/x/net v0.0.0-20170726083632-f5079bd7f6f7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20170803140359-d8f5ea21b929 h1:M4VPQYSW/nB4Bcg1XMD4yW2sprnwerD3Kb6apRphtZw=
 golang.org/x/sys v0.0.0-20170803140359-d8f5ea21b929/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed h1:WBkVNH1zd9jg/dK4HCM4lNANnmd12EHC9z+LmcCG4ns=
 golang.org/x/text v0.0.0-20170730040918-3bd178b88a81 h1:7aXI3TQ9sZ4JdDoIDGjxL6G2mQxlsPy9dySnJaL6Bdk=
 golang.org/x/text v0.0.0-20170730040918-3bd178b88a81/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/yaml.v2 v2.0.0-20170721122051-25c4ec802a7d h1:2DX7x6HUDGZUyuEDAhUsQQNqkb1zvDyKTjVoTdzaEzo=


### PR DESCRIPTION
**This is a proof of concept, nothing more.**

---

In https://github.com/exercism/v3/discussions/2164#discussioncomment-49086 I suggested it would be nice to have a button that automatically downloads a solution or exercise instead of having to copy the command into the terminal; similar to a `spotify:track:2pnZVpeKqLrEto2X9vYF6s` URI opening the Spotify app.

This PR contains a proof of concept that adds such a handler on Windows, based on the protocol outlined on [MSDN](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767914(v=vs.85)?redirectedfrom=MSDN) (note that the docs refer to Internet Explorer, but these handlers are system-wide). The primary purpose is to demonstrate that this is easily possible without modifying the CLI itself.

### What would be required to actually add this feature?

- Support for it in the UI (v3)
    - to be clear: I don't think this should replace the copy buttons, it should be an addition. Maybe with a dropdown button or a user setting to configure the default.
- Figure out how to test this properly. Since it modifies the registry, we need to be careful to not destroy anything.
- Figure out macOS support (https://superuser.com/questions/548119/how-do-i-configure-custom-url-handlers-on-os-x as a starting point)
- People who use Linux are proficient enough to figure this out on their own if they want to use it ¯\\\_(ツ)\_/¯
- Ideally add a command that adds the cli to PATH. Otherwise allow people to specify which path it is in.
- Add unregister command.
- Instead of launching `exercism download --uuid=...`, we should define a command `exercism uri-handler-entrypoint %1` that parses the custom URI and then executes the commands. This would allow us to run different commands, e.g. we could have `exercism:download:mentor:<uuid>` that runs  `exercism download --uuid=<uuid>` and `exercism:download:julia:leap` that runs `exercism download --exercise=leap --track=julia`. Everything that right now requires copying a command could be run through this.
- MSDN lists security precautions. I don't really see any attack vectors through the CLI, but it's something that needs to be considered.

Alternatively, but I like this option far less, we could wrap the CLI in a standard installer which can probably set this up quite easily.

@ErikSchierboom Do you know how to help with the windows API side of this? Primarily, how should one test changes to the registry etc?