### PR TITLE
Allow users to provide their token via a stdin prompt

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -61,6 +61,9 @@ func runConfigure(configuration config.Config, flags *pflag.FlagSet) error {
 	// If the command is run 'bare' and we have no token,
 	// prompt the user to provide the token.
 	if flags.NFlag() == 0 && cfg.GetString("token") == "" {
+		tokenURL := config.SettingsURL(cfg.GetString("apibaseurl"))
+		fmt.Println("Find your token on", tokenURL)
+
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print("Enter your token: ")
 		token, err := reader.ReadString('\n')

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -58,9 +58,12 @@ func runConfigure(configuration config.Config, flags *pflag.FlagSet) error {
 		return nil
 	}
 
-	// If the command is run 'bare' and we have no token,
-	// prompt the user to provide the token.
-	if flags.NFlag() == 0 && cfg.GetString("token") == "" {
+	// Interactive configuration.
+	interactive, err := flags.GetBool("interactive")
+	if err != nil {
+		return err
+	}
+	if interactive {
 		tokenURL := config.SettingsURL(cfg.GetString("apibaseurl"))
 		fmt.Println("Find your token on", tokenURL)
 
@@ -81,6 +84,13 @@ func runConfigure(configuration config.Config, flags *pflag.FlagSet) error {
 		}
 
 		flags.Set("token", token)
+	}
+
+	// If the command is run 'bare' and we have no token,
+	// explain how to set the token.
+	if flags.NFlag() == 0 && cfg.GetString("token") == "" {
+		tokenURL := config.SettingsURL(cfg.GetString("apibaseurl"))
+		return fmt.Errorf("There is no token configured. Find your token on %s, and call this command again with --token=<your-token>.", tokenURL)
 	}
 
 	// Determine the base API URL.
@@ -250,6 +260,7 @@ func setupConfigureFlags(flags *pflag.FlagSet) {
 	flags.StringP("workspace", "w", "", "directory for exercism exercises")
 	flags.StringP("api", "a", "", "API base url")
 	flags.BoolP("show", "s", false, "show the current configuration")
+	flags.BoolP("interactive", "i", false, "set configuration values with interactive prompts")
 	flags.BoolP("no-verify", "", false, "skip online token authorization check")
 }
 

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -32,7 +32,7 @@ func TestBareConfigure(t *testing.T) {
 
 	err = runConfigure(cfg, flags)
 	if assert.Error(t, err) {
-		assert.Regexp(t, "no token provided", err.Error())
+		assert.Regexp(t, "no token configured", err.Error())
 	}
 }
 

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -32,7 +32,7 @@ func TestBareConfigure(t *testing.T) {
 
 	err = runConfigure(cfg, flags)
 	if assert.Error(t, err) {
-		assert.Regexp(t, "no token configured", err.Error())
+		assert.Regexp(t, "no token provided", err.Error())
 	}
 }
 


### PR DESCRIPTION
Forum discussion: https://forum.exercism.org/t/allow-users-to-provide-their-token-via-a-stdin-prompt/12492

---

Currently the only way to provide a token is via the CLI arg `--token`. This is not ideal because the token will be saved to the shell history, which makes it easier to steal and easier to leak. 

Instead this PR provides an implementation where the user can run the command `exercism configure` without providing a token and then the user will be asked to provide the token via a stdin input.

![image](https://github.com/user-attachments/assets/ccb6bf83-c08c-41e5-af92-7d8da871095b)

**This token has been reset.**
![image](https://github.com/user-attachments/assets/f308c541-674f-4565-8b58-89f5e9599077)

-----
Also thank you for making `exercism`, it is my go to spot for learning new languages.
