### PR TITLE
Fix CLI command name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/exercism/cli/api"
@@ -42,7 +43,7 @@ func Execute() {
 }
 
 func getCommandName() string {
-	return os.Args[0]
+	return filepath.Base(os.Args[0])
 }
 
 func init() {


### PR DESCRIPTION
Fixes problem described in #1207 and discussed in https://forum.exercism.org/t/invalid-completion-script-asdf/18526/11

---

**Before**

```shell
$ /tmp/exercism-cli/build/exercism | tail -n1
Use "/tmp/exercism-cli/build/exercism [command] --help" for more information about a command.
$ /tmp/exercism-cli/build/exercism completion bash | head -n3
# bash completion V2 for /tmp/exercism-cli/build/exercism     -*- shell-script -*-

__/tmp/exercism-cli/build/exercism_debug()
```

**After**

```shell
$ /tmp/exercism-cli/build/exercism | tail -n1
Use "exercism [command] --help" for more information about a command.
$ /tmp/exercism-cli/build/exercism completion bash | head -n3
# bash completion V2 for exercism                             -*- shell-script -*-

__exercism_debug()
```