### PR TITLE
Add --postprocess configure option to designate a script to run after downloading an exercise.

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -132,10 +132,10 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 		cmd := exec.Command(usrCfg.GetString("postprocess"))
 		cmd.Dir = metadata.Dir
 		err := cmd.Run()
-		if err != nil {
-			fmt.Fprintf(Err, "\nThere was an error running the postprocess script: %v\n", err)
-		} else {
+		if err == nil {
 			fmt.Fprintf(Err, "\nSuccessfully executed the postprocess script.\n")
+		} else {
+			fmt.Fprintf(Err, "\nThere was an error running the postprocess script: %v\n", err)
 		}
 	}
 	return nil

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	netURL "net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -125,6 +126,18 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 	}
 	fmt.Fprintf(Err, "\nDownloaded to\n")
 	fmt.Fprintf(Out, "%s\n", metadata.Dir)
+
+	// run postprocess script if one was configured
+	if usrCfg.GetString("postprocess") != "" {
+		cmd := exec.Command(usrCfg.GetString("postprocess"))
+		cmd.Dir = metadata.Dir
+		err := cmd.Run()
+		if err != nil {
+			fmt.Fprintf(Err, "\nThere was an error running the postprocess script: %v\n", err)
+		} else {
+			fmt.Fprintf(Err, "\nSuccessfully executed the postprocess script.\n")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This adds a `--postprocess` option to `exercism configure` that, when set, causes a designated script to be executed after each download. Additionally, there is a `--no-postprocess` option to remove the postprocess configuration. The postprocess script runs with the current directory set to the newly downloaded exercise directory.

The use case I have in mind for this, and the reason I added it, is to allow me to provide a script that automatically sets up each new downloaded exercise as a git repository so I can track my changes to the exercise:

```
#!/usr/bin/env bash

git init .
git add .
git commit -m 'Initial commit from exercism'
```

I just put that into a script, then use `exercism configure --postprocess /path/to/above/script` to set up exercism to automatically run it after each download.