### PR TITLE
Update FAQ link in Upgrade output

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,7 +32,7 @@ We were not able to upgrade the cli because we encountered an error:
 
 Please check the FAQ for solutions to common upgrading issues.
 
-https://exercism.org/docs/using/faqs`, err)
+https://exercism.org/faqs`, err)
 		}
 		return nil
 	},

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,7 +32,7 @@ We were not able to upgrade the cli because we encountered an error:
 
 Please check the FAQ for solutions to common upgrading issues.
 
-https://exercism.io/faqs`, err)
+https://exercism.org/docs/using/faqs`, err)
 		}
 		return nil
 	},


### PR DESCRIPTION
The existing link gives a 404, so after posting to the forum: 
https://forum.exercism.org/t/https-exercism-io-faqs-gives-404/8965

I have updated the link