### PR TITLE
Add risc-v test configuration

### DIFF
--- a/workspace/test_configurations.go
+++ b/workspace/test_configurations.go
@@ -235,6 +235,9 @@ var TestConfigurations = map[string]TestConfiguration{
 	"red": {
 		Command: "red {{test_files}}",
 	},
+	"risc-v": {
+		Command: "make",
+	},
 	"roc": {
 		Command: "roc test {{test_files}}",
 	},


### PR DESCRIPTION
Context:

- [forum thread](http://forum.exercism.org/t/risc-v-assembly-track/3573/16)

- [hello-world prototype](https://github.com/keiravillekode/prototype-risc-v/blob/167c5b4d1eb3dad3592985b345ccf6e1bbb497cd/config.json#L3)

The aspiration is for the risc-v track to be 32 bit. I don't have the 32 bit tooling working yet, but "How hard can it be?"

cc @ErikSchierboom 