### PR TITLE
Add `test` command to run any unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The exercism CLI follows [semantic versioning](http://semver.org/).
 ----------------
 
 ## Next Release
+* [#1092](https://github.com/exercism/cli/pull/1092) Add `exercism test` command to run the unit tests for nearly any track (inspired by [universal-test-runner](https://github.com/xavdid/universal-test-runner)) - [@xavdid]
 * **Your contribution here**
 
 ## v3.1.0 (2022-10-04)
@@ -489,5 +490,6 @@ All changes by [@msgehard]
 [@sfairchild]: https://github.com/sfairchild
 [@simonjefford]: https://github.com/simonjefford
 [@srt32]: https://github.com/srt32
+[@xavdid]: https://github.com/xavdid
 [@williandrade]: https://github.com/williandrade
 [@zabawaba99]: https://github.com/zabawaba99

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,5 @@ On Windows:
 
 ### Releasing a new CLI version
 Consult the [release documentation](RELEASE.md).
+
+[fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,3 @@ On Windows:
 
 ### Releasing a new CLI version
 Consult the [release documentation](RELEASE.md).
-
-[fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -26,12 +26,14 @@ const cfgHomeKey = "EXERCISM_CONFIG_HOME"
 // test, call the command by calling Execute on the App.
 //
 // Example:
-// cmdTest := &CommandTest{
-// 	Cmd:    myCmd,
-// 	InitFn: initMyCmd,
-// 	Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
-// 	MockInteractiveResponse: "first-input\nsecond\n",
-// }
+//
+//	cmdTest := &CommandTest{
+//		Cmd:    myCmd,
+//		InitFn: initMyCmd,
+//		Args:   []string{"fakeapp", "mycommand", "arg1", "--flag", "value"},
+//		MockInteractiveResponse: "first-input\nsecond\n",
+//	}
+//
 // cmdTest.Setup(t)
 // defer cmdTest.Teardown(t)
 // ...

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -47,6 +47,7 @@ func runTest(args []string) error {
 		cmdParts = append(cmdParts, args...)
 	}
 
+	fmt.Printf("--> %s\n", strings.Join(cmdParts, " "))
 	exerciseTestCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
 
 	// pipe output directly out, preserving any color

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/exercism/cli/workspace"
+	"github.com/spf13/cobra"
+)
+
+type TestConfiguration struct {
+	// The static portion of the test command, which will be run for every test on this track. Examples include `cargo test` or `go test`
+	command string
+	// Some tracks test by running a specific file, such as `ruby lasagna_test.rb`. Set this to `true` to look up and include the name of the default test file.
+	AppendTestFiles bool
+	// All args after `--` aren't parsed and are passed to the test command. Some languages (especially `rust`) expect an additional `--` between _their_ args. So instead of requiring a user to call `exercism test -- -- --include-ingored` to run all `rust` tests, set this to `true` to separate the args passed to the test runner by a `--` automatically.
+	autoSeparateArgs bool
+}
+
+var testConfigurations = map[string]TestConfiguration{
+	"go": {
+		command: "go test",
+	},
+	"rust": {
+		command:          "cargo test",
+		autoSeparateArgs: true,
+	},
+	"ruby": {
+		command:         "ruby",
+		AppendTestFiles: true,
+	},
+}
+
+var testCmd = &cobra.Command{
+	Use:     "test",
+	Aliases: []string{"t"},
+	Short:   "Infer and run the test command for an exercise.",
+	Long: `Infer and run the test command for an exercise.
+
+	Run this command in an exercise's root directory.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		track, err := getTrack()
+
+		if err != nil {
+			return err
+		}
+
+		testConf, ok := testConfigurations[track]
+
+		if !ok {
+			return fmt.Errorf("test handler for track `%s` not yet implemented. Please see HELP.md for testing instructions", track)
+		}
+
+		cmdParts := strings.Split(testConf.command, " ")
+
+		if testConf.AppendTestFiles {
+			testFiles, err := workspace.NewExerciseConfig(".")
+			if err != nil {
+				return err
+			}
+			cmdParts = append(cmdParts, testFiles.Files.Test...)
+		}
+
+		if len(args) > 0 {
+			if testConf.autoSeparateArgs {
+				cmdParts = append(cmdParts, "--")
+			}
+			cmdParts = append(cmdParts, args...)
+		}
+
+		exerciseTestCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+
+		// pipe output directly out, preserving any color
+		exerciseTestCmd.Stdout = os.Stdout
+		exerciseTestCmd.Stderr = os.Stderr
+
+		err = exerciseTestCmd.Run()
+		if err != nil {
+			// unclear what other errors would pop up here, but it pays to be defensive
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode := exitErr.ExitCode()
+				// if subcommand returned a non-zero exit code, exit with the same
+				os.Exit(exitCode)
+			} else {
+				log.Fatalf("Failed to get error from failed subcommand: %v", err)
+			}
+		}
+		return nil
+	},
+}
+
+func getTrack() (string, error) {
+	metadata, err := workspace.NewExerciseMetadata(".")
+	if err != nil {
+		return "", err
+	}
+
+	return metadata.Track, nil
+}
+
+func init() {
+	RootCmd.AddCommand(testCmd)
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -36,15 +36,11 @@ func runTest(args []string) error {
 		return fmt.Errorf("test handler for the `%s` track not yet implemented. Please see HELP.md for testing instructions", track)
 	}
 
-	cmdParts := strings.Split(testConf.GetTestCommand(), " ")
-
-	if testConf.AppendTestFiles {
-		testFiles, err := getTestFiles()
-		if err != nil {
-			return err
-		}
-		cmdParts = append(cmdParts, testFiles...)
+	command, err := testConf.GetTestCommand()
+	if err != nil {
+		return err
 	}
+	cmdParts := strings.Split(command, " ")
 
 	// pass args/flags to this command down to the test handler
 	if len(args) > 0 {
@@ -79,14 +75,6 @@ func getTrack() (string, error) {
 	}
 
 	return metadata.Track, nil
-}
-
-func getTestFiles() ([]string, error) {
-	testFiles, err := workspace.NewExerciseConfig(".")
-	if err != nil {
-		return []string{}, err
-	}
-	return testFiles.Files.Test, nil
 }
 
 func init() {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -14,8 +14,8 @@ import (
 var testCmd = &cobra.Command{
 	Use:     "test",
 	Aliases: []string{"t"},
-	Short:   "Infer and run the test command for an exercise.",
-	Long: `Infer and run the test command for an exercise.
+	Short:   "Run the exercise's tests.",
+	Long: `Run the exercise's tests.
 
 	Run this command in an exercise's root directory.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -48,9 +48,7 @@ func runTest(args []string) error {
 
 	// pass args/flags to this command down to the test handler
 	if len(args) > 0 {
-		if testConf.AutoSeparateArgs {
-			cmdParts = append(cmdParts, "--")
-		}
+
 		cmdParts = append(cmdParts, args...)
 	}
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -44,7 +44,6 @@ func runTest(args []string) error {
 
 	// pass args/flags to this command down to the test handler
 	if len(args) > 0 {
-
 		cmdParts = append(cmdParts, args...)
 	}
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -32,7 +32,7 @@ func runTest(args []string) error {
 	testConf, ok := workspace.TestConfigurations[track]
 
 	if !ok {
-		return fmt.Errorf("test handler for the `%s` track not yet implemented. Please see HELP.md for testing instructions", track)
+		return fmt.Errorf("the \"%s\" track does not yet support running tests using the Exercism CLI. Please see HELP.md for testing instructions", track)
 	}
 
 	command, err := testConf.GetTestCommand()
@@ -46,7 +46,7 @@ func runTest(args []string) error {
 		cmdParts = append(cmdParts, args...)
 	}
 
-	fmt.Printf("--> %s\n", strings.Join(cmdParts, " "))
+	fmt.Printf("Running tests via `%s`\n\n", strings.Join(cmdParts, " "))
 	exerciseTestCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
 
 	// pipe output directly out, preserving any color

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,7 +25,6 @@ var testCmd = &cobra.Command{
 
 func runTest(args []string) error {
 	track, err := getTrack()
-
 	if err != nil {
 		return err
 	}
@@ -72,6 +71,9 @@ func getTrack() (string, error) {
 	metadata, err := workspace.NewExerciseMetadata(".")
 	if err != nil {
 		return "", err
+	}
+	if metadata.Track == "" {
+		return "", fmt.Errorf("no track found in exercise metadata")
 	}
 
 	return metadata.Track, nil

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -51,19 +51,20 @@ var testCmd = &cobra.Command{
 		testConf, ok := testConfigurations[track]
 
 		if !ok {
-			return fmt.Errorf("test handler for track `%s` not yet implemented. Please see HELP.md for testing instructions", track)
+			return fmt.Errorf("test handler for the `%s` track not yet implemented. Please see HELP.md for testing instructions", track)
 		}
 
 		cmdParts := strings.Split(testConf.command, " ")
 
 		if testConf.AppendTestFiles {
-			testFiles, err := workspace.NewExerciseConfig(".")
+			testFiles, err := getTestFiles()
 			if err != nil {
 				return err
 			}
-			cmdParts = append(cmdParts, testFiles.Files.Test...)
+			cmdParts = append(cmdParts, testFiles...)
 		}
 
+		// pass args/flags to this command down to the test handler
 		if len(args) > 0 {
 			if testConf.autoSeparateArgs {
 				cmdParts = append(cmdParts, "--")
@@ -99,6 +100,14 @@ func getTrack() (string, error) {
 	}
 
 	return metadata.Track, nil
+}
+
+func getTestFiles() ([]string, error) {
+	testFiles, err := workspace.NewExerciseConfig(".")
+	if err != nil {
+		return []string{}, err
+	}
+	return testFiles.Files.Test, nil
 }
 
 func init() {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -5,69 +5,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/exercism/cli/workspace"
 	"github.com/spf13/cobra"
 )
-
-type PlatformSpecificCommands struct {
-	Windows string
-	Darwin  string
-	Linux   string
-}
-
-type TestConfiguration struct {
-	// The static portion of the test Command, which will be run for every test on this track. Examples include `cargo test` or `go test`.
-	// Might be empty if there are platform-specific versions
-	Command string
-
-	// Platform-specific test commands. Mostly relevant for tests wrapped by shell invocations. Falls back to `Command` if platform isn't available.
-	PlatformSpecificCommands
-
-	// Some tracks test by running a specific file, such as `ruby lasagna_test.rb`. Set this to `true` to look up and include the name of the default test file(s).
-	AppendTestFiles bool
-	// All args after `--` aren't parsed and are passed to the test command. Some languages (especially `rust`) expect an additional `--` between _their_ args. So instead of requiring a user to call `exercism test -- -- --include-ingored` to run all `rust` tests, set this to `true` to separate the args passed to the test runner by a `--` automatically.
-	AutoSeparateArgs bool
-}
-
-func (c *TestConfiguration) getTestCommand() string {
-	if c.PlatformSpecificCommands == (PlatformSpecificCommands{}) {
-		return c.Command
-	}
-
-	switch runtime.GOOS {
-	case "windows":
-		if c.PlatformSpecificCommands.Windows != "" {
-			return c.PlatformSpecificCommands.Windows
-		}
-	case "darwin":
-		if c.PlatformSpecificCommands.Darwin != "" {
-			return c.PlatformSpecificCommands.Darwin
-		}
-	case "linux":
-		if c.PlatformSpecificCommands.Linux != "" {
-			return c.PlatformSpecificCommands.Linux
-		}
-	}
-
-	return c.Command
-}
-
-var testConfigurations = map[string]TestConfiguration{
-	"go": {
-		Command: "go test",
-	},
-	"rust": {
-		Command:          "cargo test",
-		AutoSeparateArgs: true,
-	},
-	"ruby": {
-		Command:         "ruby",
-		AppendTestFiles: true,
-	},
-}
 
 var testCmd = &cobra.Command{
 	Use:     "test",
@@ -88,13 +30,13 @@ func runTest(args []string) error {
 		return err
 	}
 
-	testConf, ok := testConfigurations[track]
+	testConf, ok := workspace.TestConfigurations[track]
 
 	if !ok {
 		return fmt.Errorf("test handler for the `%s` track not yet implemented. Please see HELP.md for testing instructions", track)
 	}
 
-	cmdParts := strings.Split(testConf.getTestCommand(), " ")
+	cmdParts := strings.Split(testConf.GetTestCommand(), " ")
 
 	if testConf.AppendTestFiles {
 		testFiles, err := getTestFiles()

--- a/workspace/exercise_config.go
+++ b/workspace/exercise_config.go
@@ -1,0 +1,33 @@
+package workspace
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+)
+
+const configFilename = "config.json"
+
+var configFilepath = filepath.Join(ignoreSubdir, configFilename)
+
+// ExerciseConfig contains metadata about the problem.
+// It's got a bunch more fields, but we don't need to read them
+type ExerciseConfig struct {
+	Files struct {
+		Test []string `json:"test"`
+	} `json:"files"`
+}
+
+// NewExerciseMetadata reads exercise metadata from a file in the given directory.
+func NewExerciseConfig(dir string) (*ExerciseConfig, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, configFilepath))
+	if err != nil {
+		return nil, err
+	}
+	var config ExerciseConfig
+	if err := json.Unmarshal(b, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/workspace/exercise_config.go
+++ b/workspace/exercise_config.go
@@ -15,7 +15,8 @@ var configFilepath = filepath.Join(ignoreSubdir, configFilename)
 // Note: we only use a subset of its fields
 type ExerciseConfig struct {
 	Files struct {
-		Test []string `json:"test"`
+		Solution []string `json:"solution"`
+		Test     []string `json:"test"`
 	} `json:"files"`
 }
 
@@ -33,12 +34,24 @@ func NewExerciseConfig(dir string) (*ExerciseConfig, error) {
 	return &config, nil
 }
 
-// GetTestFiles finds returns the names of the files that hold unit tests for this exercise, if any
+// GetTestFiles finds returns the names of the file(s) that hold unit tests for this exercise, if any
+func (c *ExerciseConfig) GetSolutionFiles() ([]string, error) {
+	result := c.Files.Solution
+	if result == nil {
+		// solution file(s) key was missing in config json, which is an error when calling this fuction
+		return []string{}, errors.New("no `files.solution` key in your `config.json`. Was it removed by mistake?")
+	}
+
+	return result, nil
+}
+
+// GetTestFiles finds returns the names of the file(s) that hold unit tests for this exercise, if any
 func (c *ExerciseConfig) GetTestFiles() ([]string, error) {
-	if c.Files.Test == nil {
-		// test files key was missing in config json, which is an error when calling this fuction
+	result := c.Files.Test
+	if result == nil {
+		// test file(s) key was missing in config json, which is an error when calling this fuction
 		return []string{}, errors.New("no `files.test` key in your `config.json`. Was it removed by mistake?")
 	}
 
-	return c.Files.Test, nil
+	return result, nil
 }

--- a/workspace/exercise_config.go
+++ b/workspace/exercise_config.go
@@ -10,15 +10,15 @@ const configFilename = "config.json"
 
 var configFilepath = filepath.Join(ignoreSubdir, configFilename)
 
-// ExerciseConfig contains metadata about the problem.
-// It's got a bunch more fields, but we don't need to read them
+// ExerciseConfig contains exercise metadata.
+// Note: we only use a subset of its fields
 type ExerciseConfig struct {
 	Files struct {
 		Test []string `json:"test"`
 	} `json:"files"`
 }
 
-// NewExerciseMetadata reads exercise metadata from a file in the given directory.
+// NewExerciseConfig reads exercise metadata from a file in the given directory.
 func NewExerciseConfig(dir string) (*ExerciseConfig, error) {
 	b, err := ioutil.ReadFile(filepath.Join(dir, configFilepath))
 	if err != nil {

--- a/workspace/exercise_config.go
+++ b/workspace/exercise_config.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 )
@@ -30,4 +31,14 @@ func NewExerciseConfig(dir string) (*ExerciseConfig, error) {
 	}
 
 	return &config, nil
+}
+
+// GetTestFiles finds returns the names of the files that hold unit tests for this exercise, if any
+func (c *ExerciseConfig) GetTestFiles() ([]string, error) {
+	if c.Files.Test == nil {
+		// test files key was missing in config json, which is an error when calling this fuction
+		return []string{}, errors.New("no `files.test` key in your `config.json`. Was it removed by mistake?")
+	}
+
+	return c.Files.Test, nil
 }

--- a/workspace/exercise_config_test.go
+++ b/workspace/exercise_config_test.go
@@ -62,7 +62,7 @@ func TestMissingExerciseConfig(t *testing.T) {
 
 	_, err = NewExerciseConfig(dir)
 	assert.Error(t, err)
-	// this error message has to show up across all platforms, so be vague
+	// any assertions about this error message have to work across all platforms, so be vague
 	// unix: ".exercism/config.json: no such file or directory"
 	// windows: "open .exercism\config.json: The system cannot find the path specified."
 	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))

--- a/workspace/exercise_config_test.go
+++ b/workspace/exercise_config_test.go
@@ -28,6 +28,11 @@ func TestExerciseConfig(t *testing.T) {
 	ec, err := NewExerciseConfig(dir)
 	assert.NoError(t, err)
 
+	assert.Equal(t, ec.Files.Solution, []string{"lasagna.rb"})
+	solutionFiles, err := ec.GetSolutionFiles()
+	assert.NoError(t, err)
+	assert.Equal(t, solutionFiles, []string{"lasagna.rb"})
+
 	assert.Equal(t, ec.Files.Test, []string{"lasagna_test.rb"})
 	testFiles, err := ec.GetTestFiles()
 	assert.NoError(t, err)
@@ -45,12 +50,14 @@ func TestExerciseConfigNoTestKey(t *testing.T) {
 	f, err := os.Create(filepath.Join(dir, ".exercism", "config.json"))
 	assert.NoError(t, err)
 
-	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.rb"], "exemplar": [".meta/exemplar.rb"] } } `)
+	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "exemplar": [".meta/exemplar.rb"] } } `)
 	assert.NoError(t, err)
 
 	ec, err := NewExerciseConfig(dir)
 	assert.NoError(t, err)
 
+	_, err = ec.GetSolutionFiles()
+	assert.Error(t, err, "no `files.solution` key in your `config.json`")
 	_, err = ec.GetTestFiles()
 	assert.Error(t, err, "no `files.test` key in your `config.json`")
 }

--- a/workspace/exercise_config_test.go
+++ b/workspace/exercise_config_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -60,7 +61,11 @@ func TestMissingExerciseConfig(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	_, err = NewExerciseConfig(dir)
-	assert.True(t, strings.Contains(err.Error(), ".exercism/config.json: no such file or directory"))
+	assert.Error(t, err)
+	// this error message has to show up across all platforms, so be vague
+	// unix: ".exercism/config.json: no such file or directory"
+	// windows: "open .exercism\config.json: The system cannot find the path specified."
+	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))
 }
 
 func TestInvalidExerciseConfig(t *testing.T) {

--- a/workspace/exercise_config_test.go
+++ b/workspace/exercise_config_test.go
@@ -20,6 +20,7 @@ func TestExerciseConfig(t *testing.T) {
 
 	f, err := os.Create(filepath.Join(dir, ".exercism", "config.json"))
 	assert.NoError(t, err)
+	defer f.Close()
 
 	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.rb"], "test": ["lasagna_test.rb"], "exemplar": [".meta/exemplar.rb"] } } `)
 	assert.NoError(t, err)
