### PR TITLE
Improve error message 'not in workspace' for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: go
 sudo: false
 
 go:
-  - "1.11.x"
-  - "1.12.x"
+  - "1.15.x"
   - tip
 
 matrix:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/exercism/cli
 
+go 1.15
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.0

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -125,7 +125,7 @@ func (ws Workspace) ExerciseDir(s string) (string, error) {
 	if !strings.HasPrefix(s, ws.Dir) {
 		var err = fmt.Errorf("not in workspace")
 		if runtime.GOOS == "darwin" {
-			err = fmt.Errorf("%w: directory location may be case sensitive: workspace directory: %s, " +
+			err = fmt.Errorf("%w: directory location may be case sensitive: workspace directory: %s, "+
 				"submit path: %s", err, ws.Dir, s)
 		}
 		return "", err

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -2,9 +2,11 @@ package workspace
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -121,7 +123,12 @@ func (ws Workspace) Exercises() ([]Exercise, error) {
 // This is the directory that contains the exercise metadata file.
 func (ws Workspace) ExerciseDir(s string) (string, error) {
 	if !strings.HasPrefix(s, ws.Dir) {
-		return "", errors.New("not in workspace")
+		var err = fmt.Errorf("not in workspace")
+		if runtime.GOOS == "darwin" {
+			err = fmt.Errorf("%w: directory location may be case sensitive: workspace directory: %s, " +
+				"submit path: %s", err, ws.Dir, s)
+		}
+		return "", err
 	}
 
 	path := s

--- a/workspace/workspace_darwin_test.go
+++ b/workspace/workspace_darwin_test.go
@@ -1,0 +1,26 @@
+package workspace
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestExerciseDir_case_insensitive(t *testing.T) {
+	_, cwd, _, _ := runtime.Caller(0)
+	root := filepath.Join(cwd, "..", "..", "fixtures", "solution-dir")
+	// configuration file was set with "workspace" - the directory that exists
+	configured := Workspace{Dir: filepath.Join(root, "workspace")}
+	// user changes into directory with "bad" case - "Workspace"
+	userPath := strings.Replace(configured.Dir, "workspace", "Workspace", 1)
+
+	_, err := configured.ExerciseDir(filepath.Join(userPath, "exercise", "file.txt"))
+
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("not in workspace: directory location may be case sensitive: " +
+		"workspace directory: %s, submit path: %s/exercise/file.txt", configured.Dir, userPath), err.Error())
+}
+

--- a/workspace/workspace_darwin_test.go
+++ b/workspace/workspace_darwin_test.go
@@ -20,7 +20,6 @@ func TestExerciseDir_case_insensitive(t *testing.T) {
 	_, err := configured.ExerciseDir(filepath.Join(userPath, "exercise", "file.txt"))
 
 	assert.Error(t, err)
-	assert.Equal(t, fmt.Sprintf("not in workspace: directory location may be case sensitive: " +
+	assert.Equal(t, fmt.Sprintf("not in workspace: directory location may be case sensitive: "+
 		"workspace directory: %s, submit path: %s/exercise/file.txt", configured.Dir, userPath), err.Error())
 }
-


### PR DESCRIPTION
cf. #907 

Default installation of MacOS allows user to change directory
insensitive of case. This commit wraps a supplemental error message for
Mac users, including prints of the workspace and submit path.