### PR TITLE
Bump the printed version of Exercism to v3

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   BinaryName,
 	Short: "A friendly command-line interface to Exercism.",
-	Long: `A command-line interface for the v2 redesign of Exercism.
+	Long: `A command-line interface for the v3 redesign of Exercism.
 
 Download exercises and submit your solutions.`,
 	SilenceUsage: true,


### PR DESCRIPTION
This is an tiny patch that updates the updates the printed version of Exercism to "v3".

Closes https://github.com/exercism/exercism/issues/6078