### PR TITLE
Revert "Fix URL in no token error message (#1166)"

### DIFF
--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -26,7 +26,7 @@ func TestDownloadWithoutToken(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Regexp(t, "Welcome to Exercism", err.Error())
 		// It uses the default base API url to infer the host
-		assert.Regexp(t, "exercism.org/settings/api_cli", err.Error())
+		assert.Regexp(t, "exercism.io/my/settings", err.Error())
 	}
 }
 

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -28,7 +28,7 @@ func TestSubmitWithoutToken(t *testing.T) {
 	err := runSubmit(cfg, pflag.NewFlagSet("fake", pflag.PanicOnError), []string{})
 	if assert.Error(t, err) {
 		assert.Regexp(t, "Welcome to Exercism", err.Error())
-		assert.Regexp(t, "exercism.org/settings/api_cli", err.Error())
+		assert.Regexp(t, "exercism.io/my/settings", err.Error())
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	defaultBaseURL = "https://exercism.org"
+	defaultBaseURL = "https://api.exercism.io/v1"
 
 	// DefaultDirName is the default name used for config and workspace directories.
 	DefaultDirName string
@@ -122,7 +122,7 @@ func InferSiteURL(apiURL string) string {
 		apiURL = defaultBaseURL
 	}
 	if apiURL == "https://api.exercism.io/v1" {
-		return "https://exercism.org"
+		return "https://exercism.io"
 	}
 	re := regexp.MustCompile("^(https?://[^/]*).*")
 	return re.ReplaceAllString(apiURL, "$1")
@@ -130,5 +130,5 @@ func InferSiteURL(apiURL string) string {
 
 // SettingsURL provides a link to where the user can find their API token.
 func SettingsURL(apiURL string) string {
-	return fmt.Sprintf("%s%s", InferSiteURL(apiURL), "/settings/api_cli")
+	return fmt.Sprintf("%s%s", InferSiteURL(apiURL), "/my/settings")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,11 +10,11 @@ func TestInferSiteURL(t *testing.T) {
 	testCases := []struct {
 		api, url string
 	}{
-		{"https://api.exercism.io/v1", "https://exercism.org"},
+		{"https://api.exercism.io/v1", "https://exercism.io"},
 		{"https://v2.exercism.io/api/v1", "https://v2.exercism.io"},
 		{"https://mentors-beta.exercism.io/api/v1", "https://mentors-beta.exercism.io"},
 		{"http://localhost:3000/api/v1", "http://localhost:3000"},
-		{"", "https://exercism.org"},           // use the default
+		{"", "https://exercism.io"},            // use the default
 		{"http://whatever", "http://whatever"}, // you're on your own, pal
 	}
 


### PR DESCRIPTION
This reverts commit 102aeb8f07d691b352412c8a80f7626656ae2f7e.

That commit broke the tool. See https://forum.exercism.org/t/cli-no-token-message-tells-the-user-to-go-to-a-incorrect-url/12985/11

+cc @exercism/guardians 