### PR TITLE
Add instructions to compile locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ This CLI ships as a binary with no additional runtime requirements.
 
 ## Installing the CLI
 
-Instructions can be found at [exercism/cli/releases](https://github.com/exercism/cli/releases)
+Instructions can be found at [exercism/cli/releases](https://github.com/exercism/cli/releases).
+
+## Compiling
+
+If your are already familiar with go and the command line,
+you could also compile and install the current version of the CLI yourself
+by running
+```bash
+go install github.com/exercism/cli/exercism@latest
+```
 
 ## Contributing
 


### PR DESCRIPTION
For people who would otherwise have to look through closed issues like "[No CLI binary available for the ARMv8 architecture](https://github.com/exercism/exercism/issues/3157)" to find out a way to install.