### PR TITLE
goreleaser: update deprecated archives.builds to new archives.ids

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,7 @@ archives:
       - LICENSE
       - README.md
   - id: installer-archives
-    builds:
+    ids:
       - installer-build
     name_template: >-
       {{- .ProjectName }}-


### PR DESCRIPTION
See [goreleaser
docs](https://goreleaser.com/deprecations/#archivesbuilds) for details.
