### PR TITLE
Hard-code `Use` field in root cobra command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ import (
 
 // RootCmd represents the base command when called without any subcommands.
 var RootCmd = &cobra.Command{
-	Use:   getCommandName(),
+	Use:   "exercism [command]",
 	Short: "A friendly command-line interface to Exercism.",
 	Long: `A command-line interface for Exercism.
 
@@ -41,12 +41,8 @@ func Execute() {
 	}
 }
 
-func getCommandName() string {
-	return os.Args[0]
-}
-
 func init() {
-	BinaryName = getCommandName()
+	BinaryName = os.Args[0]
 	config.SetDefaultDirName(BinaryName)
 	Out = os.Stdout
 	Err = os.Stderr


### PR DESCRIPTION
...so generated completions are for the end result built, not the
current binary that we run. While the latter might make sense in some
cases (maybe?), I'd think the end goal with completions is to produce
them for the final result (so `exercism` command), not the intermediate
binary that we're building. Judging by Cobra's docs [0] that's the
intended usage here.
Also the current approach produces unusable completions for fish shell,
where function names can't have `/` in them. This can be observed by
making a test build and trying to source the completion result in fish
shell:

```fish
go build -o testercism ./exercism/main.go

./testercism completion fish | source
- (line 3): function: __./testercism_debug: invalid function name
...

This also makes autogenerated completions usable in nix, where
generation process would pass an absolute path to built binary when
calling completions script [1].

As this repo auto-suggests, I also created a forum thread regarding this
[2], but figured I might as well create a PR with possible solution.

[0] https://pkg.go.dev/github.com/spf13/cobra#Command
[1] https://github.com/NixOS/nixpkgs/pull/369128
[2] https://forum.exercism.org/t/fish-shell-completion-generation-doesnt-always-work/14299
