### PR TITLE
Allow read-write access to configuration and download directories when installed as a Snap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,4 +97,9 @@ snapcrafts:
       386: i386
     apps:
       exercism:
-        plugs: ["home", "network", "removable-media"]
+        plugs: ["home", "network", "removable-media","personal-files"]
+    plugs:
+      personal-files:
+        write:
+        - $HOME/.config/exercism/
+        - $HOME/exercism/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,5 +101,4 @@ snapcrafts:
     plugs:
       personal-files:
         write:
-        - $HOME/.config/exercism/
-        - $HOME/exercism/
+        - $HOME/


### PR DESCRIPTION
We need write access to the $HOME/.config/exercism/ directory for `exercism config` and $HOME/exercism is the default download directory so we need write access there as well.

This should resolve issue #945