@@ -48,6 +49,7 @@ func TestExerciseConfigNoTestKey(t *testing.T) {
 
 	f, err := os.Create(filepath.Join(dir, ".exercism", "config.json"))
 	assert.NoError(t, err)
+	defer f.Close()
 
 	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "exemplar": [".meta/exemplar.rb"] } } `)
 	assert.NoError(t, err)
@@ -84,6 +86,7 @@ func TestInvalidExerciseConfig(t *testing.T) {
 
 	f, err := os.Create(filepath.Join(dir, ".exercism", "config.json"))
 	assert.NoError(t, err)
+	defer f.Close()
 
 	// invalid JSON
 	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarr `)

--- a/workspace/exercise_config_test.go
+++ b/workspace/exercise_config_test.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,7 +71,7 @@ func TestMissingExerciseConfig(t *testing.T) {
 	// any assertions about this error message have to work across all platforms, so be vague
 	// unix: ".exercism/config.json: no such file or directory"
 	// windows: "open .exercism\config.json: The system cannot find the path specified."
-	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))
+	assert.Contains(t, err.Error(), filepath.Join(".exercism", "config.json:"))
 }
 
 func TestInvalidExerciseConfig(t *testing.T) {

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"errors"
 	"runtime"
 	"strings"
 )
@@ -24,7 +23,12 @@ func (c *TestConfiguration) GetTestCommand() (string, error) {
 	}
 
 	if strings.Contains(cmd, "{{test_files}}") {
-		testFiles, err := getTestFiles()
+		exerciseConfig, err := NewExerciseConfig(".")
+		if err != nil {
+			return "", err
+		}
+
+		testFiles, err := exerciseConfig.GetTestFiles()
 		if err != nil {
 			return "", err
 		}
@@ -79,19 +83,4 @@ var TestConfigurations = map[string]TestConfiguration{
 	"ruby": {
 		Command: "ruby {{test_files}}",
 	},
-}
-
-func getTestFiles() ([]string, error) {
-	testFiles, err := NewExerciseConfig(".")
-	if err != nil {
-		return []string{}, err
-	}
-
-	if testFiles.Files.Test == nil {
-		// test files key was missing in config json,
-		// we only call this when we actually need the test files, so error out
-		return []string{}, errors.New("no files.test key in your config.json, but required to run the test")
-	}
-
-	return testFiles.Files.Test, nil
 }

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"runtime"
 	"strings"
 )
@@ -35,7 +36,7 @@ func (c *TestConfiguration) GetTestCommand() (string, error) {
 
 var TestConfigurations = map[string]TestConfiguration{
 	"8th": {
-		Command:        "tester.sh",
+		Command:        "bash tester.sh",
 		WindowsCommand: "tester.bat",
 	},
 	"ballerina": {
@@ -48,8 +49,8 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "box task run TestRunner",
 	},
 	"cobol": {
-		Command:        "test.sh",
-		WindowsCommand: "test.ps1",
+		Command:        "bash test.sh",
+		WindowsCommand: "pwsh test.ps1",
 	},
 	"coffeescript": {
 		Command: "jasmine-node --coffee {{test_files}}",
@@ -85,5 +86,12 @@ func getTestFiles() ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
+
+	if testFiles.Files.Test == nil {
+		// test files key was missing in config json,
+		// we only call this when we actually need the test files, so error out
+		return []string{}, errors.New("no files.test key in your config.json, but required to run the test")
+	}
+
 	return testFiles.Files.Test, nil
 }

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -43,14 +43,24 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command:        "bash tester.sh",
 		WindowsCommand: "tester.bat",
 	},
+	"awk": {
+		Command: "bats {{test_files}}",
+	},
 	"ballerina": {
 		Command: "bal test",
+	},
+	"bash": {
+		Command: "bats {{test_files}}",
 	},
 	"c": {
 		Command: "make",
 	},
 	"cfml": {
 		Command: "box task run TestRunner",
+	},
+	"clojure": {
+		// chosen because the docs recommend `clj` by default and `lein` as optional
+		Command: "clj -X:test",
 	},
 	"cobol": {
 		Command:        "bash test.sh",
@@ -64,6 +74,10 @@ var TestConfigurations = map[string]TestConfiguration{
 	},
 	"csharp": {
 		Command: "dotnet test",
+	},
+	"d": {
+		// this always works even if the user installed DUB
+		Command: "dmd source/*.d -de -w -main -unittest",
 	},
 	"dart": {
 		Command: "dart test",
@@ -100,6 +114,9 @@ var TestConfigurations = map[string]TestConfiguration{
 	},
 	"javascript": {
 		Command: "npm run test",
+	},
+	"jq": {
+		Command: "bats {{test_files}}",
 	},
 	"julia": {
 		Command: "julia runtests.jl",

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -1,0 +1,74 @@
+package workspace
+
+import "runtime"
+
+type TestConfiguration struct {
+	// The static portion of the test Command, which will be run for every test on this track. Examples include `cargo test` or `go test`.
+	// Might be empty if there are platform-specific versions
+	Command string
+
+	// Windows-specific test command. Mostly relevant for tests wrapped by shell invocations. Falls back to `Command` if we're not running windows or this is empty.
+	WindowsCommand string
+
+	// Some tracks test by running a specific file, such as `ruby lasagna_test.rb`. Set this to `true` to look up and include the name of the default test file(s).
+	AppendTestFiles bool
+	// All args after `--` aren't parsed and are passed to the test command. Some languages (especially `rust`) expect an additional `--` between _their_ args. So instead of requiring a user to call `exercism test -- -- --include-ingored` to run all `rust` tests, set this to `true` to separate the args passed to the test runner by a `--` automatically.
+	AutoSeparateArgs bool
+}
+
+func (c *TestConfiguration) GetTestCommand() string {
+	if runtime.GOOS == "windows" && c.WindowsCommand != "" {
+		return c.WindowsCommand
+	}
+	return c.Command
+}
+
+var TestConfigurations = map[string]TestConfiguration{
+	"8th": {
+		Command:        "tester.sh",
+		WindowsCommand: "tester.bat",
+	},
+	"ballerina": {
+		Command: "bal test",
+	},
+	"c": {
+		Command: "make",
+	},
+	"cfml": {
+		Command: "box task run TestRunner",
+	},
+	"cobol": {
+		Command:        "test.sh",
+		WindowsCommand: "test.ps1",
+	},
+	"coffeescript": {
+		Command:         "jasmine-node --coffee",
+		AppendTestFiles: true,
+	},
+	"crystal": {
+		Command: "crystal spec",
+	},
+	"csharp": {
+		Command: "dotnet test",
+	},
+	"dart": {
+		Command: "dart test",
+	},
+	"elixir": {
+		Command: "mix test",
+	},
+	"elm": {
+		Command: "elm-test",
+	},
+	"go": {
+		Command: "go test",
+	},
+	"rust": {
+		Command:          "cargo test",
+		AutoSeparateArgs: true,
+	},
+	"ruby": {
+		Command:         "ruby",
+		AppendTestFiles: true,
+	},
+}

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -74,13 +74,116 @@ var TestConfigurations = map[string]TestConfiguration{
 	"elm": {
 		Command: "elm-test",
 	},
+	"emacs-lisp": {
+		Command: "emacs -batch -l ert -l *-test.el -f ert-run-tests-batch-and-exit",
+	},
+	"erlang": {
+		Command: "rebar3 eunit",
+	},
+	"fsharp": {
+		Command: "dotnet test",
+	},
+	"gleam": {
+		Command: "gleam test",
+	},
 	"go": {
 		Command: "go test",
+	},
+	"groovy": {
+		Command: "gradle test",
+	},
+	"haskell": {
+		Command: "stack test",
+	},
+	"java": {
+		Command: "gradle test",
+	},
+	"javascript": {
+		Command: "npm run test",
+	},
+	"julia": {
+		Command: "julia runtests.jl",
+	},
+	"kotlin": {
+		Command:        "./gradlew test",
+		WindowsCommand: "gradlew.bat test",
+	},
+	"lfe": {
+		Command: "make test",
+	},
+	"lua": {
+		Command: "busted",
+	},
+	"mips": {
+		Command: "java -jar /path/to/mars.jar nc runner.mips impl.mips",
+	},
+	"nim": {
+		Command: "nim r {{test_files}}",
+	},
+	"ocaml": {
+		Command: "make",
+	},
+	"perl5": {
+		Command: "prove .",
+	},
+	"php": {
+		Command: "phpunit {{test_files}}",
+	},
+	"purescript": {
+		Command: "spago test",
+	},
+	"python": {
+		Command: "python3 -m pytest -o markers=task {{test_files}}",
+	},
+	"racket": {
+		Command: "raco test {{test_files}}",
+	},
+	"raku": {
+		Command: "prove6 {{test_files}}",
+	},
+	"reasonml": {
+		Command: "npm run test",
+	},
+	"red": {
+		Command: "red {{test_files}}",
+	},
+	"ruby": {
+		Command: "ruby {{test_files}}",
 	},
 	"rust": {
 		Command: "cargo test --",
 	},
-	"ruby": {
-		Command: "ruby {{test_files}}",
+	"scala": {
+		Command: "sbt test",
+	},
+	"sml": {
+		Command: "poly -q --use {{test_files}}",
+	},
+	"swift": {
+		Command: "swift test",
+	},
+	"tcl": {
+		Command: "tclsh {{test_files}}",
+	},
+	"typescript": {
+		Command: "yarn test",
+	},
+	"vbnet": {
+		Command: "dotnet test",
+	},
+	"vlang": {
+		Command: "v -stats test run_test.v",
+	},
+	"wasm": {
+		Command: "npm run test",
+	},
+	"wren": {
+		Command: "wrenc {{test_files}}",
+	},
+	"x86-64-assembly": {
+		Command: "make",
+	},
+	"zig": {
+		Command: "zig test {{test_files}}",
 	},
 }

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -93,7 +93,9 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "jasmine-node --coffee {{test_files}}",
 	},
 	// common-lisp: tests are loaded into a "running Lisp implementation", not the CLI directly
-	// cpp: tests are mostly run via IDE; only linux seems to support `make`. There's also a more complex test creation process (using `CMake`)
+	"cpp": {
+		Command: "make",
+	},
 	"crystal": {
 		Command: "crystal spec",
 	},
@@ -120,7 +122,9 @@ var TestConfigurations = map[string]TestConfiguration{
 	"erlang": {
 		Command: "rebar3 eunit",
 	},
-	// fortran: tests are mostly run via IDE; macOS/linux seem to support `make`, but there's also a more complex test creation process (using `CMake`)
+	"fortran": {
+		Command: "make",
+	},
 	"fsharp": {
 		Command: "dotnet test",
 	},

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -59,11 +59,13 @@ func (c *TestConfiguration) GetTestCommand() (string, error) {
 	return cmd, nil
 }
 
+// some tracks aren't (or won't be) implemented; every track is listed either way
 var TestConfigurations = map[string]TestConfiguration{
 	"8th": {
 		Command:        "bash tester.sh",
 		WindowsCommand: "tester.bat",
 	},
+	// abap: tests are run via "ABAP Development Tools", not the CLI
 	"awk": {
 		Command: "bats {{test_files}}",
 	},
@@ -90,6 +92,8 @@ var TestConfigurations = map[string]TestConfiguration{
 	"coffeescript": {
 		Command: "jasmine-node --coffee {{test_files}}",
 	},
+	// common-lisp: tests are loaded into a "running Lisp implementation", not the CLI directly
+	// cpp: tests are mostly run via IDE; only linux seems to support `make`. There's also a more complex test creation process (using `CMake`)
 	"crystal": {
 		Command: "crystal spec",
 	},
@@ -103,6 +107,7 @@ var TestConfigurations = map[string]TestConfiguration{
 	"dart": {
 		Command: "dart test",
 	},
+	// delphi: tests are run via IDE
 	"elixir": {
 		Command: "mix test",
 	},
@@ -115,6 +120,7 @@ var TestConfigurations = map[string]TestConfiguration{
 	"erlang": {
 		Command: "rebar3 eunit",
 	},
+	// fortran: tests are mostly run via IDE; macOS/linux seem to support `make`, but there's also a more complex test creation process (using `CMake`)
 	"fsharp": {
 		Command: "dotnet test",
 	},
@@ -158,15 +164,18 @@ var TestConfigurations = map[string]TestConfiguration{
 	"nim": {
 		Command: "nim r {{test_files}}",
 	},
+	// objective-c: tests are run via XCode. There's a CLI option (ruby gem `objc`), but the docs note that this is an inferior experience
 	"ocaml": {
 		Command: "make",
 	},
 	"perl5": {
 		Command: "prove .",
 	},
+	// pharo-smalltalk: tests are run via IDE
 	"php": {
 		Command: "phpunit {{test_files}}",
 	},
+	// plsql: test are run via a "mounted oracle db"
 	"prolog": {
 		Command: "swipl -f {{solution_files}} -s {{test_files}} -g run_tests,halt -t 'halt(1)'",
 	},
@@ -176,6 +185,7 @@ var TestConfigurations = map[string]TestConfiguration{
 	"python": {
 		Command: "python3 -m pytest -o markers=task {{test_files}}",
 	},
+	// r: test are run via the IDE
 	"racket": {
 		Command: "raco test {{test_files}}",
 	},
@@ -197,6 +207,7 @@ var TestConfigurations = map[string]TestConfiguration{
 	"scala": {
 		Command: "sbt test",
 	},
+	// scheme: docs present 2 equally valid test methods (`make chez` and `make guile`). So I wasn't sure which to pick
 	"sml": {
 		Command: "poly -q --use {{test_files}}",
 	},
@@ -209,9 +220,11 @@ var TestConfigurations = map[string]TestConfiguration{
 	"typescript": {
 		Command: "yarn test",
 	},
+	// unison: tests are run from an active UCM session
 	"vbnet": {
 		Command: "dotnet test",
 	},
+	// vimscript: tests are run from inside a vim session
 	"vlang": {
 		Command: "v -stats test run_test.v",
 	},

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -188,7 +188,9 @@ var TestConfigurations = map[string]TestConfiguration{
 	"python": {
 		Command: "python3 -m pytest -o markers=task {{test_files}}",
 	},
-	// r: test are run via the IDE
+	"r": {
+		Command: "Rscript {{test_files}}",
+	},
 	"racket": {
 		Command: "raco test {{test_files}}",
 	},

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -12,8 +12,6 @@ type TestConfiguration struct {
 
 	// Some tracks test by running a specific file, such as `ruby lasagna_test.rb`. Set this to `true` to look up and include the name of the default test file(s).
 	AppendTestFiles bool
-	// All args after `--` aren't parsed and are passed to the test command. Some languages (especially `rust`) expect an additional `--` between _their_ args. So instead of requiring a user to call `exercism test -- -- --include-ingored` to run all `rust` tests, set this to `true` to separate the args passed to the test runner by a `--` automatically.
-	AutoSeparateArgs bool
 }
 
 func (c *TestConfiguration) GetTestCommand() string {
@@ -64,8 +62,7 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "go test",
 	},
 	"rust": {
-		Command:          "cargo test",
-		AutoSeparateArgs: true,
+		Command: "cargo test --",
 	},
 	"ruby": {
 		Command:         "ruby",

--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -176,6 +176,9 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "phpunit {{test_files}}",
 	},
 	// plsql: test are run via a "mounted oracle db"
+	"powershell": {
+		Command: "Invoke-Pester",
+	},
 	"prolog": {
 		Command: "swipl -f {{solution_files}} -s {{test_files}} -g run_tests,halt -t 'halt(1)'",
 	},

--- a/workspace/test_configurations_test.go
+++ b/workspace/test_configurations_test.go
@@ -1,0 +1,77 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCommand(t *testing.T) {
+	testConfig, ok := TestConfigurations["elixir"]
+	assert.True(t, ok, "unexpectedly unable to find elixir test config")
+
+	cmd, err := testConfig.GetTestCommand()
+	assert.NoError(t, err)
+
+	assert.Equal(t, cmd, "mix test")
+}
+
+func TestWindowsCommands(t *testing.T) {
+	testConfig, ok := TestConfigurations["cobol"]
+	assert.True(t, ok, "unexpectedly unable to find cobol test config")
+
+	cmd, err := testConfig.GetTestCommand()
+	assert.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, cmd, ".ps1")
+		assert.NotContains(t, cmd, ".sh")
+	} else {
+		assert.Contains(t, cmd, ".sh")
+		assert.NotContains(t, cmd, ".ps1")
+	}
+}
+
+func TestGetCommandMissingConfig(t *testing.T) {
+	testConfig, ok := TestConfigurations["ruby"]
+	assert.True(t, ok, "unexpectedly unable to find ruby test config")
+
+	_, err := testConfig.GetTestCommand()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), ".exercism/config.json: no such file or directory")
+}
+
+func TestIncludesTestFilesInCommand(t *testing.T) {
+	testConfig, ok := TestConfigurations["ruby"]
+	assert.True(t, ok, "unexpectedly unable to find ruby test config")
+
+	// this creates a config file in the test directory and removes it
+	dir := filepath.Join(".", ".exercism")
+	err := os.Mkdir(dir, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	f, err := os.Create(filepath.Join(dir, "config.json"))
+	assert.NoError(t, err)
+
+	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.rb"], "test": ["lasagna_test.rb", "some_other_file.rb"], "exemplar": [".meta/exemplar.rb"] } } `)
+	assert.NoError(t, err)
+
+	cmd, err := testConfig.GetTestCommand()
+	assert.NoError(t, err)
+	assert.Equal(t, cmd, "ruby lasagna_test.rb some_other_file.rb")
+}
+
+func TestRustHasTrailingDashes(t *testing.T) {
+	testConfig, ok := TestConfigurations["rust"]
+	assert.True(t, ok, "unexpectedly unable to find rust test config")
+
+	cmd, err := testConfig.GetTestCommand()
+	assert.NoError(t, err)
+
+	assert.True(t, strings.HasSuffix(cmd, "--"), "rust's test command should have trailing dashes")
+}

--- a/workspace/test_configurations_test.go
+++ b/workspace/test_configurations_test.go
@@ -49,6 +49,27 @@ func TestGetCommandMissingConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))
 }
 
+func TestIncludesSolutionAndTestFilesInCommand(t *testing.T) {
+	testConfig, ok := TestConfigurations["prolog"]
+	assert.True(t, ok, "unexpectedly unable to find prolog test config")
+
+	// this creates a config file in the test directory and removes it
+	dir := filepath.Join(".", ".exercism")
+	err := os.Mkdir(dir, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	f, err := os.Create(filepath.Join(dir, "config.json"))
+	assert.NoError(t, err)
+
+	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Prolog by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.pl"], "test": ["lasagna_tests.plt"] } } `)
+	assert.NoError(t, err)
+
+	cmd, err := testConfig.GetTestCommand()
+	assert.NoError(t, err)
+	assert.Equal(t, cmd, "swipl -f lasagna.pl -s lasagna_tests.plt -g run_tests,halt -t 'halt(1)'")
+}
+
 func TestIncludesTestFilesInCommand(t *testing.T) {
 	testConfig, ok := TestConfigurations["ruby"]
 	assert.True(t, ok, "unexpectedly unable to find ruby test config")

--- a/workspace/test_configurations_test.go
+++ b/workspace/test_configurations_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -41,8 +42,11 @@ func TestGetCommandMissingConfig(t *testing.T) {
 	assert.True(t, ok, "unexpectedly unable to find ruby test config")
 
 	_, err := testConfig.GetTestCommand()
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), ".exercism/config.json: no such file or directory")
+	assert.Error(t, err)
+	// any assertions about this error message have to work across all platforms, so be vague
+	// unix: ".exercism/config.json: no such file or directory"
+	// windows: "open .exercism\config.json: The system cannot find the path specified."
+	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))
 }
 
 func TestIncludesTestFilesInCommand(t *testing.T) {

--- a/workspace/test_configurations_test.go
+++ b/workspace/test_configurations_test.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -46,7 +45,7 @@ func TestGetCommandMissingConfig(t *testing.T) {
 	// any assertions about this error message have to work across all platforms, so be vague
 	// unix: ".exercism/config.json: no such file or directory"
 	// windows: "open .exercism\config.json: The system cannot find the path specified."
-	assert.Contains(t, err.Error(), path.Join(".exercism", "config.json:"))
+	assert.Contains(t, err.Error(), filepath.Join(".exercism", "config.json:"))
 }
 
 func TestIncludesSolutionAndTestFilesInCommand(t *testing.T) {
@@ -55,12 +54,13 @@ func TestIncludesSolutionAndTestFilesInCommand(t *testing.T) {
 
 	// this creates a config file in the test directory and removes it
 	dir := filepath.Join(".", ".exercism")
+	defer os.RemoveAll(dir)
 	err := os.Mkdir(dir, os.ModePerm)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	f, err := os.Create(filepath.Join(dir, "config.json"))
 	assert.NoError(t, err)
+	defer f.Close()
 
 	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Prolog by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.pl"], "test": ["lasagna_tests.plt"] } } `)
 	assert.NoError(t, err)
@@ -76,12 +76,13 @@ func TestIncludesTestFilesInCommand(t *testing.T) {
 
 	// this creates a config file in the test directory and removes it
 	dir := filepath.Join(".", ".exercism")
+	defer os.RemoveAll(dir)
 	err := os.Mkdir(dir, os.ModePerm)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	f, err := os.Create(filepath.Join(dir, "config.json"))
 	assert.NoError(t, err)
+	defer f.Close()
 
 	_, err = f.WriteString(`{ "blurb": "Learn about the basics of Ruby by following a lasagna recipe.", "authors": ["iHiD", "pvcarrera"], "files": { "solution": ["lasagna.rb"], "test": ["lasagna_test.rb", "some_other_file.rb"], "exemplar": [".meta/exemplar.rb"] } } `)
 	assert.NoError(t, err)


### PR DESCRIPTION
Per discussion in [this forum post](https://forum.exercism.org/t/introducing-the-universal-test-runner/6228), I've added a `test` command to the exercism CLI. Much like the [universal test runner](https://github.com/xavdid/universal-test-runner) it's inspired by, its goal is to be able to run the basic unit test suite for any exercism exercise. 

It does this by:

1. reading `.exercism/metadata.json` to get the track name
2. doing a lookup in a table which maps track name => a test command (and some configuration; see below)
3. maybe reading `.exercism/config.json` to get test file name(s) and including them
4. including any args from `exercism test`
5. Using go's `exec.Command` to run and return info about the exit code

## Types of Tests

Based on my (very brief) sampling of exercism tracks, there are 2 main ways tests are run:

1. Using a language-wide common command (e.g `cargo test`, `go test`, `lien test`, etc)
2. A single test file invoked like any program of that language (e.g. `ruby lasagna_test.rb`)

So, the `TestConfiguration` struct covers both of those cases (by including an option to append the test file(s) to the command).

The other configuration option aids in arg passing. Some language tools (namely `cargo`) expect arguments to the test command to be after a double dash (`--`). Unfortunately, so does `Cobra,` the `go` arg parser. So, I was running into the following trying to run rust tests with `--include-ignored`:

1. `exercism test --include-ignored`: `--include-ignored` is not a valid flag for the test command
2. `exercism test -- --include-ignored`: `--include-ignored` is not a valid flag for `cargo`, put it behind a `--` 
3. `exercism test -- -- --include-ignored`: works as expected

This isn't great UX though, so I added an option for languages to be able to ask that args to their test runner be put behind an implied `--`. This way, the rust command works when run as option 2 above (which is in line with most other languages).

## TODO

- [x] add tests
- [x] add more languages (I don't know that we need to ship with 100% coverage, but the top 20 most popular languages would be great)
- [x] add docs / changelog