### PR TITLE
Mask API token by default when printing configuration

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/exercism/cli/api"
 	"github.com/exercism/cli/config"
+	"github.com/exercism/cli/debug"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -202,9 +203,14 @@ func printCurrentConfig(configuration config.Config) {
 
 	v := configuration.UserViperConfig
 
+	token := v.GetString("token")
+	if !debug.UnmaskAPIKey {
+		token = debug.Redact(token)
+	}
+
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, fmt.Sprintf("Config dir:\t\t%s", configuration.Dir))
-	fmt.Fprintln(w, fmt.Sprintf("Token:\t(-t, --token)\t%s", v.GetString("token")))
+	fmt.Fprintln(w, fmt.Sprintf("Token:\t(-t, --token)\t%s", token))
 	fmt.Fprintln(w, fmt.Sprintf("Workspace:\t(-w, --workspace)\t%s", v.GetString("workspace")))
 	fmt.Fprintln(w, fmt.Sprintf("API Base URL:\t(-a, --api)\t%s", v.GetString("apibaseurl")))
 	fmt.Fprintln(w, "")

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -73,7 +73,7 @@ func TestConfigureShow(t *testing.T) {
 	assert.Regexp(t, "configured.example", Err)
 	assert.NotRegexp(t, "override.example", Err)
 
-	assert.Regexp(t, "configured-token", Err)
+	assert.Regexp(t, `conf\*\*\*\*\*\*\*\*\*ken`, Err)
 	assert.NotRegexp(t, "token-override", Err)
 
 	assert.Regexp(t, "configured-workspace", Err)

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -91,6 +91,9 @@ func DumpResponse(res *http.Response) {
 
 // Redact masks the given token by replacing part of the string with *
 func Redact(token string) string {
+	if len(token) < 7 {
+		return "*******"
+	}
 	str := token[4 : len(token)-3]
 	redaction := strings.Repeat("*", len(str))
 	return string(token[:4]) + redaction + string(token[len(token)-3:])


### PR DESCRIPTION
This is already done for when requests are printed, but not configuration. This is unexpected and may lead to inadvertent leaks of tokens.