### PR TITLE
Allow to configure the workspace to be a symlink 

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -254,6 +254,10 @@ func TestConfigureWorkspace(t *testing.T) {
 	co.override()
 	defer co.reset()
 
+	tmpDir, err := ioutil.TempDir("", "existing-workspace")
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
 	testCases := []struct {
 		desc       string
 		configured string
@@ -279,6 +283,12 @@ func TestConfigureWorkspace(t *testing.T) {
 			configured: "/configured-workspace",
 			args:       []string{"--no-verify", "--workspace", "/replacement-workspace"},
 			expected:   "/replacement-workspace",
+		},
+		{
+			desc:       "It writes a workspace when the target directory exists",
+			configured: "/configured-workspace",
+			args:       []string{"--no-verify", "--workspace", tmpDir},
+			expected:   tmpDir,
 		},
 		{
 			desc:       "It gets the default workspace when neither configured nor passed as a flag",


### PR DESCRIPTION
Currently `configure` command fails if the workspace specified is a symlink:
```
$ readlink ~/code/exercism
/home/raindev/Dropbox/exercism/

$ exercism configure -w ~/code/exercism
Error:

    There is already something at the workspace location you are configuring:

      /home/raindev/code/exercism

     Please rename it, or set a different workspace location:

       exercism configure --workspace=/home/raindev/code/exercism --workspace=PATH_TO_DIFFERENT_FOLDER
```

If the symlink is created after running the configuration command, everything works as expected. The suggested  modify `configure` to be able to recognize symlinks and allow them.

I'm not very proficient with Go. Feedback is welcome, I would be happy to follow up with improvements.