### PR TITLE
Indent output of download command

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -123,8 +123,8 @@ func runDownload(cfg config.Config, flags *pflag.FlagSet, args []string) error {
 			return err
 		}
 	}
-	fmt.Fprintf(Err, "\nDownloaded to\n")
-	fmt.Fprintf(Out, "%s\n", metadata.Dir)
+	fmt.Fprintf(Err, "\n    Exercise has been successfully downloaded to:\n\n")
+	fmt.Fprintf(Out, "    %s\n", metadata.Dir)
 	return nil
 }
 


### PR DESCRIPTION
Hey! This is a suggestion to align the output of the `download` command with the same format as other commands in the cli. Usually the command outputs are indented by 4 spaces and lines are separated by one empty line, see the `submit` command for example:

```
exercism submit expenses.go


    Your solution has been submitted successfully.
    View it at:


    https://exercism.org/tracks/go/exercises/expenses

```

`download` previous to the change:

```
$ exercism download --exercise=expenses --track=go

Downloaded to
/home/user/snap/exercism/5/exercism/go/expenses

$
```

`download` after the change:

```
$ exercism download --exercise=animal-magic --track=go

    Exercise has been successfully downloaded to:

    /home/user/exercism/5/exercism/go/animal-magic

$
```