### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 )
 
 const cfgHomeKey = "EXERCISM_CONFIG_HOME"
@@ -26,12 +25,14 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // test, call the command by calling Execute on the App.
 //
 // Example:
-// cmdTest := &CommandTest{
-// 	Cmd:    myCmd,
-// 	InitFn: initMyCmd,
-// 	Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
-// 	MockInteractiveResponse: "first-input\nsecond\n",
-// }
+//
+//	cmdTest := &CommandTest{
+//		Cmd:    myCmd,
+//		InitFn: initMyCmd,
+//		Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
+//		MockInteractiveResponse: "first-input\nsecond\n",
+//	}
+//
 // cmdTest.Setup(t)
 // defer cmdTest.Teardown(t)
 // ...
@@ -61,11 +62,7 @@ type CommandTest struct {
 // The method takes a *testing.T as an argument, that way the method can
 // fail the test if the creation of the temporary directory fails.
 func (test *CommandTest) Setup(t *testing.T) {
-	dir, err := ioutil.TempDir("", "command-test")
-	defer os.RemoveAll(dir)
-	assert.NoError(t, err)
-
-	test.TmpDir = dir
+	test.TmpDir = t.TempDir()
 	test.OriginalValues.ConfigHome = os.Getenv(cfgHomeKey)
 	test.OriginalValues.Args = os.Args
 

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -344,9 +344,7 @@ func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
 	ts := httptest.NewServer(endpoint)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "no-clobber")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	cfg := config.Config{
 		OS:              "linux",
@@ -360,7 +358,7 @@ func TestConfigureDefaultWorkspaceWithoutClobbering(t *testing.T) {
 
 	// Create a directory at the workspace directory's location
 	// so that it's already present.
-	err = os.MkdirAll(config.DefaultWorkspaceDir(cfg), os.FileMode(0755))
+	err := os.MkdirAll(config.DefaultWorkspaceDir(cfg), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)
@@ -379,9 +377,7 @@ func TestConfigureExplicitWorkspaceWithoutClobberingNonDirectory(t *testing.T) {
 	co.override()
 	defer co.reset()
 
-	tmpDir, err := ioutil.TempDir("", "no-clobber")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -396,7 +392,7 @@ func TestConfigureExplicitWorkspaceWithoutClobberingNonDirectory(t *testing.T) {
 	}
 
 	// Create a file at the workspace directory's location
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "workspace"), []byte("This is not a directory"), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(tmpDir, "workspace"), []byte("This is not a directory"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	flags := pflag.NewFlagSet("fake", pflag.PanicOnError)

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -169,9 +169,7 @@ func TestDownload(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tmpDir, err := ioutil.TempDir("", "download-cmd")
-		defer os.RemoveAll(tmpDir)
-		assert.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		ts := fakeDownloadServer(strconv.FormatBool(tc.requester), tc.flags["team"])
 		defer ts.Close()
@@ -190,7 +188,7 @@ func TestDownload(t *testing.T) {
 			flags.Set(name, value)
 		}
 
-		err = runDownload(cfg, flags, []string{})
+		err := runDownload(cfg, flags, []string{})
 		assert.NoError(t, err)
 
 		targetDir := filepath.Join(tmpDir, tc.expectedDir)
@@ -229,11 +227,9 @@ func TestDownloadToExistingDirectory(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tmpDir, err := ioutil.TempDir("", "download-cmd")
-		defer os.RemoveAll(tmpDir)
-		assert.NoError(t, err)
+		tmpDir := t.TempDir()
 
-		err = os.MkdirAll(filepath.Join(tmpDir, tc.exerciseDir), os.FileMode(0755))
+		err := os.MkdirAll(filepath.Join(tmpDir, tc.exerciseDir), os.FileMode(0755))
 		assert.NoError(t, err)
 
 		ts := fakeDownloadServer("true", "")
@@ -281,11 +277,9 @@ func TestDownloadToExistingDirectoryWithForce(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tmpDir, err := ioutil.TempDir("", "download-cmd")
-		defer os.RemoveAll(tmpDir)
-		assert.NoError(t, err)
+		tmpDir := t.TempDir()
 
-		err = os.MkdirAll(filepath.Join(tmpDir, tc.exerciseDir), os.FileMode(0755))
+		err := os.MkdirAll(filepath.Join(tmpDir, tc.exerciseDir), os.FileMode(0755))
 		assert.NoError(t, err)
 
 		ts := fakeDownloadServer("true", "")
@@ -383,9 +377,7 @@ func TestDownloadError(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-err-tmp-dir")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -402,7 +394,7 @@ func TestDownloadError(t *testing.T) {
 	setupDownloadFlags(flags)
 	flags.Set("uuid", "value")
 
-	err = runDownload(cfg, flags, []string{})
+	err := runDownload(cfg, flags, []string{})
 
 	assert.Equal(t, "test error", err.Error())
 

--- a/cmd/submit_symlink_test.go
+++ b/cmd/submit_symlink_test.go
@@ -25,16 +25,12 @@ func TestSubmitFilesInSymlinkedPath(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "symlink-destination")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	dstDir := filepath.Join(tmpDir, "workspace")
 
-	srcDir, err := ioutil.TempDir("", "symlink-source")
-	defer os.RemoveAll(srcDir)
-	assert.NoError(t, err)
+	srcDir := t.TempDir()
 
-	err = os.Symlink(srcDir, dstDir)
+	err := os.Symlink(srcDir, dstDir)
 	assert.NoError(t, err)
 
 	dir := filepath.Join(dstDir, "bogus-track", "bogus-exercise")

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -48,9 +48,7 @@ func TestSubmitWithoutWorkspace(t *testing.T) {
 }
 
 func TestSubmitNonExistentFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -63,7 +61,7 @@ func TestSubmitNonExistentFile(t *testing.T) {
 		DefaultBaseURL:  "http://example.com",
 	}
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(tmpDir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-2.txt"), []byte("This is file 2"), os.FileMode(0755))
@@ -80,15 +78,13 @@ func TestSubmitNonExistentFile(t *testing.T) {
 }
 
 func TestSubmitExerciseWithoutMetadataFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "no-metadata-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
 
 	file := filepath.Join(dir, "file.txt")
-	err = ioutil.WriteFile(file, []byte("This is a file."), os.FileMode(0755))
+	err := ioutil.WriteFile(file, []byte("This is a file."), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	v := viper.New()
@@ -109,19 +105,14 @@ func TestSubmitExerciseWithoutMetadataFile(t *testing.T) {
 }
 
 func TestGetExerciseSolutionFiles(t *testing.T) {
+	tmpDir := t.TempDir()
 
-	tmpDir, err := ioutil.TempDir("", "dir-with-no-metadata")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
-
-	_, err = getExerciseSolutionFiles(tmpDir)
+	_, err := getExerciseSolutionFiles(tmpDir)
 	if assert.Error(t, err) {
 		assert.Regexp(t, "no files to submit", err.Error())
 	}
 
-	validTmpDir, err := ioutil.TempDir("", "dir-with-valid-metadata")
-	defer os.RemoveAll(validTmpDir)
-	assert.NoError(t, err)
+	validTmpDir := t.TempDir()
 
 	metadataDir := filepath.Join(validTmpDir, ".exercism")
 	err = os.MkdirAll(metadataDir, os.FileMode(0755))
@@ -148,9 +139,7 @@ func TestGetExerciseSolutionFiles(t *testing.T) {
 }
 
 func TestSubmitFilesAndDir(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "submit-no-such-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -163,7 +152,7 @@ func TestSubmitFilesAndDir(t *testing.T) {
 		DefaultBaseURL:  "http://example.com",
 	}
 
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(tmpDir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(tmpDir, "file-2.txt"), []byte("This is file 2"), os.FileMode(0755))
@@ -191,9 +180,7 @@ func TestDuplicateFiles(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "duplicate-files")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -211,7 +198,7 @@ func TestDuplicateFiles(t *testing.T) {
 	}
 
 	file1 := filepath.Join(dir, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file1, file1})
 	assert.NoError(t, err)
@@ -231,16 +218,14 @@ func TestSubmitFiles(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-files")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 	writeFakeMetadata(t, dir, "bogus-track", "bogus-exercise")
 
 	file1 := filepath.Join(dir, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	file2 := filepath.Join(dir, "subdir", "file-2.txt")
@@ -288,9 +273,7 @@ func TestLegacyMetadataMigration(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "legacy-metadata-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -351,9 +334,7 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "empty-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -371,7 +352,7 @@ func TestSubmitWithEmptyFile(t *testing.T) {
 	}
 
 	file1 := filepath.Join(dir, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte(""), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte(""), os.FileMode(0755))
 	file2 := filepath.Join(dir, "file-2.txt")
 	err = ioutil.WriteFile(file2, []byte("This is file 2."), os.FileMode(0755))
 
@@ -392,9 +373,7 @@ func TestSubmitWithEnormousFile(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "enormous-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -412,7 +391,7 @@ func TestSubmitWithEnormousFile(t *testing.T) {
 	}
 
 	file := filepath.Join(dir, "file.txt")
-	err = ioutil.WriteFile(file, make([]byte, 65535), os.FileMode(0755))
+	err := ioutil.WriteFile(file, make([]byte, 65535), os.FileMode(0755))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,15 +413,14 @@ func TestSubmitFilesForTeamExercise(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-files")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "teams", "bogus-team", "bogus-track", "bogus-exercise")
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 	writeFakeMetadata(t, dir, "bogus-track", "bogus-exercise")
 
 	file1 := filepath.Join(dir, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	file2 := filepath.Join(dir, "subdir", "file-2.txt")
@@ -476,9 +454,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	co.override()
 	defer co.reset()
 
-	tmpDir, err := ioutil.TempDir("", "just-an-empty-file")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -496,7 +472,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 	}
 
 	file := filepath.Join(dir, "file.txt")
-	err = ioutil.WriteFile(file, []byte(""), os.FileMode(0755))
+	err := ioutil.WriteFile(file, []byte(""), os.FileMode(0755))
 
 	err = runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{file})
 	if assert.Error(t, err) {
@@ -505,9 +481,7 @@ func TestSubmitOnlyEmptyFile(t *testing.T) {
 }
 
 func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "dir-1-submit")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir1 := filepath.Join(tmpDir, "bogus-track", "bogus-exercise-1")
 	os.MkdirAll(dir1, os.FileMode(0755))
@@ -518,7 +492,7 @@ func TestSubmitFilesFromDifferentSolutions(t *testing.T) {
 	writeFakeMetadata(t, dir2, "bogus-track", "bogus-exercise-2")
 
 	file1 := filepath.Join(dir1, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	file2 := filepath.Join(dir2, "file-2.txt")
@@ -579,9 +553,7 @@ func TestSubmitRelativePath(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "relative-path")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(dir, os.FileMode(0755))
@@ -598,7 +570,13 @@ func TestSubmitRelativePath(t *testing.T) {
 		UserViperConfig: v,
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("This is a file."), os.FileMode(0755))
+
+	currentDir, err := os.Getwd()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(currentDir))
+	})
 
 	err = os.Chdir(dir)
 	assert.NoError(t, err)
@@ -619,9 +597,7 @@ func TestSubmitServerErr(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-err-tmp-dir")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -638,7 +614,7 @@ func TestSubmitServerErr(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 	writeFakeMetadata(t, dir, "bogus-track", "bogus-exercise")
 
-	err = ioutil.WriteFile(filepath.Join(dir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(dir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	files := []string{
@@ -658,9 +634,7 @@ func TestHandleErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-nonsuccess")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	v := viper.New()
 	v.Set("token", "abc123")
@@ -677,7 +651,7 @@ func TestHandleErrorResponse(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 	writeFakeMetadata(t, dir, "bogus-track", "bogus-exercise")
 
-	err = ioutil.WriteFile(filepath.Join(dir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
+	err := ioutil.WriteFile(filepath.Join(dir, "file-1.txt"), []byte("This is file 1"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	files := []string{
@@ -693,9 +667,7 @@ func TestSubmissionNotConnectedToRequesterAccount(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-files")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise")
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
@@ -707,7 +679,7 @@ func TestSubmissionNotConnectedToRequesterAccount(t *testing.T) {
 		URL:          "http://example.com/bogus-url",
 		IsRequester:  false,
 	}
-	err = metadata.Write(dir)
+	err := metadata.Write(dir)
 	assert.NoError(t, err)
 
 	file1 := filepath.Join(dir, "file-1.txt")
@@ -736,16 +708,14 @@ func TestExerciseDirnameMatchesMetadataSlug(t *testing.T) {
 	ts := fakeSubmitServer(t, submittedFiles)
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "submit-files")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "bogus-track", "bogus-exercise-doesnt-match-metadata-slug")
 	os.MkdirAll(filepath.Join(dir, "subdir"), os.FileMode(0755))
 	writeFakeMetadata(t, dir, "bogus-track", "bogus-exercise")
 
 	file1 := filepath.Join(dir, "file-1.txt")
-	err = ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
+	err := ioutil.WriteFile(file1, []byte("This is file 1."), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	v := viper.New()

--- a/workspace/document_test.go
+++ b/workspace/document_test.go
@@ -10,11 +10,9 @@ import (
 )
 
 func TestNormalizedDocumentPath(t *testing.T) {
-	root, err := ioutil.TempDir("", "docpath")
-	assert.NoError(t, err)
-	defer os.RemoveAll(root)
+	root := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(root, "subdirectory"), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Join(root, "subdirectory"), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	testCases := []struct {

--- a/workspace/exercise_metadata_test.go
+++ b/workspace/exercise_metadata_test.go
@@ -1,8 +1,6 @@
 package workspace
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -10,9 +8,7 @@ import (
 )
 
 func TestExerciseMetadata(t *testing.T) {
-	dir, err := ioutil.TempDir("", "solution")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	em1 := &ExerciseMetadata{
 		Track:        "a-track",
@@ -23,7 +19,7 @@ func TestExerciseMetadata(t *testing.T) {
 		IsRequester:  true,
 		Dir:          dir,
 	}
-	err = em1.Write(dir)
+	err := em1.Write(dir)
 	assert.NoError(t, err)
 
 	em2, err := NewExerciseMetadata(dir)

--- a/workspace/exercise_test.go
+++ b/workspace/exercise_test.go
@@ -10,14 +10,12 @@ import (
 )
 
 func TestHasMetadata(t *testing.T) {
-	ws, err := ioutil.TempDir("", "fake-workspace")
-	defer os.RemoveAll(ws)
-	assert.NoError(t, err)
+	ws := t.TempDir()
 
 	exerciseA := Exercise{Root: ws, Track: "bogus-track", Slug: "apple"}
 	exerciseB := Exercise{Root: ws, Track: "bogus-track", Slug: "banana"}
 
-	err = os.MkdirAll(filepath.Dir(exerciseA.MetadataFilepath()), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Dir(exerciseA.MetadataFilepath()), os.FileMode(0755))
 	assert.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(exerciseB.MetadataFilepath()), os.FileMode(0755))
 	assert.NoError(t, err)
@@ -35,14 +33,12 @@ func TestHasMetadata(t *testing.T) {
 }
 
 func TestHasLegacyMetadata(t *testing.T) {
-	ws, err := ioutil.TempDir("", "fake-workspace")
-	defer os.RemoveAll(ws)
-	assert.NoError(t, err)
+	ws := t.TempDir()
 
 	exerciseA := Exercise{Root: ws, Track: "bogus-track", Slug: "apple"}
 	exerciseB := Exercise{Root: ws, Track: "bogus-track", Slug: "banana"}
 
-	err = os.MkdirAll(filepath.Dir(exerciseA.LegacyMetadataFilepath()), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Dir(exerciseA.LegacyMetadataFilepath()), os.FileMode(0755))
 	assert.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(exerciseB.LegacyMetadataFilepath()), os.FileMode(0755))
 	assert.NoError(t, err)
@@ -76,13 +72,11 @@ func TestMigrationStatusString(t *testing.T) {
 }
 
 func TestMigrateLegacyMetadataFileWithoutLegacy(t *testing.T) {
-	ws, err := ioutil.TempDir("", "fake-workspace")
-	defer os.RemoveAll(ws)
-	assert.NoError(t, err)
+	ws := t.TempDir()
 
 	exercise := Exercise{Root: ws, Track: "bogus-track", Slug: "no-legacy"}
 	metadataFilepath := exercise.MetadataFilepath()
-	err = os.MkdirAll(filepath.Dir(metadataFilepath), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Dir(metadataFilepath), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(metadataFilepath, []byte{}, os.FileMode(0600))
@@ -104,13 +98,11 @@ func TestMigrateLegacyMetadataFileWithoutLegacy(t *testing.T) {
 }
 
 func TestMigrateLegacyMetadataFileWithLegacy(t *testing.T) {
-	ws, err := ioutil.TempDir("", "fake-workspace")
-	defer os.RemoveAll(ws)
-	assert.NoError(t, err)
+	ws := t.TempDir()
 
 	exercise := Exercise{Root: ws, Track: "bogus-track", Slug: "legacy"}
 	legacyMetadataFilepath := exercise.LegacyMetadataFilepath()
-	err = os.MkdirAll(filepath.Dir(legacyMetadataFilepath), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Dir(legacyMetadataFilepath), os.FileMode(0755))
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(legacyMetadataFilepath, []byte{}, os.FileMode(0600))
@@ -132,14 +124,12 @@ func TestMigrateLegacyMetadataFileWithLegacy(t *testing.T) {
 }
 
 func TestMigrateLegacyMetadataFileWithLegacyAndModern(t *testing.T) {
-	ws, err := ioutil.TempDir("", "fake-workspace")
-	defer os.RemoveAll(ws)
-	assert.NoError(t, err)
+	ws := t.TempDir()
 
 	exercise := Exercise{Root: ws, Track: "bogus-track", Slug: "both-legacy-and-modern"}
 	metadataFilepath := exercise.MetadataFilepath()
 	legacyMetadataFilepath := exercise.LegacyMetadataFilepath()
-	err = os.MkdirAll(filepath.Dir(legacyMetadataFilepath), os.FileMode(0755))
+	err := os.MkdirAll(filepath.Dir(legacyMetadataFilepath), os.FileMode(0755))
 	assert.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(metadataFilepath), os.FileMode(0755))
 	assert.NoError(t, err)

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestWorkspacePotentialExercises(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "walk")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	a1 := filepath.Join(tmpDir, "track-a", "exercise-one")
 	b1 := filepath.Join(tmpDir, "track-b", "exercise-one")
@@ -54,9 +52,7 @@ func TestWorkspacePotentialExercises(t *testing.T) {
 }
 
 func TestWorkspaceExercises(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "walk-with-metadata")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	a1 := filepath.Join(tmpDir, "track-a", "exercise-one")
 	a2 := filepath.Join(tmpDir, "track-a", "exercise-two") // no metadata


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```