### PR TITLE
test: use Gradle wrapper for Java track

### DIFF
--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -141,7 +141,8 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "stack test",
 	},
 	"java": {
-		Command: "gradle test",
+		Command:        "./gradlew test",
+		WindowsCommand: "gradlew.bat test",
 	},
 	"javascript": {
 		Command: "npm run test",


### PR DESCRIPTION
This updates the `exercism test` command to use the Gradle wrapper for exercises on the Java track.

Dependencies:

- [ ] https://github.com/exercism/java/pull/2657