### PR TITLE
Add error decoding support for content type parameters such as charset

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -26,7 +27,7 @@ var (
 	// Err is used to write errors.
 	Err io.Writer
 	// jsonContentTypeRe is used to match Content-Type which contains JSON.
-	jsonContentTypeRe = regexp.MustCompile(`^application/([[:alpha:]]+\+)?json$`)
+	jsonContentTypeRe = regexp.MustCompile(`^application/([[:alpha:]]+\+)?json($|;)`)
 )
 
 const msgWelcomePleaseConfigure = `
@@ -122,7 +123,7 @@ func decodedAPIError(resp *http.Response) error {
 				strings.Join(apiError.Error.PossibleTrackIDs, ", "),
 			)
 		}
-		return fmt.Errorf(apiError.Error.Message)
+		return errors.New(apiError.Error.Message)
 	}
 	return fmt.Errorf("unexpected API response: %d", resp.StatusCode)
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -163,6 +163,10 @@ func TestDecodeErrorResponse(t *testing.T) {
 			wantMessage: "failed to parse API error response: invalid character 'o' in literal null (expecting 'u')",
 		},
 		{
+			response:    errorResponse418("application/json; charset=utf-8", `{"error": {"type": "track_ambiguous", "message": "message", "possible_track_ids": ["a", "b"]}}`),
+			wantMessage: "message: a, b",
+		},
+		{
 			response:    errorResponse418("application/json", `{"error": {"type": "track_ambiguous", "message": "message", "possible_track_ids": ["a", "b"]}}`),
 			wantMessage: "message: a, b",
 		},


### PR DESCRIPTION
For context, see [this thread](https://forum.exercism.org/t/exercism-submit-400-bad-request/18408)