### PR TITLE
Initial refactor for list command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -76,35 +76,45 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 // TokenIsValid calls the API to determine whether the token is valid.
 func (c *Client) TokenIsValid() (bool, error) {
-	url := fmt.Sprintf("%s/validate_token", c.APIBaseURL)
-	req, err := c.NewRequest("GET", url, nil)
-	if err != nil {
-		return false, err
-	}
-	resp, err := c.Do(req)
+	resp, err := c.MakeRequest("/validate_token", false)
 	if err != nil {
 		return false, err
 	}
 	defer resp.Body.Close()
-
 	return resp.StatusCode == http.StatusOK, nil
 }
 
 // IsPingable calls the API /ping to determine whether the API can be reached.
 func (c *Client) IsPingable() error {
-	url := fmt.Sprintf("%s/ping", c.APIBaseURL)
-	req, err := c.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
+	resp, err := c.MakeRequest("/ping", false)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API returned %s", resp.Status)
 	}
 	return nil
+}
+
+// MakeRequest makes a http request to the given path (which may be a full URL).
+func (c *Client) MakeRequest(path string, isFullURL bool) (*http.Response, error) {
+	var url string
+
+	if isFullURL {
+		url = path
+	} else {
+		url = fmt.Sprintf("%s%s", c.APIBaseURL, path)
+	}
+
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/api/client.go
+++ b/api/client.go
@@ -76,7 +76,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 // TokenIsValid calls the API to determine whether the token is valid.
 func (c *Client) TokenIsValid() (bool, error) {
-	resp, err := c.MakeRequest("/validate_token", false)
+	resp, err := c.MakeRequest("GET", "/validate_token", false)
 	if err != nil {
 		return false, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) TokenIsValid() (bool, error) {
 
 // IsPingable calls the API /ping to determine whether the API can be reached.
 func (c *Client) IsPingable() error {
-	resp, err := c.MakeRequest("/ping", false)
+	resp, err := c.MakeRequest("GET", "/ping", false)
 	if err != nil {
 		return err
 	}
@@ -97,8 +97,11 @@ func (c *Client) IsPingable() error {
 	return nil
 }
 
-// MakeRequest makes a http request to the given path (which may be a full URL).
-func (c *Client) MakeRequest(path string, isFullURL bool) (*http.Response, error) {
+// MakeRequest makes a http request to the given path. 
+// If isFullURL is true, the function treats the path as a full URL. 
+// If isFullURL is false, the function treats the path as a relative path and prepends the API base URL.
+// The method parameter allows for different HTTP methods (e.g., "GET", "POST").
+func (c *Client) MakeRequest(method string, path string, isFullURL bool) (*http.Response, error) {
 	var url string
 
 	if isFullURL {
@@ -107,7 +110,7 @@ func (c *Client) MakeRequest(path string, isFullURL bool) (*http.Response, error
 		url = fmt.Sprintf("%s%s", c.APIBaseURL, path)
 	}
 
-	req, err := c.NewRequest("GET", url, nil)
+	req, err := c.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -123,7 +123,7 @@ func TestSolutionFile(t *testing.T) {
 				t.Fatalf("Expected path '%s', got '%s'", tc.expectedPath, sf.relativePath())
 			}
 
-			url, err := sf.url()
+			url, err := sf.createDownloadURL()
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION

**Refactor `download.go` in Preparation for [Add list command](https://github.com/exercism/cli/pull/1113)**

**Purpose of this PR:**

This PR primarily aims to simplify the `download` command, paving the way for the seamless integration of the `list` command. This will eventually allow users to list tracks and related exercises (refer to the linked PR for details).

**Key Modifications (ordered for clarity)**:

**1. `download.go`:**
   - Introduced a shared `*api.Client` across all methods and functions for uniformity.
   - Decomposed `runDownload` and `newDownload` functions to enhance readability.
   - Eliminated superfluous `usrCfg` verifications.
   - Extracted `usrCfg` items from `solutionDownload` structs, decoupling configuration from download operations.
   - Modularized and delegated the setup and validation of the `download` command flags to distinct methods.
   - Unified the creation process of `solutionURL`.
   - Refactored method names, replacing vague identifiers like `url()`, `files()`.
   - Reorganized the structure: placed all structs at the beginning, and logically grouped related methods/functions.
   - Augmented all functions, methods, and structs with descriptive comments.

**2. `client.go`:**
   - Introduced `MakeRequest` to merge the functionalities of `client.NewRequest` and `client.Do`, enhancing the DRY principle.

**3. `configure.go`:**
   - Implemented `LoadUserConfig()`, which encapsulates the logic for fetching the user config governed by Viper.

---

**Compatibility & Testing:**

To the best of my knowledge, this PR introduces no breaking changes. All previously established functionalities should persist undisturbed. Both the `go test ./...` command on this branch and the test suite in `download_test.go` have been executed without any discrepancies.
