### PR TITLE
Submit without specifying files

### DIFF
--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -108,6 +108,45 @@ func TestSubmitExerciseWithoutMetadataFile(t *testing.T) {
 	}
 }
 
+func TestGetExerciseSolutionFiles(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "dir-with-no-metadata")
+	defer os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	_, err = getExerciseSolutionFiles(tmpDir)
+	if assert.Error(t, err) {
+		assert.Regexp(t, "no files to submit", err.Error())
+	}
+
+	validTmpDir, err := ioutil.TempDir("", "dir-with-valid-metadata")
+	defer os.RemoveAll(validTmpDir)
+	assert.NoError(t, err)
+
+	metadataDir := filepath.Join(validTmpDir, ".exercism")
+	err = os.MkdirAll(metadataDir, os.FileMode(0755))
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(
+		filepath.Join(metadataDir, "config.json"),
+		[]byte(`
+{
+	"files": {
+		"solution": [
+		  "expenses.go"
+		]
+  	}
+}
+`), os.FileMode(0755))
+	assert.NoError(t, err)
+
+	files, err := getExerciseSolutionFiles(validTmpDir)
+	assert.NoError(t, err)
+	if assert.Equal(t, len(files), 1) {
+		assert.Equal(t, files[0], "expenses.go")
+	}
+}
+
 func TestSubmitFilesAndDir(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
Fixes #991

Adds the possibility of submitting without specifying files, with the "algorithm" specified in https://github.com/exercism/cli/issues/991#issuecomment-939768772

Other than the tests in the PR, I also tried to submit solutions using this version of the program, including messing up the exercise directory and everything went as expected :)