### PR TITLE
Fix tests with Go1.17

### DIFF
--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -272,7 +272,7 @@ func TestSubmitFiles(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, 3, len(submittedFiles))
 		assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
-		assert.Equal(t, "This is file 2.", submittedFiles["subdir/file-2.txt"])
+		assert.Equal(t, "This is file 2.", submittedFiles["file-2.txt"])
 		assert.Equal(t, "This is the readme.", submittedFiles["README.md"])
 		assert.Regexp(t, "submitted successfully", Err)
 	}
@@ -468,7 +468,7 @@ func TestSubmitFilesForTeamExercise(t *testing.T) {
 	assert.Equal(t, 2, len(submittedFiles))
 
 	assert.Equal(t, "This is file 1.", submittedFiles["file-1.txt"])
-	assert.Equal(t, "This is file 2.", submittedFiles["subdir/file-2.txt"])
+	assert.Equal(t, "This is file 2.", submittedFiles["file-2.txt"])
 }
 
 func TestSubmitOnlyEmptyFile(t *testing.T) {
@@ -561,7 +561,7 @@ func fakeSubmitServer(t *testing.T, submittedFiles map[string]string) *httptest.
 			if err != nil {
 				t.Fatal(err)
 			}
-			submittedFiles[fileHeader.Filename] = string(body)
+			submittedFiles[filepath.Base(fileHeader.Filename)] = string(body)
 		}
 
 		fmt.Fprint(w, "{}")


### PR DESCRIPTION
`Part.FileName` now applies `filepath.Base` to the return value [1]. For compatibility with older versions, this now explicitly applies `Base` when fetching `FileName` always.

Note that CI is on 1.15 which is no longer supported; I can update that to supported versions if needed.

[1] https://go.dev/doc/go1.17#mime/multipart