### PR TITLE
Fix `batch` track test command

### DIFF
--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -75,7 +75,7 @@ var TestConfigurations = map[string]TestConfiguration{
 		Command: "bal test",
 	},
 	"batch": {
-		WindowsCommand: "call {{test_files}}",
+		WindowsCommand: "cmd /c {{test_files}}",
 	},
 	"bash": {
 		Command: "bats {{test_files}}",


### PR DESCRIPTION
See http://forum.exercism.org/t/track-specific-testing-documentation/12829/6 for context. `exercism test` currently doesn't work for Batch Script exercises in Command Prompt or PowerShell. I locally built `testercism` with the proposed `cmd /c {{test_files}}` command, and it worked in my limited testing within both shells.