### PR TITLE
Add sqlite support to `exercism test`

### DIFF
--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -222,6 +222,9 @@ var TestConfigurations = map[string]TestConfiguration{
 	"sml": {
 		Command: "poly -q --use {{test_files}}",
 	},
+	"sqlite": {
+		Command: "sqlite3 -bail < {{test_files}}",
+	},
 	"swift": {
 		Command: "swift test",
 	},


### PR DESCRIPTION
Note: this doesn't actually work. When I try this out, I get:

````
Running tests via `sqlite3 -bail < hello-world_test.sql`

Error: in prepare, near "hello": syntax error (1)
```

@xavdid do you have any idea?