### PR TITLE
goreleaser: add arm64 build for each OS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     - amd64
     - 386
     - arm
+    - arm64
     - ppc64
   goarm:
     - 5

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/viper v0.0.0-20180507071007-15738813a09d
 	github.com/stretchr/testify v1.1.4
 	golang.org/x/net v0.0.0-20170726083632-f5079bd7f6f7
-	golang.org/x/sys v0.0.0-20170803140359-d8f5ea21b929
+	golang.org/x/sys v0.0.0-20201202213521-69691e467435
 	golang.org/x/text v0.0.0-20170730040918-3bd178b88a81
 	gopkg.in/yaml.v2 v2.0.0-20170721122051-25c4ec802a7d
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ golang.org/x/net v0.0.0-20170726083632-f5079bd7f6f7 h1:1Pw+ZX4dmGORIwGkTwnUr7RFu
 golang.org/x/net v0.0.0-20170726083632-f5079bd7f6f7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20170803140359-d8f5ea21b929 h1:M4VPQYSW/nB4Bcg1XMD4yW2sprnwerD3Kb6apRphtZw=
 golang.org/x/sys v0.0.0-20170803140359-d8f5ea21b929/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20201202213521-69691e467435 h1:25AvDqqB9PrNqj1FLf2/70I4W0L19qqoaFq3gjNwbKk=
+golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170730040918-3bd178b88a81 h1:7aXI3TQ9sZ4JdDoIDGjxL6G2mQxlsPy9dySnJaL6Bdk=
 golang.org/x/text v0.0.0-20170730040918-3bd178b88a81/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/yaml.v2 v2.0.0-20170721122051-25c4ec802a7d h1:2DX7x6HUDGZUyuEDAhUsQQNqkb1zvDyKTjVoTdzaEzo=


### PR DESCRIPTION
The latest release of the Exercism CLI ([3.1.0](https://github.com/exercism/cli/releases/tag/v3.1.0), 2022-10-04) includes these assets, via GoReleaser:

```text
exercism-3.1.0-darwin-x86_64.tar.gz
exercism-3.1.0-freebsd-i386.tar.gz
exercism-3.1.0-freebsd-x86_64.tar.gz
exercism-3.1.0-linux-armv5.tar.gz
exercism-3.1.0-linux-armv6.tar.gz
exercism-3.1.0-linux-i386.tar.gz
exercism-3.1.0-linux-ppc64.tar.gz
exercism-3.1.0-linux-x86_64.tar.gz
exercism-3.1.0-openbsd-i386.tar.gz
exercism-3.1.0-openbsd-x86_64.tar.gz
exercism-3.1.0-windows-armv5.zip
exercism-3.1.0-windows-armv6.zip
exercism-3.1.0-windows-i386.zip
exercism-3.1.0-windows-x86_64.zip
exercism_checksums.txt
exercism_checksums.txt.sig
```

For the next release, make GoReleaser include an arm64 (AKA aarch64) build for each of the existing OSes. This means we will have separate x86_64 and arm64 release assets for macOS; previously macOS users on arm64 had to run the x86_64 binary via Rosetta (or build the CLI themselves).

At least for now, let's avoid adding a fat binary (which contains both x86_64 and arm64 executables). But note that [GoReleaser does support it][goreleaser-universal-binaries].

Closes: #966

[goreleaser-universal-binaries]: https://goreleaser.com/customization/universalbinaries/

---

I am not a GoReleaser expert - please review this carefully.

Note for Go 1.19.3, the [first class](https://github.com/golang/go/wiki/PortingPolicy#first-class-ports) targets are:

```console
$ go tool dist list -json \
    | jq -r '.[] | select(.FirstClass) | [.GOOS, .GOARCH] | @tsv'
darwin	amd64
darwin	arm64
linux	386
linux	amd64
linux	arm
linux	arm64
windows	386
windows	amd64
```

so Go itself does not declare arm64 as "first class" on Windows, FreeBSD, and OpenBSD. But the Exercism CLI already provides lots of releases that aren't in the above list.

GitHub does not yet provide arm64 machines for their hosted runners, so we can't run integration tests of the new arm64 binaries on the native architecture without adding a new CI provider